### PR TITLE
Fix: Handle iOS audio events

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -284,7 +284,8 @@ class AudioPlayer: NSObject {
                 await PlayerProgress.shared.syncFromPlayer(currentTime: currentTime, includesPlayProgress: self.isPlaying(), isStopping: false)
             }
         }
-
+        
+        self.markAudioSessionAs(active: true)
         self.audioPlayer.play()
         self.status = 1
         self.rate = self.tmpRate
@@ -302,6 +303,7 @@ class AudioPlayer: NSObject {
         guard self.isInitialized() else { return }
         
         self.audioPlayer.pause()
+        self.markAudioSessionAs(active: false)
         
         Task {
             if let currentTime = self.getCurrentTime() {
@@ -572,10 +574,17 @@ class AudioPlayer: NSObject {
     private func initAudioSession() {
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio)
-            try AVAudioSession.sharedInstance().setActive(true)
         } catch {
             NSLog("Failed to set AVAudioSession category")
             print(error)
+        }
+    }
+    
+    private func markAudioSessionAs(active: Bool) {
+        do {
+            try AVAudioSession.sharedInstance().setActive(active)
+        } catch {
+            NSLog("Failed to set audio session as active=\(active)")
         }
     }
     


### PR DESCRIPTION
This PR addresses several issues (fixes #343):
* The active audio session is now changed to `false` when the player is paused
  * This also ensures the below fixes do not trigger when the player is paused
* When an audio interruption occurs (such as Siri, directions in CarPlay, a phone call, etc), if ABS was playing before the interruption occurred, ABS will resume playback after the interruption
  * The player will use the `skipBack` setting when resuming, so for long interruptions, audio will be allowed to rewind back
* If plugging in headphones, audio will continue in the headphones
* If disconnecting headphones, audio will stop playing
  * There may be other scenarios we want to pause audio, but I'm not sure of them at this moment
  * We now have the framework to add others in the future

Note: This PR also includes #359 as there was a merge conflict that needed to be fixed between them. If you would like to review the code for this without #359, I can trigger an update to this PR after #359 is merged