### PR TITLE
Fix TypeError on Logout

### DIFF
--- a/store/user.js
+++ b/store/user.js
@@ -35,7 +35,7 @@ export const getters = {
     })
   },
   getUserBookmarksForItem: (state) => (libraryItemId) => {
-    if (!state.user.bookmarks) return []
+    if (!state?.user?.bookmarks) return []
     return state.user.bookmarks.filter(bm => bm.libraryItemId === libraryItemId)
   },
   getUserSetting: (state) => (key) => {


### PR DESCRIPTION
Clicking on “logout”, you get the following TypeError:

```
TypeError: state.user is null
    getUserBookmarksForItem user.js:38
    bookmarks AudioPlayerContainer.vue:45
    VueJS 4
    render AudioPlayerContainer.vue:11
    VueJS 13
    logout user.js:115
    wrappedMutationHandler vuex.esm.js:844
    commitIterator vuex.esm.js:466
    commit vuex.esm.js:465
    _withCommit vuex.esm.js:624
    commit vuex.esm.js:464
    boundCommit vuex.esm.js:409
    _callee$ account.vue:67
    tryCatch pdf_viewer.js:1329
    invoke pdf_viewer.js:1502
    defineIteratorMethods pdf_viewer.js:1372
    Babel 10
    logout account.vue:56
    VueJS 4
    click Btn.vue:65
    VueJS 33
client.js:103
```

This patch fixes the problem by checking for `null` values.