### PR TITLE
Colored status and navigationbar

### DIFF
--- a/android/app/src/main/res/values-v21/styles.xml
+++ b/android/app/src/main/res/values-v21/styles.xml
@@ -11,6 +11,8 @@
       <item name="windowActionBar">false</item>
       <item name="windowNoTitle">true</item>
       <item name="android:background">@null</item>
+      <item name="android:statusBarColor">@color/background_dark</item>
+      <item name="android:navigationBarColor">@color/background_dark</item>
     </style>
 
 

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
     <color name="light_blue_200">#FF81D4FA</color>
     <color name="light_blue_600">#FF039BE5</color>
     <color name="light_blue_900">#FF01579B</color>
+    <color name="background_dark">#262626</color>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -13,6 +13,8 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <item name="android:statusBarColor">@color/background_dark</item>
+        <item name="android:navigationBarColor">@color/background_dark</item>
     </style>
 
 


### PR DESCRIPTION
On some Samsung devices, white is used as the default color for the navigation bar in dark mode, see https://github.com/jellyfin/jellyfin-android/issues/581.

I colored the status and navigationbar with the same background color as the header of the website.

![image](https://user-images.githubusercontent.com/70302993/196016894-412e1a6a-ea50-4397-9e17-aac11665a1d3.png)

There is no issue for this PR.
