### PR TITLE
Show server version in drawer

### DIFF
--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -19,7 +19,7 @@
       </div>
       <div class="absolute bottom-0 left-0 w-full py-6 px-6 text-gray-300">
         <div v-if="serverConnectionConfig" class="mb-4 flex justify-center">
-          <p class="text-xs" style="word-break: break-word">{{ serverConnectionConfig.address }} (v{{serverVersion}})</p>
+          <p class="text-xs" style="word-break: break-word">{{ serverConnectionConfig.address }} (v{{serverSettings.version}})</p>
         </div>
         <div class="flex items-center">
           <p class="text-xs">{{ $config.version }}</p>
@@ -71,8 +71,8 @@ export default {
     serverConnectionConfig() {
       return this.$store.state.user.serverConnectionConfig
     },
-    serverVersion() {
-      return this.$store.state.serverSettings.version || 'Version Unavailable'
+    serverSettings() {
+      return this.$store.state.serverSettings || 'Version Unavailable'
     },
     username() {
       return this.user ? this.user.username : ''

--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -72,7 +72,7 @@ export default {
       return this.$store.state.user.serverConnectionConfig
     },
     serverSettings() {
-      return this.$store.state.serverSettings || 'Version Unavailable'
+      return this.$store.state.serverSettings || {}
     },
     username() {
       return this.user ? this.user.username : ''

--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -19,7 +19,7 @@
       </div>
       <div class="absolute bottom-0 left-0 w-full py-6 px-6 text-gray-300">
         <div v-if="serverConnectionConfig" class="mb-4 flex justify-center">
-          <p class="text-xs">{{ serverConnectionConfig.address }}</p>
+          <p class="text-xs" style="word-break: break-word">{{ serverConnectionConfig.address }} (v{{serverVersion}})</p>
         </div>
         <div class="flex items-center">
           <p class="text-xs">{{ $config.version }}</p>
@@ -70,6 +70,9 @@ export default {
     },
     serverConnectionConfig() {
       return this.$store.state.user.serverConnectionConfig
+    },
+    serverVersion() {
+      return this.$store.state.serverSettings.version || 'Version Unavailable'
     },
     username() {
       return this.user ? this.user.username : ''


### PR DESCRIPTION
This commit adds the server version next to the URL. It also adds a new style to ensure that the text wraps properly if the URL is too long. Trying text-wrap didn't work for whatever reason.

Screenshots of the textwrap change:
before:
![image](https://user-images.githubusercontent.com/13617455/172924759-cff27149-189e-4341-9f2c-2ac09fb22c69.png)

after:
![image](https://user-images.githubusercontent.com/13617455/172924718-24e2ddf5-dcb4-4192-9f30-ff968d9ae34d.png)
