### PR TITLE
Prevent selecting of text in the app

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full layout-wrapper bg-bg text-white">
+  <div class="select-none w-full layout-wrapper bg-bg text-white">
     <app-appbar />
     <div id="content" class="overflow-hidden relative" :class="playerIsOpen ? 'playerOpen' : ''">
       <Nuxt />


### PR DESCRIPTION
Fixes #379 (mostly). Prevents selecting text in the app, but does not prevent long-press to download covers on iOS. Seems like an appropriate "bug" to keep as it exists on the item page?