### PR TITLE
fix: iOS 16 realm crash

### DIFF
--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -36,7 +36,7 @@ public class AbsAudioPlayer: CAPPlugin {
     func restorePlaybackSession() async {
         do {
             // Fetch the most recent active session
-            let activeSession = try await Realm().objects(PlaybackSession.self).where({
+            let activeSession = try Realm(queue: nil).objects(PlaybackSession.self).where({
                 $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
             }).last?.freeze()
             

--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -106,7 +106,7 @@ class PlayerProgress {
     
     private func updateAllServerSessionFromLocalSession() async throws {
         try await withThrowingTaskGroup(of: Void.self) { [self] group in
-            for session in try await Realm().objects(PlaybackSession.self).where({ $0.serverConnectionConfigId == Store.serverConfig?.id }) {
+            for session in try Realm(queue: nil).objects(PlaybackSession.self).where({ $0.serverConnectionConfigId == Store.serverConfig?.id }) {
                 let session = session.freeze()
                 group.addTask {
                     try await self.updateServerSessionFromLocalSession(session)
@@ -164,7 +164,7 @@ class PlayerProgress {
     
     private func updateLocalSessionFromServerMediaProgress() async throws {
         logger.log("updateLocalSessionFromServerMediaProgress: Checking if local media progress was updated on server")
-        guard let session = try await Realm().objects(PlaybackSession.self).last(where: {
+        guard let session = try Realm(queue: nil).objects(PlaybackSession.self).last(where: {
             $0.isActiveSession == true && $0.serverConnectionConfigId == Store.serverConfig?.id
         })?.freeze() else {
             logger.log("updateLocalSessionFromServerMediaProgress: Failed to get session")


### PR DESCRIPTION
Using the `async` version of Realm on iOS 16 is resulting in incorrect thread crashes. This fix changes the async Realm calls to use the synchronized version by using a different constructor.

`Realm()` == `Realm(queue: DispatchQueue = nil)`

But when calling Realm in an async method, the code is picking up the `Realm() async` constructor, which we don't want.

By calling `Realm(queue: nil)` we force the non-async path.