### PR TITLE
feat: Groundwork for testable iOS swift code

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -59,9 +59,21 @@
 		E9D5507328AC218300C746DD /* DaoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5507228AC218300C746DD /* DaoExtensions.swift */; };
 		E9D5507528AEF93100C746DD /* PlayerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D5507428AEF93100C746DD /* PlayerSettings.swift */; };
 		E9DFCBFB28C28F4A00B36356 /* AudioPlayerSleepTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9DFCBFA28C28F4A00B36356 /* AudioPlayerSleepTimer.swift */; };
+		E9E8814A28DA644F00D750C1 /* PlayerTimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E8814928DA644F00D750C1 /* PlayerTimeUtils.swift */; };
+		E9E8814D28DA6B9000D750C1 /* PlayerTimeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E8814C28DA6B9000D750C1 /* PlayerTimeUtilsTests.swift */; };
 		E9E985F828B02D9400957F23 /* PlayerProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E985F728B02D9400957F23 /* PlayerProgress.swift */; };
 		E9FA07E328C82848005520B0 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FA07E228C82848005520B0 /* Logger.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E9E8813E28DA5DE500D750C1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 504EC2FC1FED79650016851F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 504EC3031FED79650016851F;
+			remoteInfo = Audiobookshelf;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
@@ -122,6 +134,9 @@
 		E9D5507228AC218300C746DD /* DaoExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaoExtensions.swift; sourceTree = "<group>"; };
 		E9D5507428AEF93100C746DD /* PlayerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerSettings.swift; sourceTree = "<group>"; };
 		E9DFCBFA28C28F4A00B36356 /* AudioPlayerSleepTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerSleepTimer.swift; sourceTree = "<group>"; };
+		E9E8813A28DA5DE500D750C1 /* AudiobookshelfUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AudiobookshelfUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9E8814928DA644F00D750C1 /* PlayerTimeUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTimeUtils.swift; sourceTree = "<group>"; };
+		E9E8814C28DA6B9000D750C1 /* PlayerTimeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTimeUtilsTests.swift; sourceTree = "<group>"; };
 		E9E985F728B02D9400957F23 /* PlayerProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerProgress.swift; sourceTree = "<group>"; };
 		E9FA07E228C82848005520B0 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
@@ -133,6 +148,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AC98F95F300E46A27FAE47A4 /* Pods_Audiobookshelf.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E9E8813728DA5DE500D750C1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,6 +172,7 @@
 		3ABF6190280432610070250E /* player */ = {
 			isa = PBXGroup;
 			children = (
+				E9E8814828DA641B00D750C1 /* util */,
 				3A200C1427D64D7E00CBF02E /* AudioPlayer.swift */,
 				E9DFCBFA28C28F4A00B36356 /* AudioPlayerSleepTimer.swift */,
 				3ABF618E2804325C0070250E /* PlayerHandler.swift */,
@@ -220,6 +243,7 @@
 			children = (
 				3AC8248B27F2316900529205 /* Shared */,
 				504EC3061FED79650016851F /* App */,
+				E9E8813B28DA5DE500D750C1 /* AudiobookshelfUnitTests */,
 				504EC3051FED79650016851F /* Products */,
 				7F8756D8B27F46E3366F6CEA /* Pods */,
 				27E2DDA53C4D2A4D1A88CE4A /* Frameworks */,
@@ -230,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				504EC3041FED79650016851F /* Audiobookshelf.app */,
+				E9E8813A28DA5DE500D750C1 /* AudiobookshelfUnitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -302,6 +327,46 @@
 			path = download;
 			sourceTree = "<group>";
 		};
+		E9E8813B28DA5DE500D750C1 /* AudiobookshelfUnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				E9E8814328DA5E5900D750C1 /* Shared */,
+			);
+			path = AudiobookshelfUnitTests;
+			sourceTree = "<group>";
+		};
+		E9E8814328DA5E5900D750C1 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				E9E8814428DA5E6000D750C1 /* player */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		E9E8814428DA5E6000D750C1 /* player */ = {
+			isa = PBXGroup;
+			children = (
+				E9E8814B28DA6B6B00D750C1 /* util */,
+			);
+			path = player;
+			sourceTree = "<group>";
+		};
+		E9E8814828DA641B00D750C1 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				E9E8814928DA644F00D750C1 /* PlayerTimeUtils.swift */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
+		E9E8814B28DA6B6B00D750C1 /* util */ = {
+			isa = PBXGroup;
+			children = (
+				E9E8814C28DA6B9000D750C1 /* PlayerTimeUtilsTests.swift */,
+			);
+			path = util;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -324,19 +389,42 @@
 			productReference = 504EC3041FED79650016851F /* Audiobookshelf.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E9E8813928DA5DE500D750C1 /* AudiobookshelfUnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E9E8814228DA5DE500D750C1 /* Build configuration list for PBXNativeTarget "AudiobookshelfUnitTests" */;
+			buildPhases = (
+				E9E8813628DA5DE500D750C1 /* Sources */,
+				E9E8813728DA5DE500D750C1 /* Frameworks */,
+				E9E8813828DA5DE500D750C1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E9E8813F28DA5DE500D750C1 /* PBXTargetDependency */,
+			);
+			name = AudiobookshelfUnitTests;
+			productName = AudiobookshelfUnitTests;
+			productReference = E9E8813A28DA5DE500D750C1 /* AudiobookshelfUnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		504EC2FC1FED79650016851F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 920;
+				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1330;
 				TargetAttributes = {
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1240;
 						ProvisioningStyle = Automatic;
+					};
+					E9E8813928DA5DE500D750C1 = {
+						CreatedOnToolsVersion = 14.0;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 504EC3031FED79650016851F;
 					};
 				};
 			};
@@ -354,6 +442,7 @@
 			projectRoot = "";
 			targets = (
 				504EC3031FED79650016851F /* Audiobookshelf */,
+				E9E8813928DA5DE500D750C1 /* AudiobookshelfUnitTests */,
 			);
 		};
 /* End PBXProject section */
