### PR TITLE
Disable ATS for iOS

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -53,6 +53,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>


### PR DESCRIPTION
As discussed on Discord, and tested as far as having Apple approve the bundle.
Just disable ATS.
https://testflight.apple.com/join/5Nf8O3mI for the approved build.
https://github.com/advplyr/audiobookshelf-app/issues/538 for related issue.
https://developer.apple.com/forums/thread/3544 for related response from Apple making it sound this is acceptable.