### PR TITLE
Player Progress Bar Position

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -65,7 +65,7 @@
       </div>
       <div v-else class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: linear-gradient(145deg, rgba(38, 38, 38, 0.5) 0%, rgba(38, 38, 38, 0.9) 20%, rgb(38, 38, 38) 60%)" />
 
-      <div id="playerControls" class="absolute right-0 bottom-0 py-2 mt-5">
+      <div id="playerControls" class="absolute right-0 bottom-0 py-2">
         <div class="flex items-center justify-center">
           <span v-show="showFullscreen && !lockUi" class="material-icons next-icon text-white text-opacity-75 cursor-pointer" :class="isLoading ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart">first_page</span>
           <span v-show="!lockUi" class="material-icons jump-icon text-white cursor-pointer" :class="isLoading ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards">{{ jumpBackwardsIcon }}</span>

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -65,7 +65,7 @@
       </div>
       <div v-else class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: linear-gradient(145deg, rgba(38, 38, 38, 0.5) 0%, rgba(38, 38, 38, 0.9) 20%, rgb(38, 38, 38) 60%)" />
 
-      <div id="playerControls" class="absolute right-0 bottom-0 py-2">
+      <div id="playerControls" class="absolute right-0 bottom-0 py-2 mt-5">
         <div class="flex items-center justify-center">
           <span v-show="showFullscreen && !lockUi" class="material-icons next-icon text-white text-opacity-75 cursor-pointer" :class="isLoading ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart">first_page</span>
           <span v-show="!lockUi" class="material-icons jump-icon text-white cursor-pointer" :class="isLoading ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards">{{ jumpBackwardsIcon }}</span>
@@ -934,7 +934,6 @@ export default {
   bottom: 20px;
 }
 .fullscreen #playerTrack {
-  top: 20px;
   bottom: unset;
 }
 


### PR DESCRIPTION
This patch moves the progress bar slightly up for a better separation between playback controls and seeking.

The reasoning behind this is that I (and probably others as well) often interact with this interface in a clumsy, half-asleep state. Due to the closeness of the progress bar and the play/pause button, I have managed it several times to accidentally seek instead of pause. That is really annoying since you then have to manually find the previous playback position again.

Long term, I would love to see more of the available space being used. In particular in the player interface. There should be enough free space available. Especially if you have just one of the progress bars active. But for now, this is just a quick-fix to improve the current situation.

![Screenshot from 2023-01-31 15-29-40](https://user-images.githubusercontent.com/1008395/215791196-82b4201b-9f9f-44aa-bae5-45fd8134a5de.png)
