### PR TITLE
Handle skip track events on iOS

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -571,6 +571,8 @@ class AudioPlayer: NSObject {
         }
         let commandCenter = MPRemoteCommandCenter.shared()
         let deviceSettings = Database.shared.getDeviceSettings()
+        let jumpForwardTime = deviceSettings.jumpForwardTime
+        let jumpBackwardsTime = deviceSettings.jumpBackwardsTime
         
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { [weak self] event in
@@ -584,7 +586,7 @@ class AudioPlayer: NSObject {
         }
         
         commandCenter.skipForwardCommand.isEnabled = true
-        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: deviceSettings.jumpForwardTime)]
+        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: jumpForwardTime)]
         commandCenter.skipForwardCommand.addTarget { [weak self] event in
             guard let command = event.command as? MPSkipIntervalCommand else {
                 return .noSuchContent
@@ -596,7 +598,7 @@ class AudioPlayer: NSObject {
             return .success
         }
         commandCenter.skipBackwardCommand.isEnabled = true
-        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: deviceSettings.jumpBackwardsTime)]
+        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: jumpBackwardsTime)]
         commandCenter.skipBackwardCommand.addTarget { [weak self] event in
             guard let command = event.command as? MPSkipIntervalCommand else {
                 return .noSuchContent
@@ -613,7 +615,7 @@ class AudioPlayer: NSObject {
             guard let currentTime = self?.getCurrentTime() else {
                 return .commandFailed
             }
-            self?.seek(currentTime + Double(deviceSettings.jumpForwardTime), from: "remote")
+            self?.seek(currentTime + Double(jumpForwardTime), from: "remote")
             return .success
         }
         commandCenter.previousTrackCommand.isEnabled = true
@@ -621,7 +623,7 @@ class AudioPlayer: NSObject {
             guard let currentTime = self?.getCurrentTime() else {
                 return .commandFailed
             }
-            self?.seek(currentTime - Double(deviceSettings.jumpBackwardsTime), from: "remote")
+            self?.seek(currentTime - Double(jumpBackwardsTime), from: "remote")
             return .success
         }
 

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -608,6 +608,23 @@ class AudioPlayer: NSObject {
             return .success
         }
         
+        commandCenter.nextTrackCommand.isEnabled = true
+        commandCenter.nextTrackCommand.addTarget { [weak self] _ in
+            guard let currentTime = self?.getCurrentTime() else {
+                return .commandFailed
+            }
+            self?.seek(currentTime + Double(deviceSettings.jumpForwardTime), from: "remote")
+            return .success
+        }
+        commandCenter.previousTrackCommand.isEnabled = true
+        commandCenter.previousTrackCommand.addTarget { [weak self] _ in
+            guard let currentTime = self?.getCurrentTime() else {
+                return .commandFailed
+            }
+            self?.seek(currentTime - Double(deviceSettings.jumpBackwardsTime), from: "remote")
+            return .success
+        }
+
         commandCenter.changePlaybackPositionCommand.isEnabled = true
         commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
             guard let event = event as? MPChangePlaybackPositionCommandEvent else {


### PR DESCRIPTION
This adds nextTrack/previousTrack handlers. I've never needed to skip entire chapters from my headphones, so the behavior is similar to skipForward/skipBackward -- only moving 5-30s in either direction.

This resolves an issue I've had where double/triple clicking AirPod Pros wouldn't change playback position.