### PR TITLE
Feat:iOS disable seek from control center/lock screen

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -642,16 +642,6 @@ class AudioPlayer: NSObject {
             self?.seek(currentTime - Double(jumpBackwardsTime), from: "remote")
             return .success
         }
-
-        commandCenter.changePlaybackPositionCommand.isEnabled = true
-        commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
-            guard let event = event as? MPChangePlaybackPositionCommandEvent else {
-                return .noSuchContent
-            }
-            
-            self?.seek(event.positionTime, from: "remote")
-            return .success
-        }
         
         commandCenter.changePlaybackRateCommand.isEnabled = true
         commandCenter.changePlaybackRateCommand.supportedPlaybackRates = [0.5, 0.75, 1.0, 1.25, 1.5, 2]


### PR DESCRIPTION
Addresses #526.

Disables the ability to scrub through a book from the lockscreen or control center. This prevents skipping several hours forward through a book.

Tested on an iPhone 13 with iOS 16.3.1.

This is a great win for UX, but could affect podcast listeners. More testing may be needed to account for that usecase.