### PR TITLE
Handle audio probes that don't return any tags

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/AudioProbeResult.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/AudioProbeResult.kt
@@ -52,7 +52,7 @@ data class AudioProbeFormat(
   val duration:Double,
   val size:Long,
   val bit_rate:Double,
-  val tags:AudioProbeFormatTags
+  val tags:AudioProbeFormatTags?
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -63,8 +63,8 @@ class AudioProbeResult (
 
   val duration get() = format.duration
   val size get() = format.size
-  val title get() = format.tags.title ?: format.filename.split("/").last()
-  val artist get() = format.tags.artist ?: ""
+  val title get() = format.tags?.title ?: format.filename.split("/").last()
+  val artist get() = format.tags?.artist ?: ""
 
   @JsonIgnore
   fun getBookChapters(): List<BookChapter> {


### PR DESCRIPTION
It appears that sometimes `ffprobe` can return a NULL value for the `format.tags` field when scanning files. This causes the Android app to crash when scanning local media folders.

Example FFProbe response:
```
{
    "streams": [
        {
            "index": 0,
            "codec_name": "mp3",
            "codec_long_name": "unknown",
            "codec_type": "audio",
            "codec_tag_string": "[0][0][0][0]",
            "codec_tag": "0x0000",
            "sample_fmt": "fltp",
            "sample_rate": "22050",
            "channels": 1,
            "channel_layout": "mono",
            "bits_per_sample": 0,
            "r_frame_rate": "0\/0",
            "avg_frame_rate": "0\/0",
            "time_base": "1\/14112000",
            "start_pts": 0,
            "start_time": "0.000000",
            "duration_ts": 445606502544,
            "duration": "31576.424500",
            "bit_rate": "32000",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0
            }
        }
    ],
    "chapters": [],
    "format": {
        "filename": "\/storage\/emulated\/0\/Audiobookshelf\/Test\/Test.mp3",
        "nb_streams": 1,
        "nb_programs": 0,
        "format_name": "mp3",
        "start_time": "0.000000",
        "duration": "31576.424500",
        "size": "126305698",
        "bit_rate": "32000",
        "probe_score": 51
    }
}
```

The subsequent crash looks like this:

```
2022-04-26 09:48:26.094 9558-9631/com.audiobookshelf.app E/Capacitor: Serious error executing plugin
    java.lang.reflect.InvocationTargetException
        at java.lang.reflect.Method.invoke(Native Method)
        at com.getcapacitor.PluginHandle.invoke(PluginHandle.java:121)
        at com.getcapacitor.Bridge.lambda$callPluginMethod$0$com-getcapacitor-Bridge(Bridge.java:592)
        at com.getcapacitor.Bridge$$ExternalSyntheticLambda5.run(Unknown Source:8)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.os.HandlerThread.run(HandlerThread.java:67)
     Caused by: com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class com.audiobookshelf.app.data.AudioProbeFormat] value failed for JSON property tags due to missing (therefore NULL) value for creator parameter tags which is a non-nullable type
     at [Source: (String)"{
        "streams": [
            {
                "index": 0,
                "codec_name": "mp3",
                "codec_long_name": "unknown",
                "codec_type": "audio",
                "codec_tag_string": "[0][0][0][0]",
                "codec_tag": "0x0000",
                "sample_fmt": "fltp",
                "sample_rate": "22050",
                "channels": 1,
                "channel_layout": "mono",
                "bits_per_sample": 0,
                "r_frame_rate": "0/0",
                "avg_frame_rate": "0/0",
```

There's already logic in place to handle missing `title` and `artist` tags, so this PR just makes that code also handle the `tags` field being null.

Running this change in an Android emulator, I no longer see the crash when scanning the local media folder.