### PR TITLE
fix: iOS chapter sleep timer issues

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -194,11 +194,6 @@ class AudioPlayer: NSObject {
                 if self.isSleepTimerSet() {
                     // Update the UI
                     NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.sleepSet.rawValue), object: nil)
-                    
-                    // Handle a sitation where the user skips past the chapter end
-                    if self.isChapterSleepTimerBeforeTime(currentTime) {
-                        self.removeSleepTimer()
-                    }
                 }
             }
         }
@@ -352,6 +347,9 @@ class AudioPlayer: NSObject {
         
         // Update the progress
         self.updateNowPlaying()
+        
+        // Handle a chapter sleep timer that may now be invalid
+        self.handleTrackChangeForChapterSleepTimer()
     }
     
     public func pause() {

--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -244,6 +244,7 @@ class Database {
     public func getPlaybackSession(id: String) -> PlaybackSession? {
         do {
             let realm = try Realm()
+            realm.refresh() // Refresh, because working with stale sessions leads to wrong times
             return realm.object(ofType: PlaybackSession.self, forPrimaryKey: id)
         } catch {
             debugPrint(error)


### PR DESCRIPTION
Fixes #367. Several chapter sleep timer issues were found, all which were address in this PR:

* In chapters with multiple tracks, the sleep timer would never stop at the end of the chapter
  * The sleep timer would not be scheduled to stop on the current track, and nothing was calling the sleep timer logic to schedule timer once we reached the correct track to schedule the stop on
* When skipping past the current chapter, the sleep timer would not always clear
  * Now tests if the chapter sleep timer is valid every time playback resumes, which always happens after a seek
* Sometimes the currentTime from the session would be inaccurate during a track change
  * Solved with `realm.refresh()`