### PR TITLE
fix: onReady called multiple times

### DIFF
--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -155,8 +155,10 @@ export default {
       }
 
       // Settings have been loaded (at least once, so it's safe to kickoff onReady)
-      this.settingsLoaded = true
-      this.notifyOnReady()
+      if (!this.settingsLoaded) {
+        this.settingsLoaded = true
+        this.notifyOnReady()
+      }
     },
     setListeners() {
       // if (!this.$server.socket) {


### PR DESCRIPTION
Fixes a regression introduced in #386. By allowing `onReady()` to be called multiple times in the native code, it unearthed a situation where it was being called multiple times from the UI... when the playback rate changes.

This fix ensures that `onReady()` is only fired the first time settings are loaded, not every time.