### PR TITLE
Rewrite iOS sleep timer to handle multi-track files

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		E9D5507128AC1EC700C746DD /* DownloadItemPart.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5507028AC1EC700C746DD /* DownloadItemPart.swift */; };
 		E9D5507328AC218300C746DD /* DaoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5507228AC218300C746DD /* DaoExtensions.swift */; };
 		E9D5507528AEF93100C746DD /* PlayerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5507428AEF93100C746DD /* PlayerSettings.swift */; };
+		E9DFCBFB28C28F4A00B36356 /* AudioPlayerSleepTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DFCBFA28C28F4A00B36356 /* AudioPlayerSleepTimer.swift */; };
 		E9E985F828B02D9400957F23 /* PlayerProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E985F728B02D9400957F23 /* PlayerProgress.swift */; };
 /* End PBXBuildFile section */
 
@@ -117,6 +118,7 @@
 		E9D5507028AC1EC700C746DD /* DownloadItemPart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadItemPart.swift; sourceTree = "<group>"; };
 		E9D5507228AC218300C746DD /* DaoExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaoExtensions.swift; sourceTree = "<group>"; };
 		E9D5507428AEF93100C746DD /* PlayerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSettings.swift; sourceTree = "<group>"; };
+		E9DFCBFA28C28F4A00B36356 /* AudioPlayerSleepTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerSleepTimer.swift; sourceTree = "<group>"; };
 		E9E985F728B02D9400957F23 /* PlayerProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerProgress.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -145,6 +147,7 @@
 			isa = PBXGroup;
 			children = (
 				3A200C1427D64D7E00CBF02E /* AudioPlayer.swift */,
+				E9DFCBFA28C28F4A00B36356 /* AudioPlayerSleepTimer.swift */,
 				3ABF618E2804325C0070250E /* PlayerHandler.swift */,
 				E9E985F728B02D9400957F23 /* PlayerProgress.swift */,
 			);
@@ -438,6 +441,7 @@
 				E9D5506028AC1CA900C746DD /* PlaybackMetadata.swift in Sources */,
 				E9D5504828AC1A7A00C746DD /* MediaType.swift in Sources */,
 				E9D5504E28AC1B0700C746DD /* AudioFile.swift in Sources */,
+				E9DFCBFB28C28F4A00B36356 /* AudioPlayerSleepTimer.swift in Sources */,
 				E9D5505428AC1B7900C746DD /* AudioTrack.swift in Sources */,
 				E9D5505C28AC1C6200C746DD /* LibraryFile.swift in Sources */,
 				4DF74912287105C600AC7814 /* DeviceSettings.swift in Sources */,

