### PR TITLE
Move Discard Progress to Menu

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -292,6 +292,7 @@ export default {
       return this.$store.getters['user/getToken']
     },
     userItemProgress() {
+      if (this.isPodcast) return null
       if (this.isLocal) return this.$store.getters['globals/getLocalMediaProgressById'](this.libraryItemId)
       return this.$store.getters['user/getUserMediaProgress'](this.libraryItemId)
     },

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -43,9 +43,6 @@
           <p class="leading-6">Your Progress: {{ Math.round(progressPercent * 100) }}%</p>
           <p v-if="progressPercent < 1" class="text-gray-400 text-xs">{{ $elapsedPretty(userTimeRemaining) }} remaining</p>
           <p v-else class="text-gray-400 text-xs">Finished {{ $formatDate(userProgressFinishedAt) }}</p>
-          <div v-if="!resettingProgress" class="absolute -top-1.5 -right-1.5 p-1 w-5 h-5 rounded-full bg-bg hover:bg-error border border-primary flex items-center justify-center cursor-pointer" @click.stop="clearProgressClick">
-            <span class="material-icons text-sm">close</span>
-          </div>
         </div>
 
         <div v-if="isLocal" class="flex mt-4 -mx-1">
@@ -378,6 +375,13 @@ export default {
           text: this.userIsFinished ? 'Mark as Not Finished' : 'Mark as Finished',
           value: 'markFinished'
         })
+
+        if (this.progressPercent > 0 && !this.userIsFinished) {
+          items.push({
+            text: 'Discard Progress',
+            value: 'discardProgress'
+          })
+        }
       }
 
       if (this.localLibraryItemId) {
@@ -445,6 +449,8 @@ export default {
         this.toggleFinished()
       } else if (action === 'history') {
         this.$router.push(`/media/${this.mediaId}/history?title=${this.title}`)
+      } else if (action === 'discardProgress') {
+        this.clearProgressClick()
       }
     },
     moreButtonPress() {


### PR DESCRIPTION
This patch moves the discard progress functionality from the tiny icon in the top right corner of the progress display to the options menu.

The reasoning for this is that resetting progress is an option which is unlikely to be used very often and therefor does not need to be on the main screen. In addition to that, the menu already holds the related options to mark the book as finished and to discard the progress of a finished book.

Finally, this removes the tiny icon which does not really match the rest of the user interface of the app.


![Screenshot from 2023-02-07 22-41-35](https://user-images.githubusercontent.com/1008395/217374905-38962f3d-48d0-4b2b-8242-e06c09a39645.png)
