### PR TITLE
fix: iOS seek back time not winding back

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -181,6 +181,7 @@ class AudioPlayer: NSObject {
             let time = CMTime(seconds: Double(seconds), preferredTimescale: timeScale)
             self.timeObserverToken = self.audioPlayer.addPeriodicTimeObserver(forInterval: time, queue: self.queue) { [weak self] time in
                 guard let self = self else { return }
+                guard self.isInitialized() else { return }
                 
                 guard let currentTime = self.getCurrentTime() else { return }
                 let isPlaying = self.isPlaying()
@@ -312,7 +313,7 @@ class AudioPlayer: NSObject {
     }
     
     private func calculateSeekBackTimeAtCurrentTime(_ currentTime: Double, lastPlayed: Double) -> Double {
-        let difference = Date.timeIntervalSinceReferenceDate - lastPlayed
+        let difference = Date().timeIntervalSince1970 - lastPlayed
         var time: Double = 0
         
         // Scale seek back time based on how long since last play

--- a/ios/App/Shared/player/PlayerHandler.swift
+++ b/ios/App/Shared/player/PlayerHandler.swift
@@ -45,7 +45,7 @@ class PlayerHandler {
             if paused {
                 self.player?.pause()
             } else {
-                self.player?.play()
+                self.player?.play(allowSeekBack: true)
             }
         }
     }


### PR DESCRIPTION
Fixes #368. Seek back time had three different issues:

1. Player initialization would update the session's `updatedAt` value, so anytime the player was reinitialized, we were starting fresh
2. Date math was wrong, leading always to 2 seconds of seek back time
3. Resuming playback from the UI was not allowing the seek back calculation

All three issues have been addressed in this PR.