### PR TITLE
Add additional controls to android auto

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -37,9 +37,9 @@ data class DeviceSettings(
   }
 
   @get:JsonIgnore
-  val jumpBackwardsTimeMs get() = jumpBackwardsTime * 1000L
+  val jumpBackwardsTimeMs get() = (jumpBackwardsTime ?: default().jumpBackwardsTime) * 1000L
   @get:JsonIgnore
-  val jumpForwardTimeMs get() = jumpForwardTime * 1000L
+  val jumpForwardTimeMs get() = (jumpForwardTime ?: default().jumpBackwardsTime) * 1000L
 }
 
 data class DeviceData(

--- a/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
@@ -7,10 +7,8 @@ import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import android.support.v4.media.session.MediaSessionCompat
-import android.support.v4.media.session.PlaybackStateCompat
 import android.util.Log
 import android.view.KeyEvent
-import com.audiobookshelf.app.R
 import com.audiobookshelf.app.data.LibraryItemWrapper
 import com.audiobookshelf.app.data.PodcastEpisode
 import java.util.*
@@ -21,7 +19,6 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
 
   private var mediaButtonClickCount: Int = 0
   var mediaButtonClickTimeout: Long = 1000  //ms
-  var seekAmount: Long = 20000   //ms
 
   override fun onPrepare() {
     Log.d(tag, "ON PREPARE MEDIA SESSION COMPAT")
@@ -75,19 +72,19 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
   }
 
   override fun onSkipToPrevious() {
-    playerNotificationService.seekBackward(seekAmount)
+    playerNotificationService.skipToPrevious()
   }
 
   override fun onSkipToNext() {
-    playerNotificationService.seekForward(seekAmount)
+    playerNotificationService.skipToNext()
   }
 
   override fun onFastForward() {
-    playerNotificationService.seekForward(seekAmount)
+    playerNotificationService.jumpForward()
   }
 
   override fun onRewind() {
-    playerNotificationService.seekForward(seekAmount)
+    playerNotificationService.jumpBackward()
   }
 
   override fun onSeekTo(pos: Long) {
@@ -179,10 +176,10 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
             handleMediaButtonClickCount()
           }
           KeyEvent.KEYCODE_MEDIA_NEXT -> {
-            playerNotificationService.seekForward(seekAmount)
+            playerNotificationService.jumpForward()
           }
           KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
-            playerNotificationService.seekBackward(seekAmount)
+            playerNotificationService.jumpBackward()
           }
           KeyEvent.KEYCODE_MEDIA_STOP -> {
             playerNotificationService.closePlayback()
@@ -226,22 +223,22 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
     override fun handleMessage(msg: Message) {
       super.handleMessage(msg)
       if (2 == msg.what) {
-        playerNotificationService.seekBackward(seekAmount)
+        playerNotificationService.jumpBackward()
         playerNotificationService.play()
       }
       else if (msg.what >= 3) {
-        playerNotificationService.seekForward(seekAmount)
+        playerNotificationService.jumpForward()
         playerNotificationService.play()
       }
     }
   }
 
-  // Example Using a custom action in android auto
-//  override fun onCustomAction(action: String?, extras: Bundle?) {
-//    super.onCustomAction(action, extras)
-//
-//    if ("com.audiobookshelf.app.PLAYBACK_RATE" == action) {
-//
-//    }
-//  }
+  override fun onCustomAction(action: String?, extras: Bundle?) {
+    super.onCustomAction(action, extras)
+
+    when (action) {
+      CUSTOM_ACTION_JUMP_FORWARD -> onFastForward()
+      CUSTOM_ACTION_JUMP_BACKWARD -> onRewind()
+    }
+  }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerConstants.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerConstants.kt
@@ -1,0 +1,4 @@
+package com.audiobookshelf.app.player
+
+const val CUSTOM_ACTION_JUMP_FORWARD = "com.audiobookshelf.customAction.jump_forward";
+const val CUSTOM_ACTION_JUMP_BACKWARD = "com.audiobookshelf.customAction.jump_backward";

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="custom_url_scheme">com.audiobookshelf.app</string>
     <string name="add_widget">Add widget</string>
     <string name="app_widget_description">Simple widget for audiobookshelf playback</string>
+    <string name="action_jump_forward">Jump Forward</string>
+    <string name="action_jump_backward">Jump Backward</string>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-      classpath 'com.google.gms:google-services:4.3.5'
-      classpath 'com.android.tools.build:gradle:7.2.0-beta04'
+      classpath 'com.google.gms:google-services:4.3.10'
+      classpath 'com.android.tools.build:gradle:7.2.2'
       classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
       // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
This PR adds additional media controls to Android Auto (and perhaps Wear and maybe Automotive?) I know little about how Android's MediaBrowserService works and Google's lack of documentation seems motivated to keep things a mystery.

So far, this change includes:
- Addition of jump forward button in Android Auto.
- Addition of jump back button in Android Auto.
- Player, Android notification, and Android Auto all respect the "Jump" times specified in device settings.

Discussion Points:
- Previous button - This button appears on Android Auto and I have no idea how to remove it, so I mapped it's functionality to the media player's previous functionality.
- Next button - Since it seems we have no control over which standard buttons are shown, I experimented with adding a next button as a custom action. This is doable but we'll have to start managing our own prev/next drawables if we want a guarantee of consistent UI.
- Order of custom action buttons on the UI is weird. Some buttons are added before play/pause and some after. I didn't find anything that gives us control of the weight.
- String - A lot of UI strings are defined in the capacitorjs code. Rather than add to strings.xml, we should be pulling from the JS if we can but I'm not sure how.


![image](https://user-images.githubusercontent.com/1752370/185803415-33ebc783-3083-4bd1-8b0e-6e9ad54fae65.png)

Ref: #79
