### PR TITLE
Rename "Logout" button to "Switch account"

### DIFF
--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -25,7 +25,7 @@
           <p class="text-xs">{{ $config.version }}</p>
           <div class="flex-grow" />
           <div v-if="user" class="flex items-center" @click="logout">
-            <p class="text-xs pr-2">Logout</p>
+            <p class="text-xs pr-2">Switch account</p>
             <span class="material-icons text-sm">logout</span>
           </div>
         </div>

--- a/pages/account.vue
+++ b/pages/account.vue
@@ -4,7 +4,7 @@
 
     <ui-text-input-with-label :value="username" label="Username" disabled class="my-2" />
 
-    <ui-btn color="primary flex items-center justify-between gap-2 ml-auto text-base mt-8" @click="logout">Logout<span class="material-icons" style="font-size: 1.1rem">logout</span></ui-btn>
+    <ui-btn color="primary flex items-center justify-between gap-2 ml-auto text-base mt-8" @click="logout">Switch account<span class="material-icons" style="font-size: 1.1rem">logout</span></ui-btn>
 
     <div class="flex justify-end items-center m-4 gap-3 right-0 bottom-0 absolute">
       <p class="text-smtext-yellow-400 text-right">Report bugs, request features, provide feedback, and contribute on <a class="underline" href="https://github.com/advplyr/audiobookshelf-app" target="_blank">GitHub</a></p>


### PR DESCRIPTION
Address #628

This makes the multiaccount more explicit, while making it less confusing when wanting to switch account from different Audiobookshelf backends.

Though this does not add a "Switch account" button within the side drawer, this renames the "Logout" button from the "Account" submenu to "Switch account".

![IMG_4244](https://github.com/advplyr/audiobookshelf-app/assets/36578146/dd37eb5d-9822-419c-b1ba-4392a559f081)
