### PR TITLE
Fix Listening Stats

### DIFF
--- a/ios/App/Shared/player/PlayerProgress.swift
+++ b/ios/App/Shared/player/PlayerProgress.swift
@@ -151,6 +151,14 @@ class PlayerProgress {
         } else {
             let playbackReport = PlaybackReport(currentTime: session.currentTime, duration: session.duration, timeListened: session.timeListening)
             success = await ApiClient.reportPlaybackProgress(report: playbackReport, sessionId: session.id)
+            // Reset time listening becuase server expects that time to be since last sync, not for the whole session
+            if success {
+                if let session = session.thaw() {
+                    try session.update {
+                        session.timeListening = 0
+                    }
+                }
+            }
         }
         
         


### PR DESCRIPTION
Resolves #404. The issue seems to be that the server expects that when syncing an open (streamed) session, the attribute `timeListened` to be time since the last sync to the server (as per the [API docs](https://api.audiobookshelf.org/#sync-an-open-session)). But the app uses that logic to store timeListened offline as well, so updates it cumulatively and sends that to the server where the time is compounded. This explains why the listening sessions seemed only slightly off for a few seconds of listening, but exponentially huge (thousands of hours) for longer streamed listens. This PR just adds a bit of logic to reset that timeListening attribute each time there is a server sync when the book is being streamed. I did some testing both with downloaded and local books and the listening time now seems to be reported accurately.