### PR TITLE
Increase server ping timeout

### DIFF
--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -194,7 +194,7 @@ export default {
     },
     pingServerAddress(address) {
       return this.$axios
-        .$get(`${address}/ping`, { timeout: 1000 })
+        .$get(`${address}/ping`, { timeout: 3000 })
         .then((data) => data.success)
         .catch((error) => {
           console.error('Server check failed', error)


### PR DESCRIPTION
As mentioned in [a discussion](https://github.com/advplyr/audiobookshelf-app/discussions/60#discussioncomment-2601321) there seems to be an issue occasionally with being unable to ping the server on cellular data, and the probable cause is the 1 second timeout. Does 3 seconds sound like a good number instead?