### PR TITLE
Added narrator to library item page.

### DIFF
--- a/pages/item/_id.vue
+++ b/pages/item/_id.vue
@@ -62,6 +62,7 @@
     </div>
 
     <div class="w-full py-4">
+      <p v-if="narrators" class="text-sm text-gray-400">Narrated by {{ narrators }}</p>
       <p class="text-sm">{{ description }}</p>
     </div>
 
@@ -172,6 +173,10 @@ export default {
     author() {
       if (this.isPodcast) return this.mediaMetadata.author
       return this.mediaMetadata.authorName
+    },
+    narrators() {
+      if (this.isPodcast) return ''
+      return this.mediaMetadata.narratorName
     },
     description() {
       return this.mediaMetadata.description || ''


### PR DESCRIPTION
This is where it looks best to me. I can see an argument for putting it right below the author by line, but it felt cluttered to me up there, especially on smaller devices or on library items with several narrators. I'll happily move it anywhere if this doesn't seem like the spot.