### PR TITLE
Build APK on Workflow Change

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,12 +4,10 @@ on:
   push:
     paths-ignore:
       - 'ios/**'
-      - '.github/**'
       - 'readme.md'
   pull_request:
     paths-ignore:
       - 'ios/**'
-      - '.github/**'
       - 'readme.md'
 jobs:
   main:

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -6,7 +6,6 @@ on:
       - master
     paths-ignore:
       - 'ios/**'
-      - '.github/**'
       - 'readme.md'
 
 jobs:


### PR DESCRIPTION
This patch removes a few restriction about when the Android build workflows run. In particular, we want to run workflows…

- If the workflows themselves change because that could mean that the output changes.
- If the deployment page template changes because that would mean that the published page needs to be updated.

We could still exclude a few specific files if we wanted to, but they should rarely change and it's probably not worth the effort of keeping those lists updated.