### PR TITLE
Icons for book details menu

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -368,21 +368,24 @@ export default {
         if (!this.isIos) {
           items.push({
             text: 'History',
-            value: 'history'
+            value: 'history',
+            icon: 'history'
           })
         }
 
         if (!this.userIsFinished) {
           items.push({
             text: 'Mark as Finished',
-            value: 'markFinished'
+            value: 'markFinished',
+            icon: 'beenhere'
           })
         }
 
         if (this.progressPercent > 0) {
           items.push({
             text: 'Discard Progress',
-            value: 'discardProgress'
+            value: 'discardProgress',
+            icon: 'backspace'
           })
         }
       }
@@ -390,20 +393,23 @@ export default {
       if (this.localLibraryItemId) {
         items.push({
           text: 'Manage Local Files',
-          value: 'manageLocal'
+          value: 'manageLocal',
+          icon: 'folder'
         })
       }
 
       if (!this.isPodcast && this.serverLibraryItemId) {
         items.push({
           text: 'Add to Playlist',
-          value: 'playlist'
+          value: 'playlist',
+          icon: 'playlist_add'
         })
       }
 
       items.push({
         text: 'More Info',
-        value: 'details'
+        value: 'details',
+        icon: 'info'
       })
 
       return items

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -372,12 +372,14 @@ export default {
           })
         }
 
-        items.push({
-          text: this.userIsFinished ? 'Mark as Not Finished' : 'Mark as Finished',
-          value: 'markFinished'
-        })
+        if (!this.userIsFinished) {
+          items.push({
+            text: 'Mark as Finished',
+            value: 'markFinished'
+          })
+        }
 
-        if (this.progressPercent > 0 && !this.userIsFinished) {
+        if (this.progressPercent > 0) {
           items.push({
             text: 'Discard Progress',
             value: 'discardProgress'


### PR DESCRIPTION
This patch adds icons similar to those used in other app menus to the book details menu.
This is based on pull request #561 and needs to be slightly adjusted if that one is not merged.

<img src="https://user-images.githubusercontent.com/1008395/217663338-062cf362-5144-4d7b-9d41-ef24f09afd47.png" width="300px" />
