### PR TITLE
Fixes iOS player seek issues with multi-track books

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -194,18 +194,18 @@ class AudioPlayer: NSObject {
     }
     
     private func setupQueueItemStatusObserver() {
+        NSLog("queueStatusObserver: Setting up")
+
+        // Listen for player item updates
         self.queueItemStatusObserver?.invalidate()
-        let status = self.audioPlayer.currentItem?.status.rawValue ?? -1
-        
-        NSLog("queueStatusObserver: Setting up status=\(status)")
-        // First item already loaded, we need to fire manually
-        if status == 1, let playerItem = self.audioPlayer.currentItem {
-            self.handleQueueItemStatus(playerItem: playerItem)
-        }
-        // Now listen for future updates
         self.queueItemStatusObserver = self.audioPlayer.currentItem?.observe(\.status, options: [.new, .old], changeHandler: { playerItem, change in
             self.handleQueueItemStatus(playerItem: playerItem)
         })
+        
+        // Ensure we didn't miss a player item update during initialization
+        if let playerItem = self.audioPlayer.currentItem {
+            self.handleQueueItemStatus(playerItem: playerItem)
+        }
     }
     
     private func handleQueueItemStatus(playerItem: AVPlayerItem) {

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -219,7 +219,7 @@ class AudioPlayer: NSObject {
             
             // Seek the player before initializing, so a currentTime of 0 does not appear in MediaProgress / session
             let firstReady = self.status < 0
-            if firstReady || !self.playWhenReady {
+            if firstReady && !self.playWhenReady {
                 // Seek is async, and if we call this when also pressing play, we will get weird jumps in the scrub bar depending on timing
                 // Seeking to the correct position happens during play()
                 self.seek(playbackSession.currentTime, from: "queueItemStatusObserver")


### PR DESCRIPTION
Fixes #350.

Note: I've observed that sometimes playback does stop when seeking. I logged this as #354. This was occurring before this PR as well. I will look at that too, but this is more important to get out the door.