### PR TITLE
feat: Handle iOS background downloads

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -6,6 +6,7 @@ import RealmSwift
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
+    var backgroundCompletionHandler: (() -> Void)?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -71,6 +72,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Feel free to add additional processing here, but if you want the App API to support
         // tracking app url opens, make sure to keep this call
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    }
+    
+    func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
+        // Stores the completion handler for background downloads
+        // The identifier of this method can be ignored at this time as we only have one background url session
+        backgroundCompletionHandler = completionHandler
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {


### PR DESCRIPTION
Implements iOS background downloads. Turns out I had this 99% of the way there, and it only needed a little extra push [of reading the documentation](https://developer.apple.com/documentation/foundation/url_loading_system/downloading_files_in_the_background).

This fixes #341. This also improves #344, as iOS will be smart and automatically pause and retry background downloads when network conditions are poor.