### PR TITLE
Adding a check so chapter sleep timer is set after resume only when a…

### DIFF
--- a/ios/App/Shared/player/AudioPlayerSleepTimer.swift
+++ b/ios/App/Shared/player/AudioPlayerSleepTimer.swift
@@ -116,8 +116,9 @@ extension AudioPlayer {
     // MARK: - Internal helpers
     
     internal func handleTrackChangeForChapterSleepTimer() {
-        // If no sleep timer is set, this does nothing
-        self.setChapterSleepTimer(stopAt: self.sleepTimeChapterStopAt)
+        if self.isChapterSleepTimerSet() {
+            self.setChapterSleepTimer(stopAt: self.sleepTimeChapterStopAt)
+        }
     }
     
     private func decrementSleepTimerIfRunning() {


### PR DESCRIPTION
The conditions makes it so the `setChapterSleepTimer` only runs if a chapter sleep timer has been set, the method removes any timers before setting a chapter sleep timer, which causes regular sleep timers to be removed causing #477 .
 