### PR TITLE
Fix playback session starting sometimes on app launch

### DIFF
--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -38,7 +38,7 @@ public class AbsAudioPlayer: CAPPlugin {
         
         do {
             // Fetch the most recent active session
-            let activeSession = try await Realm().objects(PlaybackSession.self).where({ $0.isActiveSession == true }).last
+            let activeSession = try await Realm().objects(PlaybackSession.self).where({ $0.isActiveSession == true }).last?.freeze()
             if let activeSession = activeSession {
                 await PlayerProgress.syncFromServer()
                 try self.startPlaybackSession(activeSession, playWhenReady: false, playbackRate: PlayerSettings.main().playbackRate)

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -167,6 +167,8 @@ class AudioPlayer: NSObject {
     
     // MARK: - Methods
     public func play(allowSeekBack: Bool = false) {
+        guard self.isInitialized() else { return }
+        
         if allowSeekBack {
             let diffrence = Date.timeIntervalSinceReferenceDate - lastPlayTime
             var time: Int?
@@ -202,6 +204,8 @@ class AudioPlayer: NSObject {
     }
     
     public func pause() {
+        guard self.isInitialized() else { return }
+        
         self.audioPlayer.pause()
         self.status = 0
         self.rate = 0.0

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -76,16 +76,25 @@ class PlayerProgress {
     }
     
     private static func updateLocalSessionFromServerMediaProgress() async {
-        NSLog("checkCurrentSessionProgress: Checking if local media progress was updated on server")
-        guard let session = PlayerHandler.getPlaybackSession()?.freeze() else { return }
+        NSLog("updateLocalSessionFromServerMediaProgress: Checking if local media progress was updated on server")
+        guard let session = try! await Realm().objects(PlaybackSession.self).last(where: { $0.isActiveSession == true })?.freeze() else {
+            NSLog("updateLocalSessionFromServerMediaProgress: Failed to get session")
+            return
+        }
         
         // Fetch the current progress
         let progress = await ApiClient.getMediaProgress(libraryItemId: session.libraryItemId!, episodeId: session.episodeId)
-        guard let progress = progress else { return }
+        guard let progress = progress else {
+            NSLog("updateLocalSessionFromServerMediaProgress: No progress object")
+            return
+        }
         
         // Determine which session is newer
         let serverLastUpdate = progress.lastUpdate
-        guard let localLastUpdate = session.updatedAt else { return }
+        guard let localLastUpdate = session.updatedAt else {
+            NSLog("updateLocalSessionFromServerMediaProgress: No local session updatedAt")
+            return
+        }
         let serverCurrentTime = progress.currentTime
         let localCurrentTime = session.currentTime
         
@@ -94,12 +103,16 @@ class PlayerProgress {
         
         // Update the session, if needed
         if serverIsNewerThanLocal && currentTimeIsDifferent {
+            NSLog("updateLocalSessionFromServerMediaProgress: Server has newer time than local serverLastUpdate=\(serverLastUpdate) localLastUpdate=\(localLastUpdate)")
             guard let session = session.thaw() else { return }
             session.update {
                 session.currentTime = serverCurrentTime
                 session.updatedAt = serverLastUpdate
             }
+            NSLog("updateLocalSessionFromServerMediaProgress: Updated session currentTime newCurrentTime=\(serverCurrentTime) previousCurrentTime=\(localCurrentTime)")
             PlayerHandler.seek(amount: session.currentTime)
+        } else {
+            NSLog("updateLocalSessionFromServerMediaProgress: Local session does not need updating; local has latest progress")
         }
     }
     


### PR DESCRIPTION
This turned out to be several problems:

1) The active session was not syncing with the server on startup, due to an assumption the player was initialized and `PlayerHandler.getPlaybackSession()` could be used
2) This lead to a scenario that when the player did sync with the server on the next sync, `seek()` was called, which was triggering playback to start
3) Upon investigation, I also found a situation where iOS being "smart" could attempt to restore playback when connecting Bluetooth headphones during app startup
4) This issue was solved by adding a guard to `play` and `pause` until the player is initialized