--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -169,7 +169,7 @@ public class AbsAudioPlayer: CAPPlugin {
     @objc func decreaseSleepTime(_ call: CAPPluginCall) {
         guard let timeString = call.getString("time") else { return call.resolve([ "success": false ]) }
         guard let time = Double(timeString) else { return call.resolve([ "success": false ]) }
-        guard let _ = PlayerHandler.remainingSleepTime else { return call.resolve([ "success": false ]) }
+        guard let _ = PlayerHandler.getSleepTimeRemaining() else { return call.resolve([ "success": false ]) }
         
         let seconds = time/1000
         PlayerHandler.decreaseSleepTime(decreaseSeconds: seconds)
@@ -179,7 +179,7 @@ public class AbsAudioPlayer: CAPPlugin {
     @objc func increaseSleepTime(_ call: CAPPluginCall) {
         guard let timeString = call.getString("time") else { return call.resolve([ "success": false ]) }
         guard let time = Double(timeString) else { return call.resolve([ "success": false ]) }
-        guard let _ = PlayerHandler.remainingSleepTime else { return call.resolve([ "success": false ]) }
+        guard let _ = PlayerHandler.getSleepTimeRemaining() else { return call.resolve([ "success": false ]) }
         
         let seconds = time/1000
         PlayerHandler.increaseSleepTime(increaseSeconds: seconds)
@@ -188,30 +188,29 @@ public class AbsAudioPlayer: CAPPlugin {
     
     @objc func setSleepTimer(_ call: CAPPluginCall) {
         guard let timeString = call.getString("time") else { return call.resolve([ "success": false ]) }
-        guard let time = Int(timeString) else { return call.resolve([ "success": false ]) }
+        guard let time = Double(timeString) else { return call.resolve([ "success": false ]) }
         let isChapterTime = call.getBool("isChapterTime", false)
         
         let seconds = time / 1000
         
         NSLog("chapter time: \(isChapterTime)")
         if isChapterTime {
-            PlayerHandler.setChapterSleepTime(stopAt: Double(seconds))
+            PlayerHandler.setChapterSleepTime(stopAt: seconds)
             return call.resolve([ "success": true ])
+        } else {
+            PlayerHandler.setSleepTime(secondsUntilSleep: seconds)
+            call.resolve([ "success": true ])
         }
-        
-        PlayerHandler.setSleepTime(secondsUntilSleep: Double(seconds))
-        call.resolve([ "success": true ])
     }
     
     @objc func cancelSleepTimer(_ call: CAPPluginCall) {
         PlayerHandler.cancelSleepTime()
-        PlayerHandler.sleepTimerChapterStopTime = nil
         call.resolve()
     }
     
     @objc func getSleepTimerTime(_ call: CAPPluginCall) {
         call.resolve([
-            "value": PlayerHandler.remainingSleepTime
+            "value": PlayerHandler.getSleepTimeRemaining()
         ])
     }
     
@@ -223,7 +222,7 @@ public class AbsAudioPlayer: CAPPlugin {
     
     @objc func sendSleepTimerSet() {
         self.notifyListeners("onSleepTimerSet", data: [
-            "value": PlayerHandler.remainingSleepTime
+            "value": PlayerHandler.getSleepTimeRemaining()
         ])
     }
     

--- a/ios/App/Shared/models/server/AudioTrack.swift
+++ b/ios/App/Shared/models/server/AudioTrack.swift
@@ -19,6 +19,13 @@ class AudioTrack: EmbeddedObject, Codable {
     @Persisted var localFileId: String?
     @Persisted var serverIndex: Int?
     
+    var endOffset: Double? {
+        if let startOffset = startOffset {
+            return startOffset + duration
+        }
+        return nil
+    }
+    
     private enum CodingKeys : String, CodingKey {
         case index, startOffset, duration, title, contentUrl, mimeType, metadata, localFileId, serverIndex
     }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -178,6 +178,11 @@ class AudioPlayer: NSObject {
                 if self.isSleepTimerSet() {
                     // Update the UI
                     NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepSet.rawValue), object: nil)
+                    
+                    // Handle a sitation where the user skips past the chapter end
+                    if self.isChapterSleepTimerBeforeTime(currentTime) {
+                        self.removeSleepTimer()
+                    }
                 }
             }
         }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -45,7 +45,7 @@ class AudioPlayer: NSObject {
     internal var sleepTimer: Timer?
     internal var sleepTimeRemaining: Double?
     
-    private var currentTrackIndex = 0
+    internal var currentTrackIndex = 0
     private var allPlayerItems:[AVPlayerItem] = []
     
     private var pausedTimer: Timer?

--- a/ios/App/Shared/player/AudioPlayerSleepTimer.swift
+++ b/ios/App/Shared/player/AudioPlayerSleepTimer.swift
@@ -42,9 +42,9 @@ extension AudioPlayer {
         self.sleepTimeRemaining = secondsUntilSleep
         
         DispatchQueue.runOnMainQueue {
-            self.sleepTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-                if self.isPlaying() {
-                    self.decrementSleepTimerIfRunning()
+            self.sleepTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                if self?.isPlaying() ?? false {
+                    self?.decrementSleepTimerIfRunning()
                 }
             }
         }

--- a/ios/App/Shared/player/AudioPlayerSleepTimer.swift
+++ b/ios/App/Shared/player/AudioPlayerSleepTimer.swift
@@ -1,0 +1,155 @@
+//
+//  AudioPlayerSleepTimer.swift
+//  App
+//
+//  Created by Ron Heft on 9/2/22.
+//
+
+import Foundation
+import AVFoundation
+
+extension AudioPlayer {
+    
+    // MARK: - Public API
+    
+    public func getSleepTimeRemaining() -> Double? {
+        guard let currentTime = self.getCurrentTime() else { return nil }
+        
+        // Return the player time until sleep
+        var timeUntilSleep: Double? = nil
+        if let chapterStopAt = self.sleepTimeChapterStopAt {
+            timeUntilSleep = chapterStopAt - currentTime
+        } else if let stopAt = self.sleepTimeStopAt {
+            timeUntilSleep = stopAt - currentTime
+        }
+        
+        // Scale the time until sleep based on the playback rate
+        if let timeUntilSleep = timeUntilSleep {
+            let timeUntilSleepScaled = timeUntilSleep / self.getPlaybackRate()
+            guard timeUntilSleepScaled.isNaN == false else { return nil }
+            
+            return timeUntilSleepScaled.rounded()
+        } else {
+            return nil
+        }
+    }
+    
+    // Let iOS handle the sleep timer logic by letting us know when it's time to stop
+    public func setSleepTime(stopAt: Double, scaleBasedOnSpeed: Bool = false) {
+        NSLog("SLEEP TIMER: Scheduling for \(stopAt)")
+        
+        // Reset any previous sleep timer
+        let isChapterSleepTimer = !scaleBasedOnSpeed
+        self.removeSleepTimer(resetStopAt: !isChapterSleepTimer)
+        
+        guard let currentTime = getCurrentTime() else {
+            NSLog("SLEEP TIMER: Failed to get currenTime")
+            return
+        }
+        
+        // Mark the time to stop playing
+        let scaledStopAt = self.calculateScaledStopAt(stopAt, currentTime: currentTime, scaleBasedOnSpeed: scaleBasedOnSpeed)
+        self.sleepTimeStopAt = scaledStopAt
+        let sleepTime = CMTime(seconds: scaledStopAt, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        
+        // Schedule the observation time
+        var times = [NSValue]()
+        times.append(NSValue(time: sleepTime))
+        
+        self.sleepTimeToken = self.audioPlayer.addBoundaryTimeObserver(forTimes: times, queue: self.queue) { [weak self] in
+            NSLog("SLEEP TIMER: Pausing audio")
+            self?.pause()
+            self?.removeSleepTimer()
+        }
+        
+        // Update the UI
+        NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepSet.rawValue), object: nil)
+    }
+    
+    public func increaseSleepTime(extraTimeInSeconds: Double) {
+        if let sleepTime = self.getSleepTimeRemaining(), let currentTime = getCurrentTime() {
+            let newSleepTimerPosition = currentTime + sleepTime + extraTimeInSeconds
+            if newSleepTimerPosition > currentTime {
+                self.setSleepTime(stopAt: newSleepTimerPosition, scaleBasedOnSpeed: true)
+            }
+        }
+    }
+    
+    public func decreaseSleepTime(removeTimeInSeconds: Double) {
+        if let sleepTime = self.getSleepTimeRemaining(), let currentTime = getCurrentTime() {
+            let newSleepTimerPosition = currentTime + sleepTime - removeTimeInSeconds
+            if newSleepTimerPosition > currentTime {
+                self.setSleepTime(stopAt: newSleepTimerPosition, scaleBasedOnSpeed: true)
+            }
+        }
+
+    }
+    
+    public func removeSleepTimer(resetStopAt: Bool = true) {
+        if resetStopAt {
+            self.sleepTimeStopAt = nil
+            self.sleepTimeChapterStopAt = nil
+        }
+        
+        if let token = self.sleepTimeToken {
+            self.audioPlayer.removeTimeObserver(token)
+            self.sleepTimeToken = nil
+        }
+        
+        // Update the UI
+        NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepEnded.rawValue), object: self)
+    }
+    
+    
+    // MARK: - Internal helpers
+    
+    internal func rescheduleSleepTimerAtTime(time: Double, secondsRemaining: Double?) {
+        guard self.isSleepTimerSet() else { return }
+        
+        // Cancel a chapter sleep timer that is no longer valid
+        if isChapterSleepTimerBeforeTime(time) {
+            return self.removeSleepTimer()
+        }
+        
+        // Update the sleep timer
+        if !isChapterSleepTimer() {
+            guard let secondsRemaining = secondsRemaining else { return }
+            let newSleepTimerPosition = time + secondsRemaining
+            self.setSleepTime(stopAt: newSleepTimerPosition, scaleBasedOnSpeed: true)
+        }
+    }
+    
+    private func isChapterSleepTimerBeforeTime(_ time: Double) -> Bool {
+        if let chapterStopAt = self.sleepTimeChapterStopAt {
+            return chapterStopAt <= time
+        }
+        
+        return false
+    }
+    
+    private func isSleepTimerSet() -> Bool {
+        return self.sleepTimeStopAt != nil
+    }
+    
+    private func isChapterSleepTimer() -> Bool {
+        return self.sleepTimeChapterStopAt != nil
+    }
+    
+    private func getPlaybackRate() -> Double {
+        // Consider paused as playing at 1x
+        return Double(self.rate > 0 ? self.rate : 1)
+    }
+    
+    private func calculateScaledStopAt(_ stopAt: Double, currentTime: Double, scaleBasedOnSpeed: Bool) -> Double {
+        if scaleBasedOnSpeed {
+            // Calculate the scaled time to stop at
+            let secondsUntilStopAt1x = stopAt - currentTime
+            let secondsUntilSleep = secondsUntilStopAt1x * self.getPlaybackRate()
+            NSLog("SLEEP TIMER: Adjusted based on playback speed of \(self.getPlaybackRate()) to \(secondsUntilSleep)")
+            return currentTime + secondsUntilSleep
+        } else {
+            return stopAt
+        }
+    }
+    
+}

--- a/ios/App/Shared/player/AudioPlayerSleepTimer.swift
+++ b/ios/App/Shared/player/AudioPlayerSleepTimer.swift
@@ -27,12 +27,6 @@ extension AudioPlayer {
             sleepTimeRemaining = self.sleepTimeRemaining
         }
         
-        // Guard against invalid sleep timers, but give it a chance to go 1 second negative to prevent a raise condition
-        if sleepTimeRemaining?.isLess(than: -1) ?? false {
-            self.removeSleepTimer()
-            return nil
-        }
-        
         return sleepTimeRemaining
     }
     
@@ -110,14 +104,8 @@ extension AudioPlayer {
         self.removeChapterSleepTimer()
         self.sleepTimeRemaining = nil
         
-        // Update the UI after a delay, to avoid a race condition when changing chapters
-        DispatchQueue.runOnMainQueue {
-            Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { _ in
-                if !self.isSleepTimerSet() {
-                    NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepEnded.rawValue), object: self)
-                }
-            }
-        }
+        // Update the UI
+        NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepEnded.rawValue), object: self)
     }
     
     
