### PR TITLE
Easy way to play current audiobook

### DIFF
--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -188,6 +188,7 @@ export default {
       const libraryItemId = payload.libraryItemId
       const episodeId = payload.episodeId
       const startTime = payload.startTime
+      const startWhenReady = !payload.paused
 
       // When playing local library item and can also play this item from the server
       //   then store the server library item id so it can be used if a cast is made
@@ -223,7 +224,7 @@ export default {
       }
 
       console.log('Called playLibraryItem', libraryItemId)
-      const preparePayload = { libraryItemId, episodeId, playWhenReady: true, playbackRate }
+      const preparePayload = { libraryItemId, episodeId, playWhenReady: startWhenReady, playbackRate }
       if (startTime !== undefined && startTime !== null) preparePayload.startTime = startTime
       AbsAudioPlayer.prepareLibraryItem(preparePayload)
         .then((data) => {

--- a/pages/bookshelf/index.vue
+++ b/pages/bookshelf/index.vue
@@ -247,6 +247,15 @@ export default {
           return cat
         })
 
+        // If we don't already have a player open
+        // Try opening the first book from continue-listening without playing it
+        if (!this.$store.state.playerLibraryItemId) {
+          const lastListening = categories.filter((cat) => cat.id === 'continue-listening')[0]?.entities?.[0]?.id
+          if (lastListening) {
+            this.$eventBus.$emit('play-item', { libraryItemId: lastListening, paused: true })
+          }
+        }
+
         // Only add the local shelf with the same media type
         const localShelves = localCategories.filter((cat) => cat.type === this.currentLibraryMediaType && !cat.localOnly)
         this.shelves.push(...localShelves)

--- a/pages/bookshelf/index.vue
+++ b/pages/bookshelf/index.vue
@@ -39,6 +39,7 @@ export default {
       shelves: [],
       loading: false,
       isFirstNetworkConnection: true,
+      isFirstAutoOpenPlayer: true,
       lastServerFetch: 0,
       lastServerFetchLibraryId: null,
       lastLocalFetch: 0,
@@ -247,14 +248,7 @@ export default {
           return cat
         })
 
-        // If we don't already have a player open
-        // Try opening the first book from continue-listening without playing it
-        if (!this.$store.state.playerLibraryItemId) {
-          const lastListening = categories.filter((cat) => cat.id === 'continue-listening')[0]?.entities?.[0]?.id
-          if (lastListening) {
-            this.$eventBus.$emit('play-item', { libraryItemId: lastListening, paused: true })
-          }
-        }
+        this.openMediaPlayerWithMostRecentListening()
 
         // Only add the local shelf with the same media type
         const localShelves = localCategories.filter((cat) => cat.type === this.currentLibraryMediaType && !cat.localOnly)
@@ -269,6 +263,40 @@ export default {
       }
 
       this.loading = false
+    },
+    openMediaPlayerWithMostRecentListening() {
+      // If we don't already have a player open
+      // Try opening the first book from continue-listening without playing it
+      if (this.$store.state.playerLibraryItemId || !this.isFirstAutoOpenPlayer) return
+      this.isFirstAutoOpenPlayer = false // Only run this once, not on every library change
+
+      const continueListeningShelf = this.shelves.find((cat) => cat.id === 'continue-listening')
+      const mostRecentEntity = continueListeningShelf?.entities?.[0]
+      if (mostRecentEntity) {
+        const playObject = {
+          libraryItemId: mostRecentEntity.id,
+          episodeId: mostRecentEntity.recentEpisode?.id || null,
+          paused: true
+        }
+
+        // Check if there is a local copy
+        if (mostRecentEntity.localLibraryItem) {
+          if (mostRecentEntity.recentEpisode) {
+            // Check if the podcast episode has a local copy
+            const localEpisode = mostRecentEntity.localLibraryItem.media.episodes.find((ep) => ep.serverEpisodeId === mostRecentEntity.recentEpisode.id)
+            if (localEpisode) {
+              playObject.libraryItemId = mostRecentEntity.localLibraryItem.id
+              playObject.episodeId = localEpisode.id
+              playObject.serverLibraryItemId = mostRecentEntity.id
+              playObject.serverEpisodeId = mostRecentEntity.recentEpisode.id
+            }
+          } else {
+            playObject.libraryItemId = mostRecentEntity.localLibraryItem.id
+            playObject.serverLibraryItemId = mostRecentEntity.id
+          }
+        }
+        this.$eventBus.$emit('play-item', playObject)
+      }
     },
     libraryChanged() {
       if (this.currentLibraryId) {


### PR DESCRIPTION
This patch implements a generic way of re-opening the player for the book you last listened to. This is especially handy when first opening the app and you can restart playback with a single click.

The player is opened only if no other book is already open in the player. It will not overwrite or replace playbacks or player already in progress.

The player is opened paused. No automatic playback since that could be really annoying.

This closes #494


https://user-images.githubusercontent.com/1008395/218283320-511981e5-26ea-4ab2-a74b-ed8aaac743a9.mp4

