### PR TITLE
App info in account settings

### DIFF
--- a/pages/account.vue
+++ b/pages/account.vue
@@ -4,11 +4,10 @@
 
     <ui-text-input-with-label :value="username" label="Username" disabled class="my-2" />
 
-    <ui-btn color="primary flex items-center justify-between text-base w-full mt-8" @click="logout">Logout<span class="material-icons" style="font-size: 1.1rem">logout</span></ui-btn>
+    <ui-btn color="primary flex items-center justify-between gap-2 ml-auto text-base mt-8" @click="logout">Logout<span class="material-icons" style="font-size: 1.1rem">logout</span></ui-btn>
 
-    <div class="flex items-center pt-8">
-      <div class="flex-grow" />
-      <p class="pr-2 text-sm font-book text-yellow-400">Report bugs, request features, provide feedback, and contribute on <a class="underline" href="https://github.com/advplyr/audiobookshelf-app" target="_blank">github</a>.</p>
+    <div class="flex justify-end items-center m-4 gap-3 right-0 bottom-0 absolute">
+      <p class="text-sm font-book text-yellow-400 text-right">Report bugs, request features, provide feedback, and contribute on <a class="underline" href="https://github.com/advplyr/audiobookshelf-app" target="_blank">GitHub</a></p>
       <a href="https://github.com/advplyr/audiobookshelf-app" target="_blank" class="text-white hover:text-gray-200 hover:scale-150 hover:rotate-6 transform duration-500">
         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="24" height="24" viewBox="0 0 24 24">
           <path
@@ -17,8 +16,6 @@
         </svg>
       </a>
     </div>
-
-    <p class="font-mono pt-1 pb-4">{{ $config.version }}</p>
   </div>
 </template>
 


### PR DESCRIPTION
This patch updates the account settings view, trying to make it look a bit cleaner by:

- Making the logout button look more like a button. The full width looked odd on large devices or in landscape mode.
- Removing the version number. It is already listed in the main menu anyway.
- Moving the hint about reporting bugs and the GitHub link to the bottom.

The hint is still a bit weird in this view. Maybe long-term, we want to move all these information about the app (version, issues, …) to a separate view. But that's something for another day.


![Screenshot from 2023-02-07 23-54-27](https://user-images.githubusercontent.com/1008395/217387195-b2d98109-20ca-4323-b670-27860bbab3ed.png)
