### PR TITLE
Show "now playing" on lock screen & in control center

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -7,6 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        UIApplication.shared.beginReceivingRemoteControlEvents()
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
- Fixed a bug that caused the player to always start at 0:00
- Added `UIApplication.shared.beginReceivingRemoteControlEvents()` to show a "now playing" notification
- Fixed a bug that caused the cover to not load correctly
- Added more remote transport commands