### PR TITLE
Fix Metadata List Separators

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -86,7 +86,7 @@
         <div v-if="narrators && narrators.length" class="text-white text-opacity-60 uppercase text-sm">Narrators</div>
         <div v-if="narrators && narrators.length" class="truncate text-sm">
           <template v-for="(narrator, index) in narrators">
-            <nuxt-link :key="narrator" :to="`/bookshelf/library?filter=narrators.${$encode(narrator)}`" class="underline">{{ narrator }}</nuxt-link><span :key="index" v-if="index < narrators.length - 1">,</span>
+            <nuxt-link :key="narrator" :to="`/bookshelf/library?filter=narrators.${$encode(narrator)}`" class="underline">{{ narrator }}</nuxt-link><span :key="index" v-if="index < narrators.length - 1">, </span>
           </template>
         </div>
 
@@ -96,7 +96,7 @@
         <div v-if="genres.length" class="text-white text-opacity-60 uppercase text-sm">Genres</div>
         <div v-if="genres.length" class="truncate text-sm">
           <template v-for="(genre, index) in genres">
-            <nuxt-link :key="genre" :to="`/bookshelf/library?filter=genres.${$encode(genre)}`" class="underline">{{ genre }}</nuxt-link><span :key="index" v-if="index < genres.length - 1">,</span>
+            <nuxt-link :key="genre" :to="`/bookshelf/library?filter=genres.${$encode(genre)}`" class="underline">{{ genre }}</nuxt-link><span :key="index" v-if="index < genres.length - 1">, </span>
           </template>
         </div>
       </div>


### PR DESCRIPTION
This patch fixes the separators between metadata list entries in the book detail view. Items were separated only by comma. A space was missing.

![Screenshot from 2023-01-31 14-44-33](https://user-images.githubusercontent.com/1008395/215778200-27bfe9e3-74f2-44f2-88a9-f3d7778dada7.png)

This just adds a space to both the genre as well as to the narrator separators.

![Screenshot from 2023-01-31 14-43-10](https://user-images.githubusercontent.com/1008395/215778234-ffaea1ad-b8f2-4f19-ab50-78818c3ada84.png)
