### PR TITLE
Enable swipe gesture to go back

### DIFF
--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -13,7 +13,7 @@ public class AbsAudioPlayer: CAPPlugin {
     override public func load() {
         NotificationCenter.default.addObserver(self, selector: #selector(sendMetadata), name: NSNotification.Name(PlayerEvents.update.rawValue), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(sendPlaybackClosedEvent), name: NSNotification.Name(PlayerEvents.closed.rawValue), object: nil)
-        
+        self.bridge?.webView?.allowsBackForwardNavigationGestures = true;
         NotificationCenter.default.addObserver(self, selector: #selector(sendMetadata), name: UIApplication.didBecomeActiveNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(sendMetadata), name: UIApplication.willEnterForegroundNotification, object: nil)
     }


### PR DESCRIPTION
This isn't a good implementation of the idea, but allowing some form of swipe back gesture would be helpful for user experience to not reach for the back button. Maybe we could make this a dedicated plugin to enable and disable the gesture on item pages and disable elsewhere, as swiping back to previous library pages isn't very intuitive, but that makes this improvement exponentially more complex. I'll tinker with making it a plugin, [this](https://github.com/diiiary/capacitor-plugin-ios-swipe-back) already exists but hasn't been updated in 3 years and calls deprecated methods. At this point I just threw a line in the middle of the AudioPlayer plugin to make it work.