### PR TITLE
Fix seekback with no play & progress bar data loss

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/MyNativeAudio.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/MyNativeAudio.kt
@@ -96,11 +96,14 @@ class MyNativeAudio : Plugin() {
       //if (!isPlaying) currentTime -= playerNotificationService.calcPauseSeekBackTime()
       var id = playerNotificationService.getCurrentAudiobookId()
       Log.d(tag, "Get Current id $id")
+      var duration = playerNotificationService.getDuration()
+      Log.d(tag, "Get duration $duration")
       val ret = JSObject()
       ret.put("lastPauseTime", lastPauseTime)
       ret.put("currentTime", currentTime)
       ret.put("isPlaying", isPlaying)
       ret.put("id", id)
+      ret.put("duration", duration)
       call.resolve(ret)
     }
   }

--- a/android/app/src/main/java/com/audiobookshelf/app/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/PlayerNotificationService.kt
@@ -493,6 +493,10 @@ class PlayerNotificationService : MediaBrowserServiceCompat()  {
     return lastPauseTime
   }
 
+  fun getDuration() : Long {
+    return mPlayer.duration
+  }
+
   fun calcPauseSeekBackTime() : Long {
     if (lastPauseTime <= 0) return 0
     var time: Long = System.currentTimeMillis() - lastPauseTime

--- a/components/AudioPlayerMini.vue
+++ b/components/AudioPlayerMini.vue
@@ -228,6 +228,7 @@ export default {
           console.log('Same audiobook')
           this.isPaused = !data.isPlaying
           this.currentTime = Number((data.currentTime / 1000).toFixed(2))
+		  this.totalDuration = Number((data.duration / 1000).toFixed(2))
           this.timeupdate()
           if (data.isPlaying) {
             console.log('playing - continue')


### PR DESCRIPTION
## fix seek back with no play
See #19

## progress bar data loss after restore from app destroy when playing is on
There is a long time without metadata while playing.
So add `duration` to `getStreamSyncData()`
and use it set `this.totalDuration` after restore