### PR TITLE
Fix local cover images not used on iOS

### DIFF
--- a/ios/App/Shared/models/local/LocalLibraryItem.swift
+++ b/ios/App/Shared/models/local/LocalLibraryItem.swift
@@ -39,12 +39,16 @@ class LocalLibraryItem: Object, Codable {
         }
     }
     
-    var coverContentUrl: String? {
+    var coverUrl: URL? {
         if let path = self._coverContentUrl {
-            return AbsDownloader.itemDownloadFolder(path: path)!.absoluteString
+            return AbsDownloader.itemDownloadFolder(path: path)
         } else {
             return nil
         }
+    }
+    
+    var coverContentUrl: String? {
+        return self.coverUrl?.absoluteString
     }
     
     var isBook: Bool { self.mediaType == "book" }

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -22,7 +22,7 @@ class PlayerHandler {
         Task { await PlayerProgress.shared.syncToServer() }
         
         // Set now playing info
-        NowPlayingInfo.shared.setSessionMetadata(metadata: NowPlayingMetadata(id: session.id, itemId: session.libraryItemId!, artworkUrl: session.coverPath, title: session.displayTitle ?? "Unknown title", author: session.displayAuthor, series: nil))
+        NowPlayingInfo.shared.setSessionMetadata(metadata: NowPlayingMetadata(id: session.id, itemId: session.libraryItemId!, title: session.displayTitle ?? "Unknown title", author: session.displayAuthor, series: nil))
         
         // Create the audio player
         player = AudioPlayer(sessionId: sessionId, playWhenReady: playWhenReady, playbackRate: playbackRate)

--- a/ios/App/Shared/util/NowPlayingInfo.swift
+++ b/ios/App/Shared/util/NowPlayingInfo.swift
@@ -20,6 +20,8 @@ struct NowPlayingMetadata {
         guard let url = URL(string: "\(config.address)/api/items/\(itemId)/cover?token=\(config.token)") else { return nil }
         return url
     }
+    
+    var isLocal: Bool { id.starts(with: "play_local_") }
 }
 
 class NowPlayingInfo {
@@ -35,8 +37,7 @@ class NowPlayingInfo {
     public func setSessionMetadata(metadata: NowPlayingMetadata) {
         setMetadata(artwork: nil, metadata: metadata)
         
-        let isLocalItem = metadata.itemId.starts(with: "local_")
-        if isLocalItem {
+        if metadata.isLocal {
             guard let artworkUrl = metadata.artworkUrl else { return }
             let coverImage = UIImage(contentsOfFile: artworkUrl)
             guard let coverImage = coverImage else { return }

--- a/ios/App/Shared/util/NowPlayingInfo.swift
+++ b/ios/App/Shared/util/NowPlayingInfo.swift
@@ -11,14 +11,19 @@ import MediaPlayer
 struct NowPlayingMetadata {
     var id: String
     var itemId: String
-    var artworkUrl: String?
     var title: String
     var author: String?
     var series: String?
+    
     var coverUrl: URL? {
-        guard let config = Store.serverConfig else { return nil }
-        guard let url = URL(string: "\(config.address)/api/items/\(itemId)/cover?token=\(config.token)") else { return nil }
-        return url
+        if self.isLocal {
+            guard let item = Database.shared.getLocalLibraryItem(byServerLibraryItemId: self.itemId) else { return nil }
+            return item.coverUrl
+        } else {
+            guard let config = Store.serverConfig else { return nil }
+            guard let url = URL(string: "\(config.address)/api/items/\(itemId)/cover?token=\(config.token)") else { return nil }
+            return url
+        }
     }
     
     var isLocal: Bool { id.starts(with: "play_local_") }
@@ -36,27 +41,17 @@ class NowPlayingInfo {
     
     public func setSessionMetadata(metadata: NowPlayingMetadata) {
         setMetadata(artwork: nil, metadata: metadata)
-        
-        if metadata.isLocal {
-            guard let artworkUrl = metadata.artworkUrl else { return }
-            let coverImage = UIImage(contentsOfFile: artworkUrl)
-            guard let coverImage = coverImage else { return }
-            let artwork = MPMediaItemArtwork(boundsSize: coverImage.size) { _ -> UIImage in
-                return coverImage
+        guard let url = metadata.coverUrl else { return }
+        // For local images, "downloading" is occurring off disk, hence this code path works as expected
+        ApiClient.getData(from: url) { [self] image in
+            guard let downloadedImage = image else {
+                return
             }
+            let artwork = MPMediaItemArtwork.init(boundsSize: downloadedImage.size, requestHandler: { _ -> UIImage in
+                return downloadedImage
+            })
+            
             self.setMetadata(artwork: artwork, metadata: metadata)
-        } else {
-            guard let url = metadata.coverUrl else { return }
-            ApiClient.getData(from: url) { [self] image in
-                guard let downloadedImage = image else {
-                    return
-                }
-                let artwork = MPMediaItemArtwork.init(boundsSize: downloadedImage.size, requestHandler: { _ -> UIImage in
-                    return downloadedImage
-                })
-                
-                self.setMetadata(artwork: artwork, metadata: metadata)
-            }
         }
     }
     public func update(duration: Double, currentTime: Double, rate: Float) {


### PR DESCRIPTION
Fixes #373. Local cover images were never being loaded and always fetched from the server, hence if the network was unavailable when playback started, the artwork would not be available.