@@ -149,7 +137,7 @@ extension AudioPlayer {
         self.sleepTimeChapterStopAt = nil
     }
     
-    private func isChapterSleepTimerBeforeTime(_ time: Double) -> Bool {
+    internal func isChapterSleepTimerBeforeTime(_ time: Double) -> Bool {
         if let chapterStopAt = self.sleepTimeChapterStopAt {
             return chapterStopAt <= time
         }
@@ -157,11 +145,11 @@ extension AudioPlayer {
         return false
     }
     
-    private func isCountdownSleepTimerSet() -> Bool {
+    internal func isCountdownSleepTimerSet() -> Bool {
         return self.sleepTimeRemaining != nil
     }
     
-    private func isChapterSleepTimerSet() -> Bool {
+    internal func isChapterSleepTimerSet() -> Bool {
         return self.sleepTimeChapterStopAt != nil
     }
     

--- a/ios/App/Shared/player/AudioPlayerSleepTimer.swift
+++ b/ios/App/Shared/player/AudioPlayerSleepTimer.swift
@@ -27,8 +27,8 @@ extension AudioPlayer {
             sleepTimeRemaining = self.sleepTimeRemaining
         }
         
-        // Guard against invalid sleep timers
-        if sleepTimeRemaining?.isLess(than: 0) ?? false {
+        // Guard against invalid sleep timers, but give it a chance to go 1 second negative to prevent a raise condition
+        if sleepTimeRemaining?.isLess(than: -1) ?? false {
             self.removeSleepTimer()
             return nil
         }

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -104,6 +104,7 @@ class PlayerHandler {
     
     public static func seekForward(amount: Double) {
         guard let player = player else { return }
+        guard player.isInitialized() else { return }
         guard let currentTime = player.getCurrentTime() else { return }
         
         let destinationTime = currentTime + amount
@@ -112,6 +113,7 @@ class PlayerHandler {
     
     public static func seekBackward(amount: Double) {
         guard let player = player else { return }
+        guard player.isInitialized() else { return }
         guard let currentTime = player.getCurrentTime() else { return }
         
         let destinationTime = currentTime - amount
@@ -119,7 +121,10 @@ class PlayerHandler {
     }
     
     public static func seek(amount: Double) {
-        player?.seek(amount, from: "handler")
+        guard let player = player else { return }
+        guard player.isInitialized() else { return }
+        
+        player.seek(amount, from: "handler")
     }
     
     public static func getMetdata() -> [String: Any]? {

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -70,13 +70,11 @@ class PlayerHandler {
     }
     
     public static func setSleepTime(secondsUntilSleep: Double) {
-        guard let currentTime = self.player?.getCurrentTime() else { return }
-        let stopAt = secondsUntilSleep + currentTime
-        self.player?.setSleepTime(stopAt: stopAt, scaleBasedOnSpeed: true)
+        self.player?.setSleepTimer(secondsUntilSleep: secondsUntilSleep)
     }
     
     public static func setChapterSleepTime(stopAt: Double) {
-        self.player?.setSleepTime(stopAt: stopAt, scaleBasedOnSpeed: false)
+        self.player?.setChapterSleepTimer(stopAt: stopAt)
     }
     
     public static func increaseSleepTime(increaseSeconds: Double) {

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -11,8 +11,6 @@ import RealmSwift
 class PlayerHandler {
     private static var player: AudioPlayer?
     
-    public static var sleepTimerChapterStopTime: Int? = nil
-    
     public static func startPlayback(sessionId: String, playWhenReady: Bool, playbackRate: Float) {
         guard let session = Database.shared.getPlaybackSession(id: sessionId) else { return }
         
@@ -59,34 +57,6 @@ class PlayerHandler {
         }
     }
     
-    public static var remainingSleepTime: Int? {
-        get {
-            guard let player = player else { return nil }
-            guard let currentTime = player.getCurrentTime() else { return nil }
-            
-            // Return the player time until sleep
-            var timeUntilSleep: Double? = nil
-            if let sleepTimerChapterStopTime = sleepTimerChapterStopTime {
-                timeUntilSleep = Double(sleepTimerChapterStopTime) - currentTime
-            } else if let stopAt = player.getSleepStopAt() {
-                timeUntilSleep = stopAt - currentTime
-            }
-            
-            // Scale the time until sleep based on the playback rate
-            if let timeUntilSleep = timeUntilSleep {
-                // Consider paused as playing at 1x
-                let rate = Double(player.rate > 0 ? player.rate : 1)
-                
-                let timeUntilSleepScaled = timeUntilSleep / rate
-                guard timeUntilSleepScaled.isNaN == false else { return nil }
-                
-                return Int(timeUntilSleepScaled.rounded())
-            } else {
-                return nil
-            }
-        }
-    }
-    
     public static func getCurrentTime() -> Double? {
         self.player?.getCurrentTime()
     }
@@ -95,31 +65,29 @@ class PlayerHandler {
         self.player?.setPlaybackRate(speed)
     }
     
+    public static func getSleepTimeRemaining() -> Double? {
+        return self.player?.getSleepTimeRemaining()
+    }
+    
     public static func setSleepTime(secondsUntilSleep: Double) {
-        guard let player = player else { return }
-        guard let currentTime = player.getCurrentTime() else { return }
+        guard let currentTime = self.player?.getCurrentTime() else { return }
         let stopAt = secondsUntilSleep + currentTime
-        player.setSleepTime(stopAt: stopAt, scaleBasedOnSpeed: true)
+        self.player?.setSleepTime(stopAt: stopAt, scaleBasedOnSpeed: true)
     }
     
     public static func setChapterSleepTime(stopAt: Double) {
-        guard let player = player else { return }
-        self.sleepTimerChapterStopTime = Int(stopAt)
-        player.setSleepTime(stopAt: stopAt, scaleBasedOnSpeed: false)
+        self.player?.setSleepTime(stopAt: stopAt, scaleBasedOnSpeed: false)
     }
     
     public static func increaseSleepTime(increaseSeconds: Double) {
-        self.sleepTimerChapterStopTime = nil
         self.player?.increaseSleepTime(extraTimeInSeconds: increaseSeconds)
     }
     
     public static func decreaseSleepTime(decreaseSeconds: Double) {
-        self.sleepTimerChapterStopTime = nil
         self.player?.decreaseSleepTime(removeTimeInSeconds: decreaseSeconds)
     }
     
     public static func cancelSleepTime() {
-        PlayerHandler.sleepTimerChapterStopTime = nil
         self.player?.removeSleepTimer()
     }
     


### PR DESCRIPTION
This took me quite a while to figure out, but I rewrote the iOS sleep timer again to address issues with multi-track books. Fixes #351.

The iOS sleep timer now:
* Uses a `Timer` for countdown-based sleep timers
* Uses a `TimeObserver` for a scheduled chapter end time

This seems to strike the balance of accuracy, reliability, and code readability. I have tested this PR with:
* Single-track books
* Multi-track books
* Podcasts

For each media type, I have verified:
* How the timer reacts to play/pause
* How the timer reacts to changes in playback speed
* How the timer reacts to seeking
* How the timer handles seeking past the end time (in case of a chapter end timer)

Why rewrite the sleep timer again? While the previous strategy worked, it involved recalculating the stop time each time seeking and playback rate changes occurred. Not to mention the edge cases with a chapter sleep time.

In theory, the previous strategy should work, but the way the player reinitialized when tracks are changed out during seeks with multi-file books caused the stop time to be recalculated wrong depending on the order of operations. I tried a number of different strategies to debug it, and race conditions would continue to come up, due to the fact that pause/stopping audio causes the playback rate to change on iOS. This would force the stop time to be recalculated, which would be occurring while the seek was happening. There is probably a way to solve for it, but I opted to simplify the logic.