@@ -369,6 +458,13 @@
 				50379B232058CBB4000EE86E /* capacitor.config.json in Resources */,
 				504EC30D1FED79650016851F /* Main.storyboard in Resources */,
 				2FAD9763203C412B000D30F8 /* config.xml in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E9E8813828DA5DE500D750C1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -460,12 +556,29 @@
 				3AF1970C2806E2590096F747 /* ApiClient.swift in Sources */,
 				4D66B954282EE87C008272D4 /* AbsDownloader.swift in Sources */,
 				E9D5505628AC1BFA00C746DD /* FileMetadata.swift in Sources */,
+				E9E8814A28DA644F00D750C1 /* PlayerTimeUtils.swift in Sources */,
 				3AB34055280832720039308B /* PlayerEvents.swift in Sources */,
 				E9D5506C28AC1E2100C746DD /* LocalMediaProgress.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E9E8813628DA5DE500D750C1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E9E8814D28DA6B9000D750C1 /* PlayerTimeUtilsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E9E8813F28DA5DE500D750C1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 504EC3031FED79650016851F /* Audiobookshelf */;
+			targetProxy = E9E8813E28DA5DE500D750C1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		504EC30B1FED79650016851F /* Main.storyboard */ = {
@@ -646,6 +759,49 @@
 			};
 			name = Release;
 		};
+		E9E8814028DA5DE500D750C1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.audiobookshelf.AudiobookshelfUnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Audiobookshelf.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Audiobookshelf";
+			};
+			name = Debug;
+		};
+		E9E8814128DA5DE500D750C1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.audiobookshelf.AudiobookshelfUnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Audiobookshelf.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Audiobookshelf";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -663,6 +819,15 @@
 			buildConfigurations = (
 				504EC3171FED79650016851F /* Debug */,
 				504EC3181FED79650016851F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E9E8814228DA5DE500D750C1 /* Build configuration list for PBXNativeTarget "AudiobookshelfUnitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E9E8814028DA5DE500D750C1 /* Debug */,
+				E9E8814128DA5DE500D750C1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -28,6 +28,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E9E8813928DA5DE500D750C1"
+               BuildableName = "AudiobookshelfUnitTests.xctest"
+               BlueprintName = "AudiobookshelfUnitTests"
+               ReferencedContainer = "container:App.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/ios/App/AudiobookshelfUnitTests/Shared/player/util/PlayerTimeUtilsTests.swift
+++ b/ios/App/AudiobookshelfUnitTests/Shared/player/util/PlayerTimeUtilsTests.swift
@@ -1,0 +1,37 @@
+//
+//  PlayerTimeUtilsTests.swift
+//  AudiobookshelfUnitTests
+//
+//  Created by Ron Heft on 9/20/22.
+//
+
+import XCTest
+@testable import Audiobookshelf
+
+final class PlayerTimeUtilsTests: XCTestCase {
+    
+    func testCalcSeekBackTime() {
+        let currentTime: Double = 1000
+        let threeSecondsAgo = Date(timeIntervalSinceNow: -3)
+        let lastPlayedMs = threeSecondsAgo.timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: lastPlayedMs), 998)
+    }
+
+    func testTimeSinceLastPlayed() throws {
+        let fiveSecondsAgo = Date(timeIntervalSinceNow: -5)
+        let lastPlayedMs = fiveSecondsAgo.timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.timeSinceLastPlayed(lastPlayedMs)!, -5, accuracy: 1.0)
+        XCTAssertNil(PlayerTimeUtils.timeSinceLastPlayed(nil))
+    }
+    
+    func testTimeToSeekBackForSinceLastPlayed() throws {
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(nil), 5, "Seeks back 5 seconds for nil")
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(5), 2, "Seeks back 2 seconds for less than 6 seconds")
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(11), 10, "Seeks back 10 seconds for less than 12 seconds")
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(29), 15, "Seeks back 15 seconds for less than 30 seconds")
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(179), 20, "Seeks back 20 seconds for less than 2 minutes")
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(3599), 25, "Seeks back 25 seconds for less than 59 minutes")
+        XCTAssertEqual(PlayerTimeUtils.timeToSeekBackForSinceLastPlayed(60000), 29, "Seeks back 29 seconds for anything over 59 minuts")
+    }
+
+}

--- a/ios/App/AudiobookshelfUnitTests/Shared/player/util/PlayerTimeUtilsTests.swift
+++ b/ios/App/AudiobookshelfUnitTests/Shared/player/util/PlayerTimeUtilsTests.swift
@@ -16,6 +16,13 @@ final class PlayerTimeUtilsTests: XCTestCase {
         let lastPlayedMs = threeSecondsAgo.timeIntervalSince1970 * 1000
         XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: lastPlayedMs), 998)
     }
+    
+    func testCalcSeekBackTimeWithZeroCurrentTime() {
+        let currentTime: Double = 0
+        let threeHundredSecondsAgo = Date(timeIntervalSinceNow: -300)
+        let lastPlayedMs = threeHundredSecondsAgo.timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: lastPlayedMs), 0)
+    }
 
     func testTimeSinceLastPlayed() throws {
         let fiveSecondsAgo = Date(timeIntervalSinceNow: -5)

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -289,8 +289,7 @@ class AudioPlayer: NSObject {
         }
         
         // Determine where we are starting playback
-        let lastPlayed = (session.updatedAt ?? 0)/1000
-        let currentTime = allowSeekBack ? calculateSeekBackTimeAtCurrentTime(session.currentTime, lastPlayed: lastPlayed) : session.currentTime
+        let currentTime = allowSeekBack ? PlayerTimeUtils.calcSeekBackTime(currentTime: session.currentTime, lastPlayedMs: session.updatedAt) : session.currentTime
         
         // Sync our new playback position
         Task { await PlayerProgress.shared.syncFromPlayer(currentTime: currentTime, includesPlayProgress: self.isPlaying(), isStopping: false) }
@@ -305,31 +304,6 @@ class AudioPlayer: NSObject {
                 self?.resumePlayback()
             }
         }
-    }
-    
-    private func calculateSeekBackTimeAtCurrentTime(_ currentTime: Double, lastPlayed: Double) -> Double {
-        let difference = Date().timeIntervalSince1970 - lastPlayed
-        var time: Double = 0
-        
-        // Scale seek back time based on how long since last play
-        if lastPlayed == 0 {
-            time = 5
-        } else if difference < 6 {
-            time = 2
-        } else if difference < 12 {
-            time = 10
-        } else if difference < 30 {
-            time = 15
-        } else if difference < 180 {
-            time = 20
-        } else if difference < 3600 {
-            time = 25
-        } else {
-            time = 29
-        }
-        
-        // Wind the clock back
-        return currentTime - time
     }
     
     private func resumePlayback() {

--- a/ios/App/Shared/player/util/PlayerTimeUtils.swift
+++ b/ios/App/Shared/player/util/PlayerTimeUtils.swift
@@ -14,7 +14,8 @@ class PlayerTimeUtils {
     static func calcSeekBackTime(currentTime: TimeInterval, lastPlayedMs: Double?) -> TimeInterval {
         let sinceLastPlayed = timeSinceLastPlayed(lastPlayedMs)
         let timeToSeekBack = timeToSeekBackForSinceLastPlayed(sinceLastPlayed)
-        return currentTime.advanced(by: -timeToSeekBack)
+        let currentTimeAfterSeekBack = currentTime.advanced(by: -timeToSeekBack)
+        return max(currentTimeAfterSeekBack, 0)
     }
     
     static internal func timeSinceLastPlayed(_ lastPlayedMs: Double?) -> TimeInterval? {

--- a/ios/App/Shared/player/util/PlayerTimeUtils.swift
+++ b/ios/App/Shared/player/util/PlayerTimeUtils.swift
@@ -1,0 +1,46 @@
+//
+//  PlayerTimeUtils.swift
+//  Audiobookshelf
+//
+//  Created by Ron Heft on 9/20/22.
+//
+
+import Foundation
+
+class PlayerTimeUtils {
+    
+    private init() {}
+    
+    static func calcSeekBackTime(currentTime: TimeInterval, lastPlayedMs: Double?) -> TimeInterval {
+        let sinceLastPlayed = timeSinceLastPlayed(lastPlayedMs)
+        let timeToSeekBack = timeToSeekBackForSinceLastPlayed(sinceLastPlayed)
+        return currentTime.advanced(by: -timeToSeekBack)
+    }
+    
+    static internal func timeSinceLastPlayed(_ lastPlayedMs: Double?) -> TimeInterval? {
+        guard let lastPlayedMs = lastPlayedMs else { return nil }
+        let lastPlayed = Date(timeIntervalSince1970: lastPlayedMs / 1000)
+        return lastPlayed.timeIntervalSinceNow
+    }
+    
+    static internal func timeToSeekBackForSinceLastPlayed(_ sinceLastPlayed: TimeInterval?) -> TimeInterval {
+        if let sinceLastPlayed = sinceLastPlayed {
+            if sinceLastPlayed < 6 {
+                return 2
+            } else if sinceLastPlayed < 12 {
+                return 10
+            } else if sinceLastPlayed < 30 {
+                return 15
+            } else if sinceLastPlayed < 180 {
+                return 20
+            } else if sinceLastPlayed < 3600 {
+                return 25
+            } else {
+                return 29
+            }
+        } else {
+            return 5
+        }
+    }
+    
+}


### PR DESCRIPTION
This PR is laying the groundwork for writing Swift unit tests:

* Refactors the seek back time logic into a testable `PlayerTimeUtils` class
* Writes a set of unit tests against `PlayerTimeUtils`
  * The can be run with `Test` build mode in Xcode
* Fixes a bug with the seek back logic that was discovered with the unit tests
  * The `currentTime` could go negative if first starting the book

Going forward, I will be aiming to write unit tests for all code. While I expect it will take time to get everything tested, I want to start somewhere!

Expect some additional PRs in the future, but not immediately:
* Adding the ability to run the unit tests from the command line via npm
* A GitHub Action to automatically run the unit test suite for all PRs