### PR TITLE
Account Setting Information

### DIFF
--- a/pages/account.vue
+++ b/pages/account.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full h-full p-4">
-    <ui-text-input-with-label :value="serverConnConfigName" label="Connection Config Name" disabled class="my-2" />
+    <ui-text-input-with-label :value="serverAddress" label="Host" disabled class="my-2" />
 
     <ui-text-input-with-label :value="username" label="Username" disabled class="my-2" />
 
@@ -40,9 +40,6 @@ export default {
     },
     serverConnectionConfig() {
       return this.$store.state.user.serverConnectionConfig || {}
-    },
-    serverConnConfigName() {
-      return this.serverConnectionConfig.name
     },
     serverAddress() {
       return this.serverConnectionConfig.address


### PR DESCRIPTION
The account setting list the connection name which is the server address directly followed by the username. This is then followed by a field repeating the username again.

This duplication of information is nor really helpful, which is why this patch replaces this with two fields containing just the two information: host address and username.

![Screenshot from 2023-02-11 23-46-54](https://user-images.githubusercontent.com/1008395/218284476-0cc15378-868d-463f-9a46-1ab4762b32af.png)
