### PR TITLE
Fix failed set category on initAudioSession

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -332,7 +332,7 @@ class AudioPlayer: NSObject {
     
     private func initAudioSession() {
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio, options: [.allowAirPlay])
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio)
             try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             NSLog("Failed to set AVAudioSession category")


### PR DESCRIPTION
I occasionally see the following error when run on my device, which does not appear on the simulator:

```
Failed to set AVAudioSession category
Error Domain=NSOSStatusErrorDomain Code=2003329396
```

It turns out the call to `AVAudioSession.sharedInstance().setCategory` does not need the `.allowAirPlay` option. That option [is only valid when the category is `.playAndRecord`](https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions/1771736-allowairplay).

I verified with this option removed AirPlay still functions, and the error is also gone.