### PR TITLE
Don't allow webview to scroll out of bounds vertically

### DIFF
--- a/android/app/src/main/res/xml/config.xml
+++ b/android/app/src/main/res/xml/config.xml
@@ -2,9 +2,5 @@
 <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <access origin="*" />
   
-  <feature name="CDVOrientation">
-    <param name="android-package" value="cordova.plugins.screenorientation.CDVOrientation"/>
-  </feature>
-
   
 </widget>

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         
         let configuration = Realm.Configuration(
-            schemaVersion: 4,
+            schemaVersion: 5,
             migrationBlock: { [weak self] migration, oldSchemaVersion in
                 if (oldSchemaVersion < 1) {
                     self?.logger.log("Realm schema version was \(oldSchemaVersion)")
@@ -28,6 +28,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     migration.enumerateObjects(ofType: ServerConnectionConfig.className()) { oldObject, newObject in
                         newObject?["index"] = indexCounter
                         indexCounter += 1
+                    }
+                }
+                if (oldSchemaVersion < 5) {
+                    self?.logger.log("Realm schema version was \(oldSchemaVersion)... Adding lockOrientation setting")
+                    migration.enumerateObjects(ofType: DeviceSettings.className()) { oldObject, newObject in
+                        newObject?["lockOrientation"] = "NONE"
                     }
                 }
             }

--- a/ios/App/App/config.xml
+++ b/ios/App/App/config.xml
@@ -2,9 +2,5 @@
 <widget version="1.0.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <access origin="*" />
   
-  <feature name="CDVOrientation">
-    <param name="ios-package" value="CDVOrientation"/>
-  </feature>
-
   
 </widget>

--- a/ios/App/App/plugins/AbsAudioPlayer.swift
+++ b/ios/App/App/plugins/AbsAudioPlayer.swift
@@ -26,6 +26,7 @@ public class AbsAudioPlayer: CAPPlugin {
         NotificationCenter.default.addObserver(self, selector: #selector(onLocalMediaProgressUpdate), name: NSNotification.Name(PlayerEvents.localProgress.rawValue), object: nil)
         
         self.bridge?.webView?.allowsBackForwardNavigationGestures = true;
+        self.bridge?.webView?.scrollView.alwaysBounceVertical = false;
         
     }
     

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -236,13 +236,13 @@ public class AbsDatabase: CAPPlugin {
         let enableAltView = call.getBool("enableAltView") ?? false
         let jumpBackwardsTime = call.getInt("jumpBackwardsTime") ?? 10
         let jumpForwardTime = call.getInt("jumpForwardTime") ?? 10
-        let lockOrientation call.getString("lockOrientation") ?? "NONE"
+        let lockOrientation = call.getString("lockOrientation") ?? "NONE"
         let settings = DeviceSettings()
         settings.disableAutoRewind = disableAutoRewind
         settings.enableAltView = enableAltView
         settings.jumpBackwardsTime = jumpBackwardsTime
         settings.jumpForwardTime = jumpForwardTime
-        settings.lockOrientation = LockOrientationSetting(rawValue: lockOrientation)
+        settings.lockOrientation = lockOrientation
         
         Database.shared.setDeviceSettings(deviceSettings: settings)
         

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -9,13 +9,12 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
-  pod 'CapacitorApp', :path => '..\..\node_modules\@capacitor\app'
-  pod 'CapacitorDialog', :path => '..\..\node_modules\@capacitor\dialog'
-  pod 'CapacitorHaptics', :path => '..\..\node_modules\@capacitor\haptics'
-  pod 'CapacitorNetwork', :path => '..\..\node_modules\@capacitor\network'
-  pod 'CapacitorStatusBar', :path => '..\..\node_modules\@capacitor\status-bar'
-  pod 'CapacitorStorage', :path => '..\..\node_modules\@capacitor\storage'
-  pod 'CordovaPlugins', :path => '../capacitor-cordova-ios-plugins'
+  pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
+  pod 'CapacitorDialog', :path => '../../node_modules/@capacitor/dialog'
+  pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'
+  pod 'CapacitorNetwork', :path => '../../node_modules/@capacitor/network'
+  pod 'CapacitorStatusBar', :path => '../../node_modules/@capacitor/status-bar'
+  pod 'CapacitorStorage', :path => '../../node_modules/@capacitor/storage'
 end
 
 target 'Audiobookshelf' do

--- a/ios/App/Shared/models/DeviceSettings.swift
+++ b/ios/App/Shared/models/DeviceSettings.swift
@@ -8,18 +8,12 @@
 import Foundation
 import RealmSwift
 
-enum LockOrientationSetting: Codable {
-    case NONE
-    case PORTRAIT
-    case LANDSCAPE
-}
-
 class DeviceSettings: Object {
     @Persisted var disableAutoRewind: Bool = false
     @Persisted var enableAltView: Bool = false
     @Persisted var jumpBackwardsTime: Int = 10
     @Persisted var jumpForwardTime: Int = 10
-    @Persisted var lockOrientation: LockOrientationSetting = LockOrientationSetting.NONE
+    @Persisted var lockOrientation: String = "NONE"
 }
 
 func getDefaultDeviceSettings() -> DeviceSettings {


### PR DESCRIPTION
Prevents the app's webview from allowing a scroll of the actual app body, as per issue [#5907](https://github.com/ionic-team/capacitor/issues/5907) in the Capacitor repo. Previously the app could behave like this:
![verticalScroll](https://user-images.githubusercontent.com/62854267/206267623-dab4678b-e92a-4925-b85e-78d0ab5f49c3.jpg)