### PR TITLE
Publish Android Test Page

### DIFF
--- a/.github/testing-page-template.html
+++ b/.github/testing-page-template.html
@@ -1,0 +1,81 @@
+﻿<!DOCTYPE html>
+<html lang=en>
+<head>
+<meta http-equiv=content-type content="text/html; charset=utf-8" />
+<meta name=viewport content="width=device-width, initial-scale=1">
+<title>Audiobookshelf :: Testers</title>
+<style>
+body {
+  background-color: rgb(55, 56, 56);
+  font-family: Sans;
+  margin: 40px auto;
+  max-width: 500px;
+  color: #ddd;
+  text-align: center;
+  padding: 5px;
+}
+img {
+    width: 100px;
+}
+h1 {
+  font-weight: 100;
+}
+a {
+  color: #fff;
+}
+#apk {
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: center;
+  column-gap: 15px;
+  text-align: left;
+  font-family: monospace;
+  background-color: #222;
+  padding: 20px;
+  border-radius: 5px;
+}
+</style>
+</head>
+<body>
+
+  <a href="https://audiobookshelf.org">
+    <img src=logo.png />
+  </a>
+	<h1>Audiobookshelf :: Testers</h1>
+
+  <p>
+  Here you can download the latest version of Audiobookshelf for Android for <b>testing</b>.
+  The app is automatically built for every new patch added to the project.
+  </p>
+
+  <div id=apk>
+    <div>Built on</div>
+    <div>__DATE__</div>
+
+    <div>Git commit</div>
+    <a href="https://github.com/advplyr/audiobookshelf-app/commit/__COMMIT__">__COMMIT__</a>
+
+    <div>Download</div>
+    <a href="__APK__">__APK__</a>
+  </div>
+
+  <p>
+  Using this requires some technical knowledge to install the APK manually.
+  Regular users should use the releases published on the <a href="https://play.google.com/store/apps/details?id=com.audiobookshelf.app">Play Store</a>.
+  </p>
+
+  <hr />
+
+  <p>Report bugs, request features, provide feedback, and contribute on <a href="https://github.com/advplyr/audiobookshelf-app/issues">GitHub</a></p>
+  <p>
+    <a href="https://github.com/advplyr/audiobookshelf-app/issues">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" width=32 height=32 viewBox="0 0 24 24">
+        <path
+          d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+        />
+      </svg>
+    </a>
+  </div>
+
+</body>
+</html>

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - 'ios/**'
+      - '.github/**'
+      - 'readme.md'
 
 jobs:
   build:

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -1,0 +1,73 @@
+name: Publish Test App
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout sources
+      uses: actions/checkout@v3
+
+    - name: use Node.js 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    - name: install dependencies
+      run: npm ci
+
+    - name: build Nuxt project
+      run: npm run generate
+
+    - name: copy to Android project
+      run: npx cap sync
+
+    - name: build Android app
+      run: ./android/gradlew assembleDebug -p android --no-daemon
+
+    - name: rename apk
+      working-directory: android/app/build/outputs/apk/debug/
+      run: |
+        build="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
+        name="audiobookshelf-${build}.apk"
+        mv -v app-debug.apk "${name}"
+
+    - name: prepare test page ressources
+      run: |
+        mkdir ghpages
+        cp android/app/build/outputs/apk/debug/*apk ghpages/
+        cp static/Logo.png ghpages/logo.png
+        cp .github/testing-page-template.html ghpages/index.html
+
+    - name: build test page
+      working-directory: ghpages
+      run: |
+        sed -i "s/__DATE__/$(date)/g" index.html
+        sed -i "s/__COMMIT__/$(git rev-parse --short HEAD)/g" index.html
+        sed -i "s/__APK__/$(ls *apk)/g" index.html
+
+    - name: upload test page artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: ./ghpages
+
+  deploy:
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This page automatically builds the Android app from the latest commit on the branch master, generates a test page and publishes it to GitHub Pages as a nice way for non-developers to get the latest app version for testing without having to build it themselves.

This page might need the pages source set to GitHub Actions at Settings → Pages → Build and deployment → Source.

![Screenshot from 2023-02-13 21-45-33](https://user-images.githubusercontent.com/1008395/218571387-eb811475-9dcb-41a5-89b0-d7dd6e4ca450.png)
