### PR TITLE
Improve iOS Player Sync Logic

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -11,7 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         let configuration = Realm.Configuration(
-            schemaVersion: 2,
+            schemaVersion: 3,
             migrationBlock: { migration, oldSchemaVersion in
                 if (oldSchemaVersion < 1) {
                     NSLog("Realm schema version was \(oldSchemaVersion)")

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -11,12 +11,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         let configuration = Realm.Configuration(
-            schemaVersion: 3,
+            schemaVersion: 4,
             migrationBlock: { migration, oldSchemaVersion in
                 if (oldSchemaVersion < 1) {
                     NSLog("Realm schema version was \(oldSchemaVersion)")
                     migration.enumerateObjects(ofType: DeviceSettings.className()) { oldObject, newObject in
                         newObject?["enableAltView"] = false
+                    }
+                }
+                if (oldSchemaVersion < 4) {
+                    NSLog("Realm schema version was \(oldSchemaVersion)... Reindexing server configs")
+                    var indexCounter = 1
+                    migration.enumerateObjects(ofType: ServerConnectionConfig.className()) { oldObject, newObject in
+                        newObject?["index"] = indexCounter
+                        indexCounter += 1
                     }
                 }
             }

--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -166,45 +166,47 @@ public class AbsAudioPlayer: CAPPlugin {
     
     @objc func decreaseSleepTime(_ call: CAPPluginCall) {
         guard let timeString = call.getString("time") else { return call.resolve([ "success": false ]) }
-        guard let time = Int(timeString) else { return call.resolve([ "success": false ]) }
-        guard let currentSleepTime = PlayerHandler.remainingSleepTime else { return call.resolve([ "success": false ]) }
+        guard let time = Double(timeString) else { return call.resolve([ "success": false ]) }
+        guard let _ = PlayerHandler.remainingSleepTime else { return call.resolve([ "success": false ]) }
         
-        PlayerHandler.remainingSleepTime = currentSleepTime - (time / 1000)
+        let seconds = time/1000
+        PlayerHandler.decreaseSleepTime(decreaseSeconds: seconds)
         call.resolve()
     }
+    
     @objc func increaseSleepTime(_ call: CAPPluginCall) {
         guard let timeString = call.getString("time") else { return call.resolve([ "success": false ]) }
-        guard let time = Int(timeString) else { return call.resolve([ "success": false ]) }
-        guard let currentSleepTime = PlayerHandler.remainingSleepTime else { return call.resolve([ "success": false ]) }
+        guard let time = Double(timeString) else { return call.resolve([ "success": false ]) }
+        guard let _ = PlayerHandler.remainingSleepTime else { return call.resolve([ "success": false ]) }
         
-        PlayerHandler.remainingSleepTime = currentSleepTime + (time / 1000)
+        let seconds = time/1000
+        PlayerHandler.increaseSleepTime(increaseSeconds: seconds)
         call.resolve()
     }
+    
     @objc func setSleepTimer(_ call: CAPPluginCall) {
         guard let timeString = call.getString("time") else { return call.resolve([ "success": false ]) }
         guard let time = Int(timeString) else { return call.resolve([ "success": false ]) }
-        let timeSeconds = time / 1000
+        let isChapterTime = call.getBool("isChapterTime", false)
         
-        NSLog("chapter time: \(call.getBool("isChapterTime", false))")
+        let seconds = time / 1000
         
-        if call.getBool("isChapterTime", false) {
-            let timeToPause = timeSeconds - Int(PlayerHandler.getCurrentTime() ?? 0)
-            if timeToPause < 0 { return call.resolve([ "success": false ]) }
-            
-            PlayerHandler.sleepTimerChapterStopTime = timeSeconds
-            PlayerHandler.remainingSleepTime = timeToPause
+        NSLog("chapter time: \(isChapterTime)")
+        if isChapterTime {
+            PlayerHandler.setChapterSleepTime(stopAt: Double(seconds))
             return call.resolve([ "success": true ])
         }
         
-        PlayerHandler.sleepTimerChapterStopTime = nil
-        PlayerHandler.remainingSleepTime = timeSeconds
+        PlayerHandler.setSleepTime(secondsUntilSleep: Double(seconds))
         call.resolve([ "success": true ])
     }
+    
     @objc func cancelSleepTimer(_ call: CAPPluginCall) {
-        PlayerHandler.remainingSleepTime = nil
+        PlayerHandler.cancelSleepTime()
         PlayerHandler.sleepTimerChapterStopTime = nil
         call.resolve()
     }
+    
     @objc func getSleepTimerTime(_ call: CAPPluginCall) {
         call.resolve([
             "value": PlayerHandler.remainingSleepTime

--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -40,7 +40,7 @@ public class AbsAudioPlayer: CAPPlugin {
             // Fetch the most recent active session
             let activeSession = try await Realm().objects(PlaybackSession.self).where({ $0.isActiveSession == true }).last
             if let activeSession = activeSession {
-                await PlayerProgress.syncFromServer()
+                await PlayerProgress.shared.syncFromServer()
                 try self.startPlaybackSession(activeSession, playWhenReady: false, playbackRate: PlayerSettings.main().playbackRate)
             }
         } catch {

--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -38,7 +38,9 @@ public class AbsAudioPlayer: CAPPlugin {
         
         do {
             // Fetch the most recent active session
-            let activeSession = try await Realm().objects(PlaybackSession.self).where({ $0.isActiveSession == true }).last?.freeze()
+            let activeSession = try await Realm().objects(PlaybackSession.self).where({
+                $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
+            }).last?.freeze()
             if let activeSession = activeSession {
                 await PlayerProgress.shared.syncFromServer()
                 try self.startPlaybackSession(activeSession, playWhenReady: false, playbackRate: PlayerSettings.main().playbackRate)

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -139,7 +139,7 @@ public class AbsDatabase: CAPPlugin {
             call.reject("localMediaProgressId not specificed")
             return
         }
-        Database.shared.removeLocalMediaProgress(localMediaProgressId: localMediaProgressId)
+        try? Database.shared.removeLocalMediaProgress(localMediaProgressId: localMediaProgressId)
         call.resolve()
     }
     
@@ -171,14 +171,14 @@ public class AbsDatabase: CAPPlugin {
                 return call.reject("localLibraryItemId or localMediaProgressId must be specified")
             }
             
-            let localMediaProgress = LocalMediaProgress.fetchOrCreateLocalMediaProgress(localMediaProgressId: localMediaProgressId, localLibraryItemId: localLibraryItemId, localEpisodeId: localEpisodeId)
+            let localMediaProgress = try LocalMediaProgress.fetchOrCreateLocalMediaProgress(localMediaProgressId: localMediaProgressId, localLibraryItemId: localLibraryItemId, localEpisodeId: localEpisodeId)
             guard let localMediaProgress = localMediaProgress else {
                 call.reject("Local media progress not found or created")
                 return
             }
             
             NSLog("syncServerMediaProgressWithLocalMediaProgress: Saving local media progress")
-            localMediaProgress.updateFromServerMediaProgress(serverMediaProgress)
+            try localMediaProgress.updateFromServerMediaProgress(serverMediaProgress)
             
             call.resolve(try localMediaProgress.asDictionary())
         } catch {
@@ -195,30 +195,36 @@ public class AbsDatabase: CAPPlugin {
         
         NSLog("updateLocalMediaProgressFinished \(localMediaProgressId ?? "Unknown") | Is Finished: \(isFinished)")
         
-        let localMediaProgress = LocalMediaProgress.fetchOrCreateLocalMediaProgress(localMediaProgressId: localMediaProgressId, localLibraryItemId: localLibraryItemId, localEpisodeId: localEpisodeId)
-        guard let localMediaProgress = localMediaProgress else {
-            call.resolve(["error": "Library Item not found"])
-            return
-        }
+        do {
+            let localMediaProgress = try LocalMediaProgress.fetchOrCreateLocalMediaProgress(localMediaProgressId: localMediaProgressId, localLibraryItemId: localLibraryItemId, localEpisodeId: localEpisodeId)
+            guard let localMediaProgress = localMediaProgress else {
+                call.resolve(["error": "Library Item not found"])
+                return
+            }
 
-        // Update finished status
-        localMediaProgress.updateIsFinished(isFinished)
-        
-        // Build API response
-        let progressDictionary = try? localMediaProgress.asDictionary()
-        var response: [String: Any] = ["local": true, "server": false, "localMediaProgress": progressDictionary ?? ""]
-        
-        // Send update to the server if logged in
-        let hasLinkedServer = localMediaProgress.serverConnectionConfigId != nil
-        let loggedIntoServer = Store.serverConfig?.id == localMediaProgress.serverConnectionConfigId
-        if hasLinkedServer && loggedIntoServer {
-            response["server"] = true
-            let payload = ["isFinished": isFinished]
-            ApiClient.updateMediaProgress(libraryItemId: localMediaProgress.libraryItemId!, episodeId: localEpisodeId, payload: payload) {
+            // Update finished status
+            try localMediaProgress.updateIsFinished(isFinished)
+            
+            // Build API response
+            let progressDictionary = try? localMediaProgress.asDictionary()
+            var response: [String: Any] = ["local": true, "server": false, "localMediaProgress": progressDictionary ?? ""]
+            
+            // Send update to the server if logged in
+            let hasLinkedServer = localMediaProgress.serverConnectionConfigId != nil
+            let loggedIntoServer = Store.serverConfig?.id == localMediaProgress.serverConnectionConfigId
+            if hasLinkedServer && loggedIntoServer {
+                response["server"] = true
+                let payload = ["isFinished": isFinished]
+                ApiClient.updateMediaProgress(libraryItemId: localMediaProgress.libraryItemId!, episodeId: localEpisodeId, payload: payload) {
+                    call.resolve(response)
+                }
+            } else {
                 call.resolve(response)
             }
-        } else {
-            call.resolve(response)
+        } catch {
+            debugPrint(error)
+            call.resolve(["error": "Failed to mark as complete"])
+            return
         }
     }
     

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -43,7 +43,7 @@ public class AbsDatabase: CAPPlugin {
         
         let config = ServerConnectionConfig()
         config.id = id ?? ""
-        config.index = 1
+        config.index = 0
         config.name = name
         config.address = address
         config.userId = userId

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -51,7 +51,8 @@ public class AbsDatabase: CAPPlugin {
         config.token = token
         
         Store.serverConfig = config
-        call.resolve(convertServerConnectionConfigToJSON(config: config))
+        let savedConfig = Store.serverConfig // Fetch the latest value
+        call.resolve(convertServerConnectionConfigToJSON(config: savedConfig!))
     }
     @objc func removeServerConnectionConfig(_ call: CAPPluginCall) {
         let id = call.getString("serverConnectionConfigId", "")

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -176,10 +176,10 @@ public class AbsDatabase: CAPPlugin {
                 call.reject("Local media progress not found or created")
                 return
             }
-            localMediaProgress.updateFromServerMediaProgress(serverMediaProgress)
             
             NSLog("syncServerMediaProgressWithLocalMediaProgress: Saving local media progress")
-            Database.shared.saveLocalMediaProgress(localMediaProgress)
+            localMediaProgress.updateFromServerMediaProgress(serverMediaProgress)
+            
             call.resolve(try localMediaProgress.asDictionary())
         } catch {
             call.reject("Failed to sync media progress")
@@ -203,7 +203,6 @@ public class AbsDatabase: CAPPlugin {
 
         // Update finished status
         localMediaProgress.updateIsFinished(isFinished)
-        Database.shared.saveLocalMediaProgress(localMediaProgress)
         
         // Build API response
         let progressDictionary = try? localMediaProgress.asDictionary()

--- a/ios/App/App/plugins/AbsDownloader.swift
+++ b/ios/App/App/plugins/AbsDownloader.swift
@@ -28,7 +28,7 @@ public class AbsDownloader: CAPPlugin, URLSessionDownloadDelegate {
     
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         handleDownloadTaskUpdate(downloadTask: downloadTask) { downloadItem, downloadItemPart in
-            let realm = try! Realm()
+            let realm = try Realm()
             try realm.write {
                 downloadItemPart.progress = 100
                 downloadItemPart.completed = true
@@ -139,7 +139,7 @@ public class AbsDownloader: CAPPlugin, URLSessionDownloadDelegate {
                         }
                         self.handleDownloadTaskCompleteFromDownloadItem(item)
                         if let item = Database.shared.getDownloadItem(downloadItemId: item.id!) {
-                            item.delete()
+                            try? item.delete()
                         }
                     }
                     
@@ -181,7 +181,7 @@ public class AbsDownloader: CAPPlugin, URLSessionDownloadDelegate {
                     }
                 } else {
                     localLibraryItem = LocalLibraryItem(libraryItem, localUrl: localDirectory, server: Store.serverConfig!, files: files, coverPath: coverFile)
-                    Database.shared.saveLocalLibraryItem(localLibraryItem: localLibraryItem!)
+                    try? Database.shared.saveLocalLibraryItem(localLibraryItem: localLibraryItem!)
                 }
                 
                 statusNotification["localLibraryItem"] = try? localLibraryItem.asDictionary()
@@ -189,7 +189,7 @@ public class AbsDownloader: CAPPlugin, URLSessionDownloadDelegate {
                 if let progress = libraryItem.userMediaProgress {
                     let episode = downloadItem.media?.episodes.first(where: { $0.id == downloadItem.episodeId })
                     let localMediaProgress = LocalMediaProgress(localLibraryItem: localLibraryItem!, episode: episode, progress: progress)
-                    Database.shared.saveLocalMediaProgress(localMediaProgress)
+                    try? localMediaProgress.save()
                     statusNotification["localMediaProgress"] = try? localMediaProgress.asDictionary()
                 }
                 
@@ -276,7 +276,7 @@ public class AbsDownloader: CAPPlugin, URLSessionDownloadDelegate {
         }
         
         // Persist in the database before status start coming in
-        Database.shared.saveDownloadItem(downloadItem)
+        try Database.shared.saveDownloadItem(downloadItem)
         
         // Start all the downloads
         for task in tasks {

--- a/ios/App/Shared/models/PlaybackSession.swift
+++ b/ios/App/Shared/models/PlaybackSession.swift
@@ -31,6 +31,7 @@ class PlaybackSession: Object, Codable, Deletable {
     @Persisted var serverConnectionConfigId: String?
     @Persisted var serverAddress: String?
     @Persisted var isActiveSession = true
+    @Persisted var serverUpdatedAt: Double = 0
     
     var isLocal: Bool { self.localLibraryItem != nil }
     var mediaPlayer: String { "AVPlayer" }

--- a/ios/App/Shared/models/download/DownloadItem.swift
+++ b/ios/App/Shared/models/download/DownloadItem.swift
@@ -88,8 +88,8 @@ extension DownloadItem {
         self.downloadItemParts.allSatisfy({ $0.failed == false })
     }
     
-    func delete() {
-        try! self.realm?.write {
+    func delete() throws {
+        try self.realm?.write {
             self.realm?.delete(self.downloadItemParts)
             self.realm?.delete(self)
         }

--- a/ios/App/Shared/models/local/LocalLibraryItem.swift
+++ b/ios/App/Shared/models/local/LocalLibraryItem.swift
@@ -198,8 +198,8 @@ extension LocalLibraryItem {
         )
     }
     
-    func delete() {
-        try! self.realm?.write {
+    func delete() throws {
+        try self.realm?.write {
             self.realm?.delete(self.localFiles)
             self.realm?.delete(self)
         }

--- a/ios/App/Shared/models/local/LocalMediaProgress.swift
+++ b/ios/App/Shared/models/local/LocalMediaProgress.swift
@@ -120,7 +120,7 @@ extension LocalMediaProgress {
     }
     
     func updateIsFinished(_ finished: Bool) {
-        try! Realm().write {
+        try! self.realm?.write {
             if self.isFinished != finished {
                 self.progress = finished ? 1.0 : 0.0
             }
@@ -136,7 +136,7 @@ extension LocalMediaProgress {
     }
     
     func updateFromPlaybackSession(_ playbackSession: PlaybackSession) {
-        try! Realm().write {
+        try! self.realm?.write {
             self.currentTime = playbackSession.currentTime
             self.progress = playbackSession.progress
             self.lastUpdate = Date().timeIntervalSince1970 * 1000
@@ -146,7 +146,7 @@ extension LocalMediaProgress {
     }
     
     func updateFromServerMediaProgress(_ serverMediaProgress: MediaProgress) {
-        try! Realm().write {
+        try! self.realm?.write {
             self.isFinished = serverMediaProgress.isFinished
             self.progress = serverMediaProgress.progress
             self.currentTime = serverMediaProgress.currentTime

--- a/ios/App/Shared/models/local/LocalMediaProgress.swift
+++ b/ios/App/Shared/models/local/LocalMediaProgress.swift
@@ -158,19 +158,24 @@ extension LocalMediaProgress {
     }
     
     static func fetchOrCreateLocalMediaProgress(localMediaProgressId: String?, localLibraryItemId: String?, localEpisodeId: String?) -> LocalMediaProgress? {
-        if let localMediaProgressId = localMediaProgressId {
-            // Check if it existing in the database, if not, we need to create it
-            if let progress = Database.shared.getLocalMediaProgress(localMediaProgressId: localMediaProgressId) {
-                return progress
+        let realm = try! Realm()
+        return try! realm.write { () -> LocalMediaProgress? in
+            if let localMediaProgressId = localMediaProgressId {
+                // Check if it existing in the database, if not, we need to create it
+                if let progress = Database.shared.getLocalMediaProgress(localMediaProgressId: localMediaProgressId) {
+                    return progress
+                }
             }
-        }
-        
-        if let localLibraryItemId = localLibraryItemId {
-            guard let localLibraryItem = Database.shared.getLocalLibraryItem(localLibraryItemId: localLibraryItemId) else { return nil }
-            let episode = localLibraryItem.getPodcastEpisode(episodeId: localEpisodeId)
-            return LocalMediaProgress(localLibraryItem: localLibraryItem, episode: episode)
-        } else {
-            return nil
+            
+            if let localLibraryItemId = localLibraryItemId {
+                guard let localLibraryItem = Database.shared.getLocalLibraryItem(localLibraryItemId: localLibraryItemId) else { return nil }
+                let episode = localLibraryItem.getPodcastEpisode(episodeId: localEpisodeId)
+                let progress = LocalMediaProgress(localLibraryItem: localLibraryItem, episode: episode)
+                realm.add(progress)
+                return progress
+            } else {
+                return nil
+            }
         }
     }
 }

--- a/ios/App/Shared/models/local/LocalMediaProgress.swift
+++ b/ios/App/Shared/models/local/LocalMediaProgress.swift
@@ -119,8 +119,8 @@ extension LocalMediaProgress {
         self.finishedAt = progress.finishedAt
     }
     
-    func updateIsFinished(_ finished: Bool) {
-        try! self.realm?.write {
+    func updateIsFinished(_ finished: Bool) throws {
+        try self.realm?.write {
             if self.isFinished != finished {
                 self.progress = finished ? 1.0 : 0.0
             }
@@ -135,8 +135,8 @@ extension LocalMediaProgress {
         }
     }
     
-    func updateFromPlaybackSession(_ playbackSession: PlaybackSession) {
-        try! self.realm?.write {
+    func updateFromPlaybackSession(_ playbackSession: PlaybackSession) throws {
+        try self.realm?.write {
             self.currentTime = playbackSession.currentTime
             self.progress = playbackSession.progress
             self.lastUpdate = Date().timeIntervalSince1970 * 1000
@@ -145,8 +145,8 @@ extension LocalMediaProgress {
         }
     }
     
-    func updateFromServerMediaProgress(_ serverMediaProgress: MediaProgress) {
-        try! self.realm?.write {
+    func updateFromServerMediaProgress(_ serverMediaProgress: MediaProgress) throws {
+        try self.realm?.write {
             self.isFinished = serverMediaProgress.isFinished
             self.progress = serverMediaProgress.progress
             self.currentTime = serverMediaProgress.currentTime
@@ -157,9 +157,9 @@ extension LocalMediaProgress {
         }
     }
     
-    static func fetchOrCreateLocalMediaProgress(localMediaProgressId: String?, localLibraryItemId: String?, localEpisodeId: String?) -> LocalMediaProgress? {
-        let realm = try! Realm()
-        return try! realm.write { () -> LocalMediaProgress? in
+    static func fetchOrCreateLocalMediaProgress(localMediaProgressId: String?, localLibraryItemId: String?, localEpisodeId: String?) throws -> LocalMediaProgress? {
+        let realm = try Realm()
+        return try realm.write { () -> LocalMediaProgress? in
             if let localMediaProgressId = localMediaProgressId {
                 // Check if it existing in the database, if not, we need to create it
                 if let progress = Database.shared.getLocalMediaProgress(localMediaProgressId: localMediaProgressId) {

--- a/ios/App/Shared/models/local/LocalMediaProgress.swift
+++ b/ios/App/Shared/models/local/LocalMediaProgress.swift
@@ -63,8 +63,12 @@ class LocalMediaProgress: Object, Codable {
         try container.encode(localLibraryItemId, forKey: .localLibraryItemId)
         try container.encode(localEpisodeId, forKey: .localEpisodeId)
         try container.encode(duration, forKey: .duration)
-        try container.encode(progress, forKey: .progress)
-        try container.encode(currentTime, forKey: .currentTime)
+        if progress.isNaN == false {
+            try container.encode(progress, forKey: .progress)
+        }
+        if currentTime.isNaN == false {
+            try container.encode(currentTime, forKey: .currentTime)
+        }
         try container.encode(isFinished, forKey: .isFinished)
         try container.encode(lastUpdate, forKey: .lastUpdate)
         try container.encode(startedAt, forKey: .startedAt)

--- a/ios/App/Shared/models/server/AudioTrack.swift
+++ b/ios/App/Shared/models/server/AudioTrack.swift
@@ -37,7 +37,7 @@ class AudioTrack: EmbeddedObject, Codable {
         contentUrl = try? values.decode(String.self, forKey: .contentUrl)
         mimeType = try values.decode(String.self, forKey: .mimeType)
         metadata = try? values.decode(FileMetadata.self, forKey: .metadata)
-        localFileId = try! values.decodeIfPresent(String.self, forKey: .localFileId)
+        localFileId = try? values.decodeIfPresent(String.self, forKey: .localFileId)
         serverIndex = try? values.decode(Int.self, forKey: .serverIndex)
     }
     

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -137,21 +137,24 @@ class AudioPlayer: NSObject {
     }
     
     private func setupTimeObserver() {
-        removeTimeObserver()
-        
-        let timeScale = CMTimeScale(NSEC_PER_SEC)
-        // Rate will be different depending on playback speed, aim for 2 observations/sec
-        let seconds = 0.5 * (self.rate > 0 ? self.rate : 1.0)
-        let time = CMTime(seconds: Double(seconds), preferredTimescale: timeScale)
-        self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: queue) { [weak self] time in
-            Task {
-                // Let the player update the current playback positions
-                await PlayerProgress.shared.syncFromPlayer(currentTime: time.seconds, includesPlayProgress: true, isStopping: false)
-            }
+        // Time observer should be configured on the main queue
+        DispatchQueue.main.sync {
+            self.removeTimeObserver()
             
-            // Update the sleep time, if set
-            if self?.sleepTimeStopAt != nil {
-                NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepSet.rawValue), object: nil)
+            let timeScale = CMTimeScale(NSEC_PER_SEC)
+            // Rate will be different depending on playback speed, aim for 2 observations/sec
+            let seconds = 0.5 * (self.rate > 0 ? self.rate : 1.0)
+            let time = CMTime(seconds: Double(seconds), preferredTimescale: timeScale)
+            self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: queue) { [weak self] time in
+                Task {
+                    // Let the player update the current playback positions
+                    await PlayerProgress.shared.syncFromPlayer(currentTime: time.seconds, includesPlayProgress: true, isStopping: false)
+                }
+                
+                // Update the sleep time, if set
+                if self?.sleepTimeStopAt != nil {
+                    NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepSet.rawValue), object: nil)
+                }
             }
         }
     }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -334,7 +334,7 @@ class AudioPlayer: NSObject {
                 self?.updateNowPlaying()
                 
                 // If we have an active sleep timer, reschedule based on seek, since seek is fuzzy
-                // Theis needs to occur after play() to capture the correct rate
+                // This needs to occur after play() to capture the correct playback rate
                 if let currentTime = self?.getCurrentTime() {
                     self?.rescheduleSleepTimerAtTime(time: currentTime, secondsRemaining: sleepSecondsRemaining)
                 }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -137,14 +137,14 @@ class AudioPlayer: NSObject {
     
     private func setupTimeObserver() {
         // Time observer should be configured on the main queue
-        DispatchQueue.main.sync {
+        DispatchQueue.runOnMainQueue {
             self.removeTimeObserver()
             
             let timeScale = CMTimeScale(NSEC_PER_SEC)
             // Rate will be different depending on playback speed, aim for 2 observations/sec
             let seconds = 0.5 * (self.rate > 0 ? self.rate : 1.0)
             let time = CMTime(seconds: Double(seconds), preferredTimescale: timeScale)
-            self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: queue) { [weak self] time in
+            self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: self.queue) { [weak self] time in
                 Task {
                     // Let the player update the current playback positions
                     await PlayerProgress.shared.syncFromPlayer(currentTime: time.seconds, includesPlayProgress: true, isStopping: false)

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -306,7 +306,7 @@ class AudioPlayer: NSObject {
         if (self.currentTrackIndex != indexOfSeek) {
             self.currentTrackIndex = indexOfSeek
             
-            playbackSession.update {
+            try? playbackSession.update {
                 playbackSession.currentTime = to
             }
             

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -25,7 +25,6 @@ class AudioPlayer: NSObject {
     @objc dynamic var rate: Float
     
     private var tmpRate: Float = 1.0
-    private var lastPlayTime: Double = 0.0
     
     private var playerContext = 0
     private var playerItemContext = 0
@@ -229,21 +228,22 @@ class AudioPlayer: NSObject {
         // Capture remaining sleep time before changing the track position
         let sleepSecondsRemaining = PlayerHandler.remainingSleepTime
         
-        if allowSeekBack {
-            let diffrence = Date.timeIntervalSinceReferenceDate - lastPlayTime
+        if allowSeekBack, let session = Database.shared.getPlaybackSession(id: self.sessionId) {
+            let lastPlayed = (session.updatedAt ?? 0)/1000
+            let difference = Date.timeIntervalSinceReferenceDate - lastPlayed
             var time: Int?
             
-            if lastPlayTime == 0 {
+            if lastPlayed == 0 {
                 time = 5
-            } else if diffrence < 6 {
+            } else if difference < 6 {
                 time = 2
-            } else if diffrence < 12 {
+            } else if difference < 12 {
                 time = 10
-            } else if diffrence < 30 {
+            } else if difference < 30 {
                 time = 15
-            } else if diffrence < 180 {
+            } else if difference < 180 {
                 time = 20
-            } else if diffrence < 3600 {
+            } else if difference < 3600 {
                 time = 25
             } else {
                 time = 29
@@ -253,7 +253,6 @@ class AudioPlayer: NSObject {
                 seek(getCurrentTime() - Double(time!), from: "play")
             }
         }
-        lastPlayTime = Date.timeIntervalSinceReferenceDate
         
         self.stopPausedTimer()
         
@@ -285,7 +284,6 @@ class AudioPlayer: NSObject {
         }
         
         updateNowPlaying()
-        lastPlayTime = Date.timeIntervalSinceReferenceDate
         
         self.startPausedTimer()
     }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -224,6 +224,9 @@ class AudioPlayer: NSObject {
     public func play(allowSeekBack: Bool = false) {
         guard self.isInitialized() else { return }
         
+        // Capture remaining sleep time before changing the track position
+        let sleepSecondsRemaining = PlayerHandler.remainingSleepTime
+        
         if allowSeekBack {
             let diffrence = Date.timeIntervalSinceReferenceDate - lastPlayTime
             var time: Int?
@@ -261,6 +264,9 @@ class AudioPlayer: NSObject {
         self.status = 1
         self.rate = self.tmpRate
         self.audioPlayer.rate = self.tmpRate
+        
+        // If we have an active sleep timer, reschedule based on rate
+        self.rescheduleSleepTimerAtTime(time: self.getCurrentTime(), secondsRemaining: sleepSecondsRemaining)
         
         updateNowPlaying()
     }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -276,12 +276,14 @@ class AudioPlayer: NSObject {
         guard self.isInitialized() else { return }
         
         self.audioPlayer.pause()
-        self.status = 0
-        self.rate = 0.0
         
         Task {
-            await PlayerProgress.shared.syncFromPlayer(currentTime: self.getCurrentTime(), includesPlayProgress: true, isStopping: true)
+            let wasPlaying = self.status > 0
+            await PlayerProgress.shared.syncFromPlayer(currentTime: self.getCurrentTime(), includesPlayProgress: wasPlaying, isStopping: true)
         }
+        
+        self.status = 0
+        self.rate = 0.0
         
         updateNowPlaying()
         

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -413,6 +413,7 @@ class AudioPlayer: NSObject {
         sleepTimeToken = self.audioPlayer.addBoundaryTimeObserver(forTimes: times, queue: queue) { [weak self] in
             NSLog("SLEEP TIMER: Pausing audio")
             self?.pause()
+            PlayerHandler.sleepTimerChapterStopTime = nil
             self?.removeSleepTimer()
         }
         
@@ -454,7 +455,6 @@ class AudioPlayer: NSObject {
     }
     
     public func removeSleepTimer() {
-        PlayerHandler.sleepTimerChapterStopTime = nil
         self.sleepTimeStopAt = nil
         if let token = sleepTimeToken {
             self.audioPlayer.removeTimeObserver(token)

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -423,13 +423,31 @@ class AudioPlayer: NSObject {
     
     private func rescheduleSleepTimerAtTime(time: Double, secondsRemaining: Int?) {
         // Not a chapter sleep timer
+        let hadToCancelChapterSleepTimer = decideIfChapterSleepTimerNeedsToBeCanceled(time: time)
+        guard !hadToCancelChapterSleepTimer else { return }
         guard PlayerHandler.sleepTimerChapterStopTime == nil else { return }
+        
+        // Verify sleep timer is set
+        guard self.sleepTimeToken != nil else { return }
         
         // Update the sleep timer
         if let secondsRemaining = secondsRemaining {
             let newSleepTimerPosition = time + Double(secondsRemaining)
             self.setSleepTime(stopAt: newSleepTimerPosition, scaleBasedOnSpeed: true)
         }
+    }
+    
+    private func decideIfChapterSleepTimerNeedsToBeCanceled(time: Double) -> Bool {
+        if let chapterSleepTime = PlayerHandler.sleepTimerChapterStopTime {
+            let sleepIsBeforeCurrentTime = Double(chapterSleepTime) <= time
+            if sleepIsBeforeCurrentTime {
+                PlayerHandler.sleepTimerChapterStopTime = nil
+                self.removeSleepTimer()
+                return true
+            }
+        }
+        
+        return false
     }
     
     public func increaseSleepTime(extraTimeInSeconds: Double) {

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -18,6 +18,8 @@ enum PlayMethod:Int {
 }
 
 class AudioPlayer: NSObject {
+    private let audioPlayerQueue = DispatchQueue(label: "ABSAudioPlayerQueue")
+    
     // enums and @objc are not compatible
     @objc dynamic var status: Int
     @objc dynamic var rate: Float
@@ -141,7 +143,7 @@ class AudioPlayer: NSObject {
         // Rate will be different depending on playback speed, aim for 2 observations/sec
         let seconds = 0.5 * (self.rate > 0 ? self.rate : 1.0)
         let time = CMTime(seconds: Double(seconds), preferredTimescale: timeScale)
-        self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: .main) { [weak self] time in
+        self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: audioPlayerQueue) { [weak self] time in
             let sleepTimeStopAt = self?.sleepTimeStopAt
             Task {
                 // Let the player update the current playback positions
@@ -205,7 +207,7 @@ class AudioPlayer: NSObject {
     
     private func startPausedTimer() {
         guard self.pausedTimer == nil else { return }
-        DispatchQueue.main.async {
+        audioPlayerQueue.async {
             self.pausedTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: true) { timer in
                 NSLog("PAUSE TIMER: Syncing from server")
                 Task { await PlayerProgress.shared.syncFromServer() }
@@ -398,7 +400,7 @@ class AudioPlayer: NSObject {
         var times = [NSValue]()
         times.append(NSValue(time: sleepTime))
         
-        sleepTimeToken = self.audioPlayer.addBoundaryTimeObserver(forTimes: times, queue: .main) { [weak self] in
+        sleepTimeToken = self.audioPlayer.addBoundaryTimeObserver(forTimes: times, queue: audioPlayerQueue) { [weak self] in
             NSLog("SLEEP TIMER: Pausing audio")
             self?.pause()
             self?.removeSleepTimer()

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -168,8 +168,4 @@ class PlayerHandler {
             }
         }
     }
-    
-    @objc public static func syncServerProgressDuringPause() {
-        Task { await PlayerProgress.shared.syncFromServer() }
-    }
 }

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -111,6 +111,7 @@ class PlayerHandler {
     }
     
     public static func cancelSleepTime() {
+        PlayerHandler.sleepTimerChapterStopTime = nil
         self.player?.removeSleepTimer()
     }
     

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -101,10 +101,12 @@ class PlayerHandler {
     }
     
     public static func increaseSleepTime(increaseSeconds: Double) {
+        self.sleepTimerChapterStopTime = nil
         self.player?.increaseSleepTime(extraTimeInSeconds: increaseSeconds)
     }
     
     public static func decreaseSleepTime(decreaseSeconds: Double) {
+        self.sleepTimerChapterStopTime = nil
         self.player?.decreaseSleepTime(removeTimeInSeconds: decreaseSeconds)
     }
     

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -159,7 +159,9 @@ class PlayerHandler {
     
     private static func cleanupOldSessions(currentSessionId: String?) {
         let realm = try! Realm()
-        let oldSessions = realm.objects(PlaybackSession.self) .where({ $0.isActiveSession == true })
+        let oldSessions = realm.objects(PlaybackSession.self) .where({
+            $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
+        })
         try! realm.write {
             for s in oldSessions {
                 if s.id != currentSessionId {

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -240,11 +240,11 @@ class PlayerHandler {
         listeningTimePassedSinceLastSync = 0
         
         // Persist items in the database and sync to the server
-        if session.isLocal { PlayerProgress.syncFromPlayer() }
-        Task { await PlayerProgress.syncToServer() }
+        if session.isLocal { PlayerProgress.shared.syncFromPlayer() }
+        Task { await PlayerProgress.shared.syncToServer() }
     }
     
     @objc public static func syncServerProgressDuringPause() {
-        Task { await PlayerProgress.syncFromServer() }
+        Task { await PlayerProgress.shared.syncFromServer() }
     }
 }

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -141,23 +141,20 @@ class PlayerHandler {
     
     public static func getPlaybackSession() -> PlaybackSession? {
         guard let player = player else { return nil }
+        guard player.isInitialized() else { return nil }
         guard let session = Database.shared.getPlaybackSession(id: player.getPlaybackSessionId()) else { return nil }
         return session
     }
     
     public static func seekForward(amount: Double) {
-        guard let player = player else {
-            return
-        }
+        guard let player = player else { return }
         
         let destinationTime = player.getCurrentTime() + amount
         player.seek(destinationTime, from: "handler")
     }
     
     public static func seekBackward(amount: Double) {
-        guard let player = player else {
-            return
-        }
+        guard let player = player else { return }
         
         let destinationTime = player.getCurrentTime() - amount
         player.seek(destinationTime, from: "handler")
@@ -240,7 +237,7 @@ class PlayerHandler {
         listeningTimePassedSinceLastSync = 0
         
         // Persist items in the database and sync to the server
-        if session.isLocal { PlayerProgress.shared.syncFromPlayer() }
+        if session.isLocal { Task { await PlayerProgress.shared.syncFromPlayer() } }
         Task { await PlayerProgress.shared.syncToServer() }
     }
     

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -63,16 +63,22 @@ class PlayerHandler {
         get {
             guard let player = player else { return nil }
             
-            // Consider paused as playing at 1x
-            let rate = Double(player.rate > 0 ? player.rate : 1)
-            
+            // Return the player time until sleep
+            var timeUntilSleep: Double? = nil
             if let sleepTimerChapterStopTime = sleepTimerChapterStopTime {
-                let timeUntilChapterEnd = Double(sleepTimerChapterStopTime) - player.getCurrentTime()
-                let timeUntilChapterEndScaled = timeUntilChapterEnd / rate
-                return Int(timeUntilChapterEndScaled.rounded())
+                timeUntilSleep = Double(sleepTimerChapterStopTime) - player.getCurrentTime()
             } else if let stopAt = player.getSleepStopAt() {
-                let timeUntilSleep = stopAt - player.getCurrentTime()
+                timeUntilSleep = stopAt - player.getCurrentTime()
+            }
+            
+            // Scale the time until sleep based on the playback rate
+            if let timeUntilSleep = timeUntilSleep {
+                // Consider paused as playing at 1x
+                let rate = Double(player.rate > 0 ? player.rate : 1)
+                
                 let timeUntilSleepScaled = timeUntilSleep / rate
+                guard timeUntilSleepScaled.isNaN == false else { return nil }
+                
                 return Int(timeUntilSleepScaled.rounded())
             } else {
                 return nil

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -158,16 +158,21 @@ class PlayerHandler {
     // MARK: - Helper logic
     
     private static func cleanupOldSessions(currentSessionId: String?) {
-        let realm = try! Realm()
-        let oldSessions = realm.objects(PlaybackSession.self) .where({
-            $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
-        })
-        try! realm.write {
-            for s in oldSessions {
-                if s.id != currentSessionId {
-                    s.isActiveSession = false
+        do {
+            let realm = try Realm()
+            let oldSessions = realm.objects(PlaybackSession.self) .where({
+                $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
+            })
+            try realm.write {
+                for s in oldSessions {
+                    if s.id != currentSessionId {
+                        s.isActiveSession = false
+                    }
                 }
             }
+        } catch {
+            debugPrint("Failed to cleanup sessions")
+            debugPrint(error)
         }
     }
 }

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -11,25 +11,27 @@ import RealmSwift
 
 class PlayerProgress {
     
+    public static let shared = PlayerProgress()
+    
     private init() {}
     
-    public static func syncFromPlayer() {
+    public func syncFromPlayer() {
         updateLocalMediaProgressFromLocalSession()
     }
     
-    public static func syncToServer() async {
+    public func syncToServer() async {
         let backgroundToken = await UIApplication.shared.beginBackgroundTask(withName: "ABS:syncToServer")
         updateAllServerSessionFromLocalSession()
         await UIApplication.shared.endBackgroundTask(backgroundToken)
     }
     
-    public static func syncFromServer() async {
+    public func syncFromServer() async {
         let backgroundToken = await UIApplication.shared.beginBackgroundTask(withName: "ABS:syncFromServer")
         await updateLocalSessionFromServerMediaProgress()
         await UIApplication.shared.endBackgroundTask(backgroundToken)
     }
     
-    private static func updateLocalMediaProgressFromLocalSession() {
+    private func updateLocalMediaProgressFromLocalSession() {
         guard let session = PlayerHandler.getPlaybackSession() else { return }
         guard session.isLocal else { return }
         
@@ -49,7 +51,7 @@ class PlayerProgress {
         NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.localProgress.rawValue), object: nil)
     }
     
-    private static func updateAllServerSessionFromLocalSession() {
+    private func updateAllServerSessionFromLocalSession() {
         let sessions = try! Realm().objects(PlaybackSession.self).where({ $0.serverConnectionConfigId == Store.serverConfig?.id })
         for session in sessions {
             let session = session.freeze()
@@ -57,7 +59,7 @@ class PlayerProgress {
         }
     }
     
-    private static func updateServerSessionFromLocalSession(_ session: PlaybackSession) async {
+    private func updateServerSessionFromLocalSession(_ session: PlaybackSession) async {
         NSLog("Sending sessionId(\(session.id)) to server")
         
         var success = false
@@ -75,7 +77,7 @@ class PlayerProgress {
         }
     }
     
-    private static func updateLocalSessionFromServerMediaProgress() async {
+    private func updateLocalSessionFromServerMediaProgress() async {
         NSLog("checkCurrentSessionProgress: Checking if local media progress was updated on server")
         guard let session = PlayerHandler.getPlaybackSession()?.freeze() else { return }
         

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -47,6 +47,7 @@ class PlayerProgress {
     
     private func updateLocalSessionFromPlayer(currentTime: Double, includesPlayProgress: Bool) async -> PlaybackSession? {
         guard let session = PlayerHandler.getPlaybackSession() else { return nil }
+        guard !currentTime.isNaN else { return nil } // Prevent bad data on player stop
         
         let now = Date().timeIntervalSince1970 * 1000
         let lastUpdate = session.updatedAt ?? now

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -141,7 +141,7 @@ class PlayerProgress {
         session = session.freeze()
         
         guard safeToSync else { return }
-        NSLog("Sending sessionId(\(session.id)) to server")
+        NSLog("Sending sessionId(\(session.id)) to server with currentTime(\(session.currentTime))")
         
         var success = false
         if session.isLocal {

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -49,16 +49,18 @@ class PlayerProgress {
         guard let session = PlayerHandler.getPlaybackSession() else { return nil }
         guard !currentTime.isNaN else { return nil } // Prevent bad data on player stop
         
-        let now = Date().timeIntervalSince1970 * 1000
-        let lastUpdate = session.updatedAt ?? now
-        let timeSinceLastUpdate = now - lastUpdate
+        let nowInSeconds = Date().timeIntervalSince1970
+        let nowInMilliseconds = nowInSeconds * 1000
+        let lastUpdateInMilliseconds = session.updatedAt ?? nowInMilliseconds
+        let lastUpdateInSeconds = lastUpdateInMilliseconds / 1000
+        let secondsSinceLastUpdate = nowInSeconds - lastUpdateInSeconds
         
         session.update {
             session.currentTime = currentTime
-            session.updatedAt = now
+            session.updatedAt = nowInMilliseconds
             
             if includesPlayProgress {
-                session.timeListening += timeSinceLastUpdate
+                session.timeListening += secondsSinceLastUpdate
             }
         }
         

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -123,7 +123,7 @@ class PlayerProgress {
         }
     }
     
-    private static func updateLocalSessionFromServerMediaProgress() async {
+    private func updateLocalSessionFromServerMediaProgress() async {
         NSLog("updateLocalSessionFromServerMediaProgress: Checking if local media progress was updated on server")
         guard let session = try! await Realm().objects(PlaybackSession.self).last(where: { $0.isActiveSession == true })?.freeze() else {
             NSLog("updateLocalSessionFromServerMediaProgress: Failed to get session")

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -148,7 +148,9 @@ class PlayerProgress {
     
     private func updateLocalSessionFromServerMediaProgress() async {
         NSLog("updateLocalSessionFromServerMediaProgress: Checking if local media progress was updated on server")
-        guard let session = try! await Realm().objects(PlaybackSession.self).last(where: { $0.isActiveSession == true })?.freeze() else {
+        guard let session = try! await Realm().objects(PlaybackSession.self).last(where: {
+            $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
+        })?.freeze() else {
             NSLog("updateLocalSessionFromServerMediaProgress: Failed to get session")
             return
         }

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -84,7 +84,6 @@ class PlayerProgress {
             }
 
             localMediaProgress.updateFromPlaybackSession(session)
-            Database.shared.saveLocalMediaProgress(localMediaProgress)
             
             NSLog("Local progress saved to the database")
             

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -15,8 +15,10 @@ class PlayerProgress {
     
     private init() {}
     
-    public func syncFromPlayer() {
+    public func syncFromPlayer() async {
+        let backgroundToken = await UIApplication.shared.beginBackgroundTask(withName: "ABS:syncFromPlayer")
         updateLocalMediaProgressFromLocalSession()
+        await UIApplication.shared.endBackgroundTask(backgroundToken)
     }
     
     public func syncToServer() async {
@@ -29,6 +31,10 @@ class PlayerProgress {
         let backgroundToken = await UIApplication.shared.beginBackgroundTask(withName: "ABS:syncFromServer")
         await updateLocalSessionFromServerMediaProgress()
         await UIApplication.shared.endBackgroundTask(backgroundToken)
+    }
+    
+    private func updateLocalSessionFromPlayer() async {
+        
     }
     
     private func updateLocalMediaProgressFromLocalSession() {

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -10,8 +10,8 @@ import UIKit
 import RealmSwift
 
 class PlayerProgress {
-    
     public static let shared = PlayerProgress()
+    public static let queue = DispatchQueue(label: "ABSPlayerProgressQueue")
     
     private static let TIME_BETWEEN_SESSION_SYNC_IN_SECONDS = 10.0
     
@@ -22,7 +22,7 @@ class PlayerProgress {
     
     public func syncFromPlayer(currentTime: Double, includesPlayProgress: Bool, isStopping: Bool) async {
         let backgroundToken = await UIApplication.shared.beginBackgroundTask(withName: "ABS:syncFromPlayer")
-        let session = await updateLocalSessionFromPlayer(currentTime: currentTime, includesPlayProgress: includesPlayProgress)
+        let session = updateLocalSessionFromPlayer(currentTime: currentTime, includesPlayProgress: includesPlayProgress)
         updateLocalMediaProgressFromLocalSession()
         if let session = session {
             await updateServerSessionFromLocalSession(session, rateLimitSync: !isStopping)
@@ -45,48 +45,52 @@ class PlayerProgress {
     
     // MARK: - SYNC LOGIC
     
-    private func updateLocalSessionFromPlayer(currentTime: Double, includesPlayProgress: Bool) async -> PlaybackSession? {
-        guard let session = PlayerHandler.getPlaybackSession() else { return nil }
-        guard !currentTime.isNaN else { return nil } // Prevent bad data on player stop
-        
-        session.update {
-            session.realm?.refresh()
+    private func updateLocalSessionFromPlayer(currentTime: Double, includesPlayProgress: Bool) -> PlaybackSession? {
+        PlayerProgress.queue.sync {
+            guard let session = PlayerHandler.getPlaybackSession() else { return nil }
+            guard !currentTime.isNaN else { return nil } // Prevent bad data on player stop
             
-            let nowInSeconds = Date().timeIntervalSince1970
-            let nowInMilliseconds = nowInSeconds * 1000
-            let lastUpdateInMilliseconds = session.updatedAt ?? nowInMilliseconds
-            let lastUpdateInSeconds = lastUpdateInMilliseconds / 1000
-            let secondsSinceLastUpdate = nowInSeconds - lastUpdateInSeconds
-            
-            session.currentTime = currentTime
-            session.updatedAt = nowInMilliseconds
-            
-            if includesPlayProgress {
-                session.timeListening += secondsSinceLastUpdate
+            session.update {
+                session.realm?.refresh()
+                
+                let nowInSeconds = Date().timeIntervalSince1970
+                let nowInMilliseconds = nowInSeconds * 1000
+                let lastUpdateInMilliseconds = session.updatedAt ?? nowInMilliseconds
+                let lastUpdateInSeconds = lastUpdateInMilliseconds / 1000
+                let secondsSinceLastUpdate = nowInSeconds - lastUpdateInSeconds
+                
+                session.currentTime = currentTime
+                session.updatedAt = nowInMilliseconds
+                
+                if includesPlayProgress {
+                    session.timeListening += secondsSinceLastUpdate
+                }
             }
+            
+            return session.freeze()
         }
-        
-        return session.freeze()
     }
     
     private func updateLocalMediaProgressFromLocalSession() {
-        guard let session = PlayerHandler.getPlaybackSession() else { return }
-        guard session.isLocal else { return }
-        
-        let localMediaProgress = LocalMediaProgress.fetchOrCreateLocalMediaProgress(localMediaProgressId: session.localMediaProgressId, localLibraryItemId: session.localLibraryItem?.id, localEpisodeId: session.episodeId)
-        guard let localMediaProgress = localMediaProgress else {
-            // Local media progress should have been created
-            // If we're here, it means a library id is invalid
-            return
-        }
+        PlayerProgress.queue.sync {
+            guard let session = PlayerHandler.getPlaybackSession() else { return }
+            guard session.isLocal else { return }
+            
+            let localMediaProgress = LocalMediaProgress.fetchOrCreateLocalMediaProgress(localMediaProgressId: session.localMediaProgressId, localLibraryItemId: session.localLibraryItem?.id, localEpisodeId: session.episodeId)
+            guard let localMediaProgress = localMediaProgress else {
+                // Local media progress should have been created
+                // If we're here, it means a library id is invalid
+                return
+            }
 
-        localMediaProgress.updateFromPlaybackSession(session)
-        Database.shared.saveLocalMediaProgress(localMediaProgress)
-        
-        NSLog("Local progress saved to the database")
-        
-        // Send the local progress back to front-end
-        NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.localProgress.rawValue), object: nil)
+            localMediaProgress.updateFromPlaybackSession(session)
+            Database.shared.saveLocalMediaProgress(localMediaProgress)
+            
+            NSLog("Local progress saved to the database")
+            
+            // Send the local progress back to front-end
+            NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.localProgress.rawValue), object: nil)
+        }
     }
     
     private func updateAllServerSessionFromLocalSession() async {
@@ -102,31 +106,32 @@ class PlayerProgress {
     }
     
     private func updateServerSessionFromLocalSession(_ session: PlaybackSession, rateLimitSync: Bool = false) async {
-        guard var session = session.thaw() else { return }
-        var safeToSync = true
-        
-        // We need to update and check the server time in a transaction for thread-safety
-        session.update {
-            session.realm?.refresh()
+        PlayerProgress.queue.sync {
+            var safeToSync = true
+            guard var session = session.thaw() else { return }
             
-            let nowInMilliseconds = Date().timeIntervalSince1970 * 1000
-            let lastUpdateInMilliseconds = session.serverUpdatedAt
-            
-            // If required, rate limit requests based on session last update
-            if rateLimitSync {
-                let timeSinceLastSync = nowInMilliseconds - lastUpdateInMilliseconds
-                let timeBetweenSessionSync = PlayerProgress.TIME_BETWEEN_SESSION_SYNC_IN_SECONDS * 1000
-                safeToSync = timeSinceLastSync > timeBetweenSessionSync
-                if !safeToSync {
-                    return // This only exits the update block
+            // We need to update and check the server time in a transaction for thread-safety
+            session.update {
+                session.realm?.refresh()
+                
+                let nowInMilliseconds = Date().timeIntervalSince1970 * 1000
+                let lastUpdateInMilliseconds = session.serverUpdatedAt
+                
+                // If required, rate limit requests based on session last update
+                if rateLimitSync {
+                    let timeSinceLastSync = nowInMilliseconds - lastUpdateInMilliseconds
+                    let timeBetweenSessionSync = PlayerProgress.TIME_BETWEEN_SESSION_SYNC_IN_SECONDS * 1000
+                    safeToSync = timeSinceLastSync > timeBetweenSessionSync
+                    if !safeToSync {
+                        return // This only exits the update block
+                    }
                 }
+                
+                session.serverUpdatedAt = nowInMilliseconds
             }
-            
-            session.serverUpdatedAt = nowInMilliseconds
+            session = session.freeze()
+            guard safeToSync else { return }
         }
-        session = session.freeze()
-        
-        guard safeToSync else { return }
         
         NSLog("Sending sessionId(\(session.id)) to server")
         
@@ -138,10 +143,13 @@ class PlayerProgress {
             success = await ApiClient.reportPlaybackProgress(report: playbackReport, sessionId: session.id)
         }
         
+        
         // Remove old sessions after they synced with the server
         if success && !session.isActiveSession {
-            if let session = session.thaw() {
-                session.delete()
+            PlayerProgress.queue.sync {
+                if let session = session.thaw() {
+                    session.delete()
+                }
             }
         }
     }
@@ -176,14 +184,16 @@ class PlayerProgress {
         
         // Update the session, if needed
         if serverIsNewerThanLocal && currentTimeIsDifferent {
-            NSLog("updateLocalSessionFromServerMediaProgress: Server has newer time than local serverLastUpdate=\(serverLastUpdate) localLastUpdate=\(localLastUpdate)")
-            guard let session = session.thaw() else { return }
-            session.update {
-                session.currentTime = serverCurrentTime
-                session.updatedAt = serverLastUpdate
+            PlayerProgress.queue.sync {
+                NSLog("updateLocalSessionFromServerMediaProgress: Server has newer time than local serverLastUpdate=\(serverLastUpdate) localLastUpdate=\(localLastUpdate)")
+                guard let session = session.thaw() else { return }
+                session.update {
+                    session.currentTime = serverCurrentTime
+                    session.updatedAt = serverLastUpdate
+                }
+                NSLog("updateLocalSessionFromServerMediaProgress: Updated session currentTime newCurrentTime=\(serverCurrentTime) previousCurrentTime=\(localCurrentTime)")
+                PlayerHandler.seek(amount: session.currentTime)
             }
-            NSLog("updateLocalSessionFromServerMediaProgress: Updated session currentTime newCurrentTime=\(serverCurrentTime) previousCurrentTime=\(localCurrentTime)")
-            PlayerHandler.seek(amount: session.currentTime)
         } else {
             NSLog("updateLocalSessionFromServerMediaProgress: Local session does not need updating; local has latest progress")
         }

--- a/ios/App/Shared/util/ApiClient.swift
+++ b/ios/App/Shared/util/ApiClient.swift
@@ -200,7 +200,12 @@ class ApiClient {
                 
                 if let updates = response.localProgressUpdates {
                     for update in updates {
-                        Database.shared.saveLocalMediaProgress(update)
+                        do {
+                            try update.save()
+                        } catch {
+                            debugPrint("Failed to update local media progress")
+                            debugPrint(error)
+                        }
                     }
                 }
                 

--- a/ios/App/Shared/util/DaoExtensions.swift
+++ b/ios/App/Shared/util/DaoExtensions.swift
@@ -9,15 +9,15 @@ import Foundation
 import RealmSwift
 
 extension Object {
-    func save() {
-        let realm = try! Realm()
-        try! realm.write {
+    func save() throws {
+        let realm = try Realm()
+        try realm.write {
             realm.add(self, update: .modified)
         }
     }
     
-    func update(handler: () -> Void) {
-        try! self.realm?.write {
+    func update(handler: () -> Void) throws {
+        try self.realm?.write {
             handler()
         }
     }
@@ -33,12 +33,12 @@ extension EmbeddedObject {
 }
 
 protocol Deletable {
-    func delete()
+    func delete() throws
 }
 
 extension Deletable where Self: Object {
-    func delete() {
-        try! self.realm?.write {
+    func delete() throws {
+        try self.realm?.write {
             self.realm?.delete(self)
         }
     }

--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -20,26 +20,38 @@ class Database {
         let realm = try! Realm()
         let existing: ServerConnectionConfig? = realm.object(ofType: ServerConnectionConfig.self, forPrimaryKey: config.id)
         
-        if config.index == 0 {
-            let lastConfig: ServerConnectionConfig? = realm.objects(ServerConnectionConfig.self).last
-            
-            if lastConfig != nil {
-                config.index = lastConfig!.index + 1
-            } else {
-                config.index = 1
-            }
-        }
-        
-        do {
-            try realm.write {
-                if existing != nil {
-                    realm.delete(existing!)
+        if let existing = existing {
+            do {
+                try existing.update {
+                    existing.name = config.name
+                    existing.address = config.address
+                    existing.userId = config.userId
+                    existing.username = config.username
+                    existing.token = config.token
                 }
-                realm.add(config)
+            } catch {
+                NSLog("failed to update server config")
+                debugPrint(error)
             }
-        } catch(let exception) {
-            NSLog("failed to save server config")
-            debugPrint(exception)
+        } else {
+            if config.index == 0 {
+                let lastConfig: ServerConnectionConfig? = realm.objects(ServerConnectionConfig.self).last
+                
+                if lastConfig != nil {
+                    config.index = lastConfig!.index + 1
+                } else {
+                    config.index = 1
+                }
+            }
+            
+            do {
+                try realm.write {
+                    realm.add(config)
+                }
+            } catch(let exception) {
+                NSLog("failed to save server config")
+                debugPrint(exception)
+            }
         }
         
         setLastActiveConfigIndex(index: config.index)

--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -33,6 +33,8 @@ class Database {
                 NSLog("failed to update server config")
                 debugPrint(error)
             }
+            
+            setLastActiveConfigIndex(index: existing.index)
         } else {
             if config.index == 0 {
                 let lastConfig: ServerConnectionConfig? = realm.objects(ServerConnectionConfig.self).last
@@ -52,9 +54,9 @@ class Database {
                 NSLog("failed to save server config")
                 debugPrint(exception)
             }
+            
+            setLastActiveConfigIndex(index: config.index)
         }
-        
-        setLastActiveConfigIndex(index: config.index)
     }
     
     public func deleteServerConnectionConfig(id: String) {

--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -112,48 +112,83 @@ class Database {
     }
     
     public func getLocalLibraryItems(mediaType: MediaType? = nil) -> [LocalLibraryItem] {
-        let realm = try! Realm()
-        return Array(realm.objects(LocalLibraryItem.self))
+        do {
+            let realm = try Realm()
+            return Array(realm.objects(LocalLibraryItem.self))
+        } catch {
+            debugPrint(error)
+            return []
+        }
     }
     
     public func getLocalLibraryItem(byServerLibraryItemId: String) -> LocalLibraryItem? {
-        let realm = try! Realm()
-        return realm.objects(LocalLibraryItem.self).first(where: { $0.libraryItemId == byServerLibraryItemId })
+        do {
+            let realm = try Realm()
+            return realm.objects(LocalLibraryItem.self).first(where: { $0.libraryItemId == byServerLibraryItemId })
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
     public func getLocalLibraryItem(localLibraryItemId: String) -> LocalLibraryItem? {
-        let realm = try! Realm()
-        return realm.object(ofType: LocalLibraryItem.self, forPrimaryKey: localLibraryItemId)
+        do {
+            let realm = try Realm()
+            return realm.object(ofType: LocalLibraryItem.self, forPrimaryKey: localLibraryItemId)
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
-    public func saveLocalLibraryItem(localLibraryItem: LocalLibraryItem) {
-        let realm = try! Realm()
-        try! realm.write { realm.add(localLibraryItem, update: .modified) }
+    public func saveLocalLibraryItem(localLibraryItem: LocalLibraryItem) throws {
+        let realm = try Realm()
+        try realm.write { realm.add(localLibraryItem, update: .modified) }
     }
     
     public func getLocalFile(localFileId: String) -> LocalFile? {
-        let realm = try! Realm()
-        return realm.object(ofType: LocalFile.self, forPrimaryKey: localFileId)
+        do {
+            let realm = try Realm()
+            return realm.object(ofType: LocalFile.self, forPrimaryKey: localFileId)
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
     public func getDownloadItem(downloadItemId: String) -> DownloadItem? {
-        let realm = try! Realm()
-        return realm.object(ofType: DownloadItem.self, forPrimaryKey: downloadItemId)
+        do {
+            let realm = try Realm()
+            return realm.object(ofType: DownloadItem.self, forPrimaryKey: downloadItemId)
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
     public func getDownloadItem(libraryItemId: String) -> DownloadItem? {
-        let realm = try! Realm()
-        return realm.objects(DownloadItem.self).filter("libraryItemId == %@", libraryItemId).first
+        do {
+            let realm = try Realm()
+            return realm.objects(DownloadItem.self).filter("libraryItemId == %@", libraryItemId).first
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
     public func getDownloadItem(downloadItemPartId: String) -> DownloadItem? {
-        let realm = try! Realm()
-        return realm.objects(DownloadItem.self).filter("SUBQUERY(downloadItemParts, $part, $part.id == %@) .@count > 0", downloadItemPartId).first
+        do {
+            let realm = try Realm()
+            return realm.objects(DownloadItem.self).filter("SUBQUERY(downloadItemParts, $part, $part.id == %@) .@count > 0", downloadItemPartId).first
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
-    public func saveDownloadItem(_ downloadItem: DownloadItem) {
-        let realm = try! Realm()
-        return try! realm.write { realm.add(downloadItem, update: .modified) }
+    public func saveDownloadItem(_ downloadItem: DownloadItem) throws {
+        let realm = try Realm()
+        return try realm.write { realm.add(downloadItem, update: .modified) }
     }
     
     public func getDeviceSettings() -> DeviceSettings {
@@ -162,31 +197,41 @@ class Database {
     }
     
     public func getAllLocalMediaProgress() -> [LocalMediaProgress] {
-        let realm = try! Realm()
-        return Array(realm.objects(LocalMediaProgress.self))
-    }
-    
-    public func saveLocalMediaProgress(_ mediaProgress: LocalMediaProgress) {
-        let realm = try! Realm()
-        try! realm.write { realm.add(mediaProgress, update: .modified) }
+        do {
+            let realm = try Realm()
+            return Array(realm.objects(LocalMediaProgress.self))
+        } catch {
+            debugPrint(error)
+            return []
+        }
     }
     
     // For books this will just be the localLibraryItemId for podcast episodes this will be "{localLibraryItemId}-{episodeId}"
     public func getLocalMediaProgress(localMediaProgressId: String) -> LocalMediaProgress? {
-        let realm = try! Realm()
-        return realm.object(ofType: LocalMediaProgress.self, forPrimaryKey: localMediaProgressId)
+        do {
+            let realm = try Realm()
+            return realm.object(ofType: LocalMediaProgress.self, forPrimaryKey: localMediaProgressId)
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
     
-    public func removeLocalMediaProgress(localMediaProgressId: String) {
-        let realm = try! Realm()
-        try! realm.write {
+    public func removeLocalMediaProgress(localMediaProgressId: String) throws {
+        let realm = try Realm()
+        try realm.write {
             let progress = realm.object(ofType: LocalMediaProgress.self, forPrimaryKey: localMediaProgressId)
             realm.delete(progress!)
         }
     }
     
     public func getPlaybackSession(id: String) -> PlaybackSession? {
-        let realm = try! Realm()
-        return realm.object(ofType: PlaybackSession.self, forPrimaryKey: id)
+        do {
+            let realm = try Realm()
+            return realm.object(ofType: PlaybackSession.self, forPrimaryKey: id)
+        } catch {
+            debugPrint(error)
+            return nil
+        }
     }
 }

--- a/ios/App/Shared/util/NowPlayingInfo.swift
+++ b/ios/App/Shared/util/NowPlayingInfo.swift
@@ -59,12 +59,17 @@ class NowPlayingInfo {
         }
     }
     public func update(duration: Double, currentTime: Double, rate: Float) {
-        nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = duration
-        nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime
-        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = rate
-        nowPlayingInfo[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
-            
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+        // Update on the main to prevent access collisions
+        DispatchQueue.main.async { [weak self] in
+            if let self = self {
+                self.nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = duration
+                self.nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentTime
+                self.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = rate
+                self.nowPlayingInfo[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1.0
+                    
+                MPNowPlayingInfoCenter.default().nowPlayingInfo = self.nowPlayingInfo
+            }
+        }
     }
     
     public func reset() {


### PR DESCRIPTION
This PR refactors the iOS player sync hooks to rely on the native instead `AVPlayer` time observation hooks instead of using timers.

The theory is in low memory situations, iOS is stopping the current tick timer in the background, leading to issues where the player does not have the most accurate `currentTime`.

## Changes

* Persisting a syncing sessions are now done via `addPeriodicTimeObserver()` firing every 0.5 wall-clock seconds
  * The database `currentTime` is updated on every invocation
  * The server receives the latest session and media progress every 10 wall-clock seconds and when the player is paused or stopped
* `timeListening` is now calculated based on `updateAt` times between sync vs. running an incremental counter each second
  * This ensures it's reliable regardless of the interval the value is updated
* Sleep timers are now done via `addBoundaryTimeObserver` scheduled for the time to stop sleep
  * This refactor takes into account playbackSpeed, changes in playbackSpeed, seeks, and locks on a specific chapter time when required, to ensure the scheduled sleep time is always accurate
* Syncing the current progress from the server is still done via a timer, but has been refactored into the Audio Player, and is now aware of pauses using the Now Playing widget or a remote
* When resuming audio with allowed seek back, the last played time is based off the database session, allowing persistence across app restarts
* Fixes an existing Realm memory leak that was made worse by this change
  * Adds lots of error handling logic as part of tracking down this memory leak