### PR TITLE
Don't use non-breaking spaces

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -69,7 +69,7 @@
         <div v-else-if="bookAuthors && bookAuthors.length" class="text-sm">
           <template v-for="(author, index) in bookAuthors">
             <nuxt-link :key="author.id" :to="`/bookshelf/library?filter=authors.${$encode(author.id)}`" class="underline">{{ author.name }}</nuxt-link>
-            <span :key="`${author.id}-comma`" v-if="index < bookAuthors.length - 1">,&nbsp;</span>
+            <span :key="`${author.id}-comma`" v-if="index < bookAuthors.length - 1">, </span>
           </template>
         </div>
 
@@ -80,7 +80,7 @@
         <div v-if="series && series.length" class="truncate text-sm">
           <template v-for="(series, index) in seriesList">
             <nuxt-link :key="series.id" :to="`/bookshelf/series/${series.id}`" class="underline">{{ series.text }}</nuxt-link
-            ><span :key="`${series.id}-comma`" v-if="index < seriesList.length - 1">,&nbsp;</span>
+            ><span :key="`${series.id}-comma`" v-if="index < seriesList.length - 1">, </span>
           </template>
         </div>
 
@@ -91,7 +91,7 @@
         <div v-if="narrators && narrators.length" class="truncate text-sm">
           <template v-for="(narrator, index) in narrators">
             <nuxt-link :key="narrator" :to="`/bookshelf/library?filter=narrators.${$encode(narrator)}`" class="underline">{{ narrator }}</nuxt-link
-            ><span :key="index" v-if="index < narrators.length - 1">,&nbsp;</span>
+            ><span :key="index" v-if="index < narrators.length - 1">, </span>
           </template>
         </div>
 
@@ -99,7 +99,7 @@
         <div v-if="genres.length" class="truncate text-sm">
           <template v-for="(genre, index) in genres">
             <nuxt-link :key="genre" :to="`/bookshelf/library?filter=genres.${$encode(genre)}`" class="underline">{{ genre }}</nuxt-link
-            ><span :key="index" v-if="index < genres.length - 1">,&nbsp;</span>
+            ><span :key="index" v-if="index < genres.length - 1">, </span>
           </template>
         </div>
 


### PR DESCRIPTION
This patch converts the non-breaking spaces in the metadata table to breaking spaces to avoid awkward wrapping. For example, due to the `&nbsp;` which is part of the author separator, you might end up with wrapping like this:

    Author    |
    A, Author |
    B         |

instead of

    Author A, |
    Author B  |