### PR TITLE
Add missing space for authors as well #777

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -91,7 +91,7 @@
         <div v-if="narrators && narrators.length" class="truncate text-sm">
           <template v-for="(narrator, index) in narrators">
             <nuxt-link :key="narrator" :to="`/bookshelf/library?filter=narrators.${$encode(narrator)}`" class="underline">{{ narrator }}</nuxt-link
-            ><span :key="${narrator.id}-comma" v-if="index < narrators.length - 1">,&nbsp;</span>
+            ><span :key="index" v-if="index < narrators.length - 1">,&nbsp;</span>
           </template>
         </div>
 
@@ -99,7 +99,7 @@
         <div v-if="genres.length" class="truncate text-sm">
           <template v-for="(genre, index) in genres">
             <nuxt-link :key="genre" :to="`/bookshelf/library?filter=genres.${$encode(genre)}`" class="underline">{{ genre }}</nuxt-link
-            ><span :key="${genre.id}-comma" v-if="index < genres.length - 1">,&nbsp;</span>
+            ><span :key="index" v-if="index < genres.length - 1">,&nbsp;</span>
           </template>
         </div>
 

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -69,7 +69,7 @@
         <div v-else-if="bookAuthors && bookAuthors.length" class="text-sm">
           <template v-for="(author, index) in bookAuthors">
             <nuxt-link :key="author.id" :to="`/bookshelf/library?filter=authors.${$encode(author.id)}`" class="underline">{{ author.name }}</nuxt-link>
-            <span :key="`${author.id}-comma`" v-if="index < bookAuthors.length - 1">,</span>
+            <span :key="`${author.id}-comma`" v-if="index < bookAuthors.length - 1">,&nbsp;</span>
           </template>
         </div>
 
@@ -91,7 +91,7 @@
         <div v-if="narrators && narrators.length" class="truncate text-sm">
           <template v-for="(narrator, index) in narrators">
             <nuxt-link :key="narrator" :to="`/bookshelf/library?filter=narrators.${$encode(narrator)}`" class="underline">{{ narrator }}</nuxt-link
-            ><span :key="index" v-if="index < narrators.length - 1">,&nbsp;</span>
+            ><span :key="${narrator.id}-comma" v-if="index < narrators.length - 1">,&nbsp;</span>
           </template>
         </div>
 
@@ -99,7 +99,7 @@
         <div v-if="genres.length" class="truncate text-sm">
           <template v-for="(genre, index) in genres">
             <nuxt-link :key="genre" :to="`/bookshelf/library?filter=genres.${$encode(genre)}`" class="underline">{{ genre }}</nuxt-link
-            ><span :key="index" v-if="index < genres.length - 1">,&nbsp;</span>
+            ><span :key="${genre.id}-comma" v-if="index < genres.length - 1">,&nbsp;</span>
           </template>
         </div>
 


### PR DESCRIPTION
Seems that the space still is missing before comma for the 'Authors' field. I believe it ought to have been a part of https://github.com/advplyr/audiobookshelf-app/commit/dd91bc666792f9ebaea6de2bb9c272cb38f0cd58 that fixes #777 🙂 

Also cleans up an inconsistency in what was used as `key` for the separator-`span`.