### PR TITLE
Add `android:largeHeap="true"` to `AndroidManifest.xml`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true" >
+        android:usesCleartextTraffic="true"
+        android:largeHeap="true" >
 
         <!-- Android app widget -->
         <receiver


### PR DESCRIPTION
Closes #227

This fix was suggested [here](https://github.com/google/ExoPlayer/issues/7354#issuecomment-627811740) in the ExoPlayer repo and completely solves the issue for me. The `android:largeHeap="true"` line also seems to be in the main ExoPlayer demo code.