### PR TITLE
Added ability to Give write permission to the SD card

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
   implementation 'io.github.pilgr:paperdb:2.7.2'
 
   // Simple Storage
-  implementation "com.anggrayudi:storage:0.13.0"
+  implementation "com.anggrayudi:storage:1.3.0"
 
   // OK HTTP
   implementation 'com.squareup.okhttp3:okhttp:4.9.2'

--- a/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
@@ -5,9 +5,11 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
+import androidx.core.app.ActivityCompat
 import com.anggrayudi.storage.SimpleStorage
 import com.anggrayudi.storage.SimpleStorageHelper
 import com.audiobookshelf.app.data.AbsDatabase
@@ -31,6 +33,11 @@ class MainActivity : BridgeActivity() {
   val storageHelper = SimpleStorageHelper(this)
   val storage = SimpleStorage(this)
 
+  val REQUEST_PERMISSIONS = 1
+  var PERMISSIONS_ALL = arrayOf(
+    Manifest.permission.READ_EXTERNAL_STORAGE
+  )
+
   public override fun onCreate(savedInstanceState: Bundle?) {
     // TODO: Optimize using strict mode logs
 //    StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder()
@@ -50,6 +57,12 @@ class MainActivity : BridgeActivity() {
 
     DbManager.initialize(applicationContext)
 
+    val permission = ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
+    if (permission != PackageManager.PERMISSION_GRANTED) {
+      ActivityCompat.requestPermissions(this,
+        PERMISSIONS_ALL,
+        REQUEST_PERMISSIONS)
+    }
 
     registerPlugin(AbsAudioPlayer::class.java)
     registerPlugin(AbsDownloader::class.java)

--- a/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
@@ -5,11 +5,9 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
-import androidx.core.app.ActivityCompat
 import com.anggrayudi.storage.SimpleStorage
 import com.anggrayudi.storage.SimpleStorageHelper
 import com.audiobookshelf.app.data.AbsDatabase
@@ -19,7 +17,6 @@ import com.audiobookshelf.app.plugins.AbsAudioPlayer
 import com.audiobookshelf.app.plugins.AbsDownloader
 import com.audiobookshelf.app.plugins.AbsFileSystem
 import com.getcapacitor.BridgeActivity
-import io.paperdb.Paper
 
 
 class MainActivity : BridgeActivity() {
@@ -33,11 +30,6 @@ class MainActivity : BridgeActivity() {
 
   val storageHelper = SimpleStorageHelper(this)
   val storage = SimpleStorage(this)
-
-  val REQUEST_PERMISSIONS = 1
-  var PERMISSIONS_ALL = arrayOf(
-    Manifest.permission.READ_EXTERNAL_STORAGE
-  )
 
   public override fun onCreate(savedInstanceState: Bundle?) {
     // TODO: Optimize using strict mode logs
@@ -58,16 +50,6 @@ class MainActivity : BridgeActivity() {
 
     DbManager.initialize(applicationContext)
 
-    // Grant full storage access for testing
-    // var ss = SimpleStorage(this)
-    // ss.requestFullStorageAccess()
-
-    val permission = ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
-    if (permission != PackageManager.PERMISSION_GRANTED) {
-      ActivityCompat.requestPermissions(this,
-        PERMISSIONS_ALL,
-        REQUEST_PERMISSIONS)
-    }
 
     registerPlugin(AbsAudioPlayer::class.java)
     registerPlugin(AbsDownloader::class.java)

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsFileSystem.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsFileSystem.kt
@@ -1,5 +1,6 @@
 package com.audiobookshelf.app.plugins
 
+import android.app.AlertDialog
 import android.database.Cursor
 import android.net.Uri
 import android.os.Build
@@ -65,39 +66,59 @@ class AbsFileSystem : Plugin() {
 
   @PluginMethod
   fun selectFolder(call: PluginCall) {
-    var mediaType = call.data.getString("mediaType", "book").toString()
+    val mediaType = call.data.getString("mediaType", "book").toString()
+    val REQUEST_CODE_SELECT_FOLDER = 6
+    val REQUEST_CODE_SDCARD_ACCESS = 7
 
     mainActivity.storage.folderPickerCallback = object : FolderPickerCallback {
       override fun onFolderSelected(requestCode: Int, folder: DocumentFile) {
         Log.d(TAG, "ON FOLDER SELECTED ${folder.uri} ${folder.name}")
-        var absolutePath = folder.getAbsolutePath(activity)
-        var storageType = folder.getStorageType(activity)
-        var simplePath = folder.getSimplePath(activity)
-        var basePath = folder.getBasePath(activity)
-        var folderId = android.util.Base64.encodeToString(folder.id.toByteArray(), android.util.Base64.DEFAULT)
+        val absolutePath = folder.getAbsolutePath(activity)
+        val storageType = folder.getStorageType(activity)
+        val simplePath = folder.getSimplePath(activity)
+        val basePath = folder.getBasePath(activity)
+        val folderId = android.util.Base64.encodeToString(folder.id.toByteArray(), android.util.Base64.DEFAULT)
 
-        var localFolder = LocalFolder(folderId, folder.name ?: "", folder.uri.toString(),basePath,absolutePath, simplePath, storageType.toString(), mediaType)
+        val localFolder = LocalFolder(folderId, folder.name ?: "", folder.uri.toString(),basePath,absolutePath, simplePath, storageType.toString(), mediaType)
 
         DeviceManager.dbManager.saveLocalFolder(localFolder)
         call.resolve(JSObject(jacksonMapper.writeValueAsString(localFolder)))
       }
 
       override fun onStorageAccessDenied(requestCode: Int, folder: DocumentFile?, storageType: StorageType) {
-        Log.e(TAG, "STORAGE ACCESS DENIED")
-        var jsobj = JSObject()
-        jsobj.put("error", "Access Denied")
-        call.resolve(jsobj)
+        val jsobj = JSObject()
+        if (requestCode == REQUEST_CODE_SELECT_FOLDER) {
+
+          val builder: AlertDialog.Builder = AlertDialog.Builder(mainActivity)
+          builder.setMessage(
+            "You have no write access to this storage, thus selecting this folder is useless." +
+            "\nWould you like to grant access to this folder?")
+          builder.setNegativeButton("Dont Allow") { _, _ ->
+            run {
+              jsobj.put("error", "User Canceled, Access Denied")
+              call.resolve(jsobj)
+            }
+          }
+          builder.setPositiveButton("Allow.") { _, _ -> mainActivity.storageHelper.requestStorageAccess(REQUEST_CODE_SDCARD_ACCESS, storageType) }
+          builder.show()
+        } else {
+          Log.d(TAG, "STORAGE ACCESS DENIED $requestCode")
+          jsobj.put("error", "Access Denied")
+          call.resolve(jsobj)
+        }
       }
+
 
       override fun onStoragePermissionDenied(requestCode: Int) {
         Log.d(TAG, "STORAGE PERMISSION DENIED $requestCode")
-        var jsobj = JSObject()
+        val jsobj = JSObject()
         jsobj.put("error", "Permission Denied")
         call.resolve(jsobj)
       }
+
     }
 
-    mainActivity.storage.openFolderPicker(6)
+    mainActivity.storage.openFolderPicker(REQUEST_CODE_SELECT_FOLDER)
   }
 
   @RequiresApi(Build.VERSION_CODES.R)


### PR DESCRIPTION
Fixes #159 

After reading over the Simple storage docs I made some changed in the AbsFileSystem plugin to handle Access Denied to External media types by requesting the needed access from the user,  Tested this code on Android 10 and it seems to work. 

User Flow
1. Open Side Bar
2. Select Local Media
3. Choose 'Books' in dropdown and Click New Folder
4. Create the folder or select and existing one on an SD card
5. Click Allow and Allow again
6. Message dialog will appear stating Write perms are needed
7. Another Folder selector is shown at SD Card Root level
8. Click Allow and Allow again

Permission is granted but the folder is not added to the App, user will need to select the folder again, However this time the app will add the folder as expected. If the user pick the folder instead of the root of the SD Card an helpful message is displayed stating the root folder should be selected and the selector is displayed again


I haven't figured out how to get this done in a nicer way, it seems Android require the user to be pestered a lot for these kind of permissions

Also this is my first look into android Dev.