### PR TITLE
Improve word wrapping

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -127,7 +127,7 @@
       </div>
 
       <div class="w-full py-4">
-        <p class="text-sm">{{ description }}</p>
+        <p class="text-sm text-justify" style="hyphens: auto;">{{ description }}</p>
       </div>
 
       <tables-podcast-episodes-table v-if="isPodcast" :library-item="libraryItem" :local-library-item-id="localLibraryItemId" :episodes="episodes" :local-episodes="localLibraryItemEpisodes" :is-local="isLocal" />


### PR DESCRIPTION
This patch improves word wrapping for the description text in book details by justifying the text block and allowing for words to be wrapped by automatically inserting hyphens if necessary.

This causes the description box to look far less ragged on the right edge which I think helps the overall cleanliness of the look.

Unfortunately the app's/browser's aren't as good as e.g. the TeX algorithm for hyphening and there are JavaScript libraries which seem to reimplement that. But this is already a significant step up and far less work for something which is not the main focus of this app.


![Screenshot from 2023-02-10 23-21-09](https://user-images.githubusercontent.com/1008395/218214516-d00e4203-8dfc-4516-b14d-0a00384426d0.png)
