### PR TITLE
Cleanup Android Auto buttons

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -39,7 +39,7 @@ data class DeviceSettings(
   @get:JsonIgnore
   val jumpBackwardsTimeMs get() = (jumpBackwardsTime ?: default().jumpBackwardsTime) * 1000L
   @get:JsonIgnore
-  val jumpForwardTimeMs get() = (jumpForwardTime ?: default().jumpBackwardsTime) * 1000L
+  val jumpForwardTimeMs get() = (jumpForwardTime ?: default().jumpForwardTime) * 1000L
 }
 
 data class DeviceData(

--- a/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
@@ -239,6 +239,8 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
     when (action) {
       CUSTOM_ACTION_JUMP_FORWARD -> onFastForward()
       CUSTOM_ACTION_JUMP_BACKWARD -> onRewind()
+      CUSTOM_ACTION_SKIP_FORWARD -> onSkipToNext()
+      CUSTOM_ACTION_SKIP_BACKWARD -> onSkipToPrevious()
     }
   }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerConstants.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerConstants.kt
@@ -2,3 +2,5 @@ package com.audiobookshelf.app.player
 
 const val CUSTOM_ACTION_JUMP_FORWARD = "com.audiobookshelf.customAction.jump_forward";
 const val CUSTOM_ACTION_JUMP_BACKWARD = "com.audiobookshelf.customAction.jump_backward";
+const val CUSTOM_ACTION_SKIP_FORWARD = "com.audiobookshelf.customAction.skip_forward";
+const val CUSTOM_ACTION_SKIP_BACKWARD = "com.audiobookshelf.customAction.skip_backward";

--- a/android/app/src/main/res/drawable-anydpi/skip_next_24.xml
+++ b/android/app/src/main/res/drawable-anydpi/skip_next_24.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24"
+  android:tint="#FFFFFF">
+  <group android:scaleX="1.127451"
+    android:scaleY="1.127451"
+    android:translateX="-1.5294118"
+    android:translateY="-1.5294118">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
+  </group>
+</vector>

--- a/android/app/src/main/res/drawable-anydpi/skip_previous_24.xml
+++ b/android/app/src/main/res/drawable-anydpi/skip_previous_24.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24"
+  android:tint="#FFFFFF">
+  <group android:scaleX="1.127451"
+    android:scaleY="1.127451"
+    android:translateX="-1.5294118"
+    android:translateY="-1.5294118">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z"/>
+  </group>
+</vector>

--- a/android/app/src/main/res/drawable/skip_next_24.xml
+++ b/android/app/src/main/res/drawable/skip_next_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+  android:tint="#FFFFFF">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
+</vector>

--- a/android/app/src/main/res/drawable/skip_previous_24.xml
+++ b/android/app/src/main/res/drawable/skip_previous_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z"/>
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="app_widget_description">Simple widget for audiobookshelf playback</string>
     <string name="action_jump_forward">Jump Forward</string>
     <string name="action_jump_backward">Jump Backward</string>
+    <string name="action_skip_forward">Skip Forward</string>
+    <string name="action_skip_backward">Skip Backward</string>
 </resources>


### PR DESCRIPTION
Control buttons in Android Auto (and probably Android Wear too) are messy. The skip back/forward buttons appears sometimes and the jump forward/back a few seconds don't show at all in minimized modes.

This PR does the following:
- Show skip buttons if multiple items are available. ![minimized](https://user-images.githubusercontent.com/1752370/188323780-a559d803-6bb7-4123-9464-74cf670ac660.png)
- Hide skip buttons when multiple queue items are not available. ![skip_hidden](https://user-images.githubusercontent.com/1752370/188323779-30ebcf3c-1c30-4677-9ee5-71ed5ee3f3c2.png)
- Show jump buttons when the app is "minimized" instead of skip buttons. ![skip_shown](https://user-images.githubusercontent.com/1752370/188323776-8b143ff7-b0ca-4c41-8ee2-895b00d05750.png)

