### PR TITLE
Simplify progress (re)sets

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -372,12 +372,14 @@ export default {
           })
         }
 
-        items.push({
-          text: this.userIsFinished ? 'Mark as Not Finished' : 'Mark as Finished',
-          value: 'markFinished'
-        })
+        if (!this.userIsFinished) {
+          items.push({
+            text: 'Mark as Finished',
+            value: 'markFinished'
+          })
+        }
 
-        if (this.progressPercent > 0 && !this.userIsFinished) {
+        if (this.progressPercent > 0) {
           items.push({
             text: 'Discard Progress',
             value: 'discardProgress'


### PR DESCRIPTION
This patch is a follow up to the discussion from #559 about potentially simplifying progress interactions.

This patch essentially reduces the interactions to two simple options which allow users to always marks books as finished or discard the progress and thus mark them as not yet started with a single interaction:

- If users have already listed to the book, regardless of the state of the progress (finished, halfway through, …), they get an option to discard the progress. This replaces the additional “mark as not finished” option, but it should still be clear to users what happens.

- If a book is not yet finished, regardless of the state of the progress (not yet started, halfway through), users get a “mark as finished” option which sets the progress to 100%.

This is hopefully a bit simpler than what we have now but also doesn't require a user to figure out that you need to first mark a book as finished to be able to discard the progress.


![Screenshot from 2023-02-08 22-20-28](https://user-images.githubusercontent.com/1008395/217656698-5b91b02a-0b6c-4a06-a45a-4de9df58edb2.png)
