### PR TITLE
OAuth2 Support

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -9,8 +9,8 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
-    implementation project(':byteowls-capacitor-oauth2')
     implementation project(':capacitor-app')
+    implementation project(':capacitor-browser')
     implementation project(':capacitor-clipboard')
     implementation project(':capacitor-dialog')
     implementation project(':capacitor-haptics')

--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_name">audiobookshelf</string>
     <string name="title_activity_main">audiobookshelf</string>
     <string name="package_name">com.audiobookshelf.app</string>
-    <string name="custom_url_scheme">com.audiobookshelf.app.debug</string>
+    <string name="custom_url_scheme">audiobookshelf</string>
     <string name="add_widget">Add widget</string>
     <string name="app_widget_description">Simple widget for audiobookshelf playback</string>
     <string name="action_jump_forward">Jump Forward</string>

--- a/android/app/src/main/assets/capacitor.plugins.json
+++ b/android/app/src/main/assets/capacitor.plugins.json
@@ -1,11 +1,11 @@
 [
 	{
-		"pkg": "@byteowls/capacitor-oauth2",
-		"classpath": "com.byteowls.capacitor.oauth2.OAuth2ClientPlugin"
-	},
-	{
 		"pkg": "@capacitor/app",
 		"classpath": "com.capacitorjs.plugins.app.AppPlugin"
+	},
+	{
+		"pkg": "@capacitor/browser",
+		"classpath": "com.capacitorjs.plugins.browser.BrowserPlugin"
 	},
 	{
 		"pkg": "@capacitor/clipboard",

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_name">audiobookshelf</string>
     <string name="title_activity_main">audiobookshelf</string>
     <string name="package_name">com.audiobookshelf.app</string>
-    <string name="custom_url_scheme">com.audiobookshelf.app</string>
+    <string name="custom_url_scheme">audiobookshelf</string>
     <string name="add_widget">Add widget</string>
     <string name="app_widget_description">Simple widget for audiobookshelf playback</string>
     <string name="action_jump_forward">Jump Forward</string>

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -2,11 +2,11 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/android/capacitor')
 
-include ':byteowls-capacitor-oauth2'
-project(':byteowls-capacitor-oauth2').projectDir = new File('../node_modules/@byteowls/capacitor-oauth2/android')
-
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
+
+include ':capacitor-browser'
+project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
 include ':capacitor-clipboard'
 project(':capacitor-clipboard').projectDir = new File('../node_modules/@capacitor/clipboard/android')

--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -52,7 +52,7 @@
             </div>
           </form>
           <div v-if="isLocalAuthEnabled && isOpenIDAuthEnabled" class="w-full h-px bg-white bg-opacity-10 my-2" />
-          <ui-btn v-if="isOpenIDAuthEnabled" :disabled="processing" class="mt-1 h-10" @click="clickLoginWithOpenId">Login with OpenId</ui-btn>
+          <ui-btn v-if="isOpenIDAuthEnabled" :disabled="processing" class="mt-1 h-10" @click="clickLoginWithOpenId">{{ oauth.buttonText }}</ui-btn>
         </template>
       </div>
 
@@ -102,7 +102,8 @@ export default {
       authMethods: [],
       oauth: {
         state: null,
-        verifier: null
+        verifier: null,
+        buttonText: 'Login with OpenID'
       }
     }
   },
@@ -595,6 +596,11 @@ export default {
         if (this.validateLoginFormResponse(statusData, this.serverConfig.address, protocolProvided)) {
           this.showAuth = true
           this.authMethods = statusData.data.authMethods || []
+          this.oauth.buttonText = statusData.data.authFormData?.authOpenIDButtonText || 'Login with OpenID'
+
+          if (statusData.data.authFormData?.authOpenIDAutoLaunch) {
+            this.clickLoginWithOpenId()
+          }
         }
       } catch (error) {
         this.handleLoginFormError(error)

--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -78,14 +78,14 @@
 </template>
 
 <script>
-import { App } from '@capacitor/app';
-import { Browser } from '@capacitor/browser';
-import { Capacitor } from '@capacitor/core';
+import { App } from '@capacitor/app'
+import { Browser } from '@capacitor/browser'
+import { Capacitor } from '@capacitor/core'
 import { CapacitorHttp } from '@capacitor/core'
 import { Dialog } from '@capacitor/dialog'
 
 // Variable which is set to an instance of ServerConnectForm.vue used below of the listener
-let serverConnectForm = null;
+let serverConnectForm = null
 
 App.addListener('appUrlOpen', async (data) => {
   // Handle the OAuth callback
@@ -105,7 +105,7 @@ App.addListener('appUrlOpen', async (data) => {
   } else {
     console.warn(`[appUrlOpen] Unknown url: ${data.url} - host: ${url.hostname} - path: ${url.pathname}`)
   }
-});
+})
 
 export default {
   data() {
@@ -178,19 +178,17 @@ export default {
         return
       }
 
-      const host = `${redirectUrl.protocol}//${redirectUrl.host}${redirectUrl.port ? ':'       + redirectUrl.port : ''}`
-      const buildUrl = `${host}${redirectUrl.pathname}?response_type=code` +
-        `&client_id=${encodeURIComponent(client_id)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}` +
-        `&redirect_uri=${encodeURIComponent('audiobookshelf://oauth')}`
+      const host = `${redirectUrl.protocol}//${redirectUrl.host}`
+      const buildUrl = `${host}${redirectUrl.pathname}?response_type=code` + `&client_id=${encodeURIComponent(client_id)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}` + `&redirect_uri=${encodeURIComponent('audiobookshelf://oauth')}`
 
       // example url for authentik
-      // const authURL = "https://authentik/application/o/authorize/?response_type=code&client_id=41cd96f...&redirect_uri=audiobookshelf%3A%2F%2Foauth&scope=openid%20openid%20email%20profile&state=asdds...";
+      // const authURL = "https://authentik/application/o/authorize/?response_type=code&client_id=41cd96f...&redirect_uri=audiobookshelf%3A%2F%2Foauth&scope=openid%20openid%20email%20profile&state=asdds..."
 
       // Open the browser. The browser/identity provider in turn will redirect to an in-app link supplementing a code
       try {
-        await Browser.open({ url: buildUrl });
+        await Browser.open({ url: buildUrl })
       } catch (error) {
-        console.error("Error opening browser", error);
+        console.error('Error opening browser', error)
       }
     },
     async oauthRequest(url) {
@@ -203,12 +201,12 @@ export default {
           url: backendEndpoint,
           disableRedirects: true,
           webFetchExtra: {
-            redirect: "manual"
-          },
+            redirect: 'manual'
+          }
         })
 
         // Depending on iOS or Android, it can be location or Location...
-        const locationHeader = response.headers[Object.keys(response.headers).find(key => key.toLowerCase() === 'location')];
+        const locationHeader = response.headers[Object.keys(response.headers).find((key) => key.toLowerCase() === 'location')]
         if (locationHeader) {
           const url = new URL(locationHeader)
           return url
@@ -217,7 +215,6 @@ export default {
           this.$toast.error(`SSO: Invalid answer`)
           return null
         }
-
       } catch (error) {
         console.log('[SSO] Error in oauthRequest: ' + error)
         this.$toast.error(`SSO error: ${error}`)
@@ -226,7 +223,7 @@ export default {
     },
     async oauthExchangeCodeForToken(code, state) {
       // We need to read the url directly from this.serverConfig.address as the callback which is called via the external browser does not pass us that info
-      const backendEndpoint = `${this.serverConfig.address}/auth/openid/callback?state=${encodeURIComponent(state)}&code=${encodeURIComponent(code)}`;
+      const backendEndpoint = `${this.serverConfig.address}/auth/openid/callback?state=${encodeURIComponent(state)}&code=${encodeURIComponent(code)}`
 
       try {
         // We can close the browser at this point (does not work on Android)
@@ -236,24 +233,23 @@ export default {
 
         const response = await CapacitorHttp.get({
           url: backendEndpoint
-        });
+        })
 
         serverConnectForm.serverConfig.token = response.data.user.token
         const payload = await serverConnectForm.authenticateToken()
 
         if (!payload) {
-          console.log('[SSO] Failed getting token: ' + this.error);
+          console.log('[SSO] Failed getting token: ' + this.error)
           this.$toast.error(`SSO error: ${this.error}`)
 
           return
         }
 
         serverConnectForm.setUserAndConnection(payload)
-
       } catch (error) {
-        console.log('[SSO] Error in exchangeCodeForToken: ' + error);
+        console.log('[SSO] Error in exchangeCodeForToken: ' + error)
         this.$toast.error(`SSO error: ${error}`)
-        return null;
+        return null
       }
     },
     addCustomHeaders() {

--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -197,10 +197,7 @@ export default {
       this.oauth.state = state
 
       const host = `https://${redirectUrl.host}`
-      const buildUrl = `${host}${redirectUrl.pathname}?response_type=code` +
-       `&client_id=${encodeURIComponent(client_id)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}` +
-       `&redirect_uri=${encodeURIComponent('audiobookshelf://oauth')}` +
-       `&code_challenge=${encodeURIComponent(this.oauth.challenge)}&code_challenge_method=S256`
+      const buildUrl = `${host}${redirectUrl.pathname}?response_type=code` + `&client_id=${encodeURIComponent(client_id)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}` + `&redirect_uri=${encodeURIComponent('audiobookshelf://oauth')}` + `&code_challenge=${encodeURIComponent(this.oauth.challenge)}&code_challenge_method=S256`
 
       // example url for authentik
       // const authURL = "https://authentik/application/o/authorize/?response_type=code&client_id=41cd96f...&redirect_uri=audiobookshelf%3A%2F%2Foauth&scope=openid%20openid%20email%20profile&state=asdds..."
@@ -225,10 +222,7 @@ export default {
       //  In accordance to RFC 7636 Section 4
       function base64URLEncode(arrayBuffer) {
         let base64String = btoa(String.fromCharCode.apply(null, new Uint8Array(arrayBuffer)))
-        return base64String
-          .replace(/\+/g, '-')
-          .replace(/\//g, '_')
-          .replace(/=+$/g, '')
+        return base64String.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
       }
 
       async function sha256(plain) {
@@ -240,7 +234,7 @@ export default {
       function generateRandomString() {
         var array = new Uint32Array(42)
         window.crypto.getRandomValues(array)
-        return Array.from(array, dec => ('0' + dec.toString(16)).slice(-2)).join('') // hex
+        return Array.from(array, (dec) => ('0' + dec.toString(16)).slice(-2)).join('') // hex
       }
 
       const verifier = generateRandomString()
@@ -249,7 +243,6 @@ export default {
 
       this.oauth.verifier = verifier
       this.oauth.challenge = challenge
-
 
       // set parameter isRest to true, so the backend wont attempt a redirect after we call backend:/callback in exchangeCodeForToken
       const backendEndpoint = `${url}auth/openid?code_challenge=${challenge}&code_challenge_method=S256&isRest=true`
@@ -346,7 +339,7 @@ export default {
         if (this.$platform === 'ios' || this.$platform === 'web') {
           await Browser.close()
         }
-      } catch(error) {} // No Error handling needed
+      } catch (error) {} // No Error handling needed
 
       try {
         const response = await CapacitorHttp.get({
@@ -362,6 +355,11 @@ export default {
 
         if (!payload) {
           throw new Error('Authentication failed with the provided token.')
+        }
+
+        const duplicateConfig = this.serverConnectionConfigs.find((scc) => scc.address === this.serverConfig.address && scc.username === payload.user.username)
+        if (duplicateConfig) {
+          throw new Error('Config already exists for this address and username.')
         }
 
         this.setUserAndConnection(payload)
@@ -640,8 +638,7 @@ export default {
         console.error(`[ServerConnectForm] Server redirected somewhere else (to ${currentAddressUrl.hostname})`)
         return false
       } // We don't allow a redirection back from https to http if the user used https:// explicitly
-      else if (protocolProvided &&
-       initialAddressWithProtocol.startsWith('https://') && currentAddressUrl.protocol === 'http') {
+      else if (protocolProvided && initialAddressWithProtocol.startsWith('https://') && currentAddressUrl.protocol === 'http') {
         this.error = `You specified https:// but the Server redirected back to plain http`
         console.error(`[ServerConnectForm] User specified https:// but server redirected to http`)
         return false
@@ -684,9 +681,11 @@ export default {
 
       if (error.code === 404) {
         this.error = `This does not seem to be an Audiobookshelf server. (Error: 404)`
-      } else if (typeof error.code === "number") { // Error with HTTP Code
+      } else if (typeof error.code === 'number') {
+        // Error with HTTP Code
         this.error = `Failed to retrieve status of server: ${error.code}`
-      } else { // error is usually a meaningful error like "Server timed out"
+      } else {
+        // error is usually a meaningful error like "Server timed out"
         this.error = `Failed to contact server. (${error})`
       }
     },
@@ -712,8 +711,8 @@ export default {
         // We only retry when the user did not specify a protocol
         // Also for security reasons, we only retry when the https request did not
         //      return a http status code (so only retry when the TCP connection could not be established)
-        if (shouldRetryWithHttp && (typeof error.code !== "number")) {
-          console.log("[ServerConnectForm] https failed, trying to connect with http...")
+        if (shouldRetryWithHttp && typeof error.code !== 'number') {
+          console.log('[ServerConnectForm] https failed, trying to connect with http...')
           const validatedHttpUrl = this.validateServerUrl(address, 'http:')
           if (validatedHttpUrl) {
             return await this.getServerAddressStatus(validatedHttpUrl)
@@ -731,9 +730,7 @@ export default {
      * @returns {string} The address with a protocol prepended if it was missing.
      */
     prependProtocolIfNeeded(address) {
-      return address.startsWith('http://') || address.startsWith('https://')
-        ? address
-        : `https://${address}`
+      return address.startsWith('http://') || address.startsWith('https://') ? address : `https://${address}`
     },
     /**
      * Compares two semantic versioning strings to determine if the current version meets

--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -51,8 +51,8 @@
               <ui-btn :disabled="processing || !networkConnected" type="submit" class="mt-1 h-10">{{ networkConnected ? 'Submit' : 'No Internet' }}</ui-btn>
             </div>
           </form>
-          <div v-if="isLocalAuthEnabled && isOpenIDAuthEnabled" class="w-full h-px bg-white bg-opacity-10 my-2" />
-          <ui-btn v-if="isOpenIDAuthEnabled" :disabled="processing" class="mt-1 h-10" @click="clickLoginWithOpenId">{{ oauth.buttonText }}</ui-btn>
+          <div v-if="isLocalAuthEnabled && isOpenIDAuthEnabled" class="w-full h-px bg-white bg-opacity-10 my-4" />
+          <ui-btn v-if="isOpenIDAuthEnabled" :disabled="processing" class="h-10 w-full" @click="clickLoginWithOpenId">{{ oauth.buttonText }}</ui-btn>
         </template>
       </div>
 

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.audiobookshelf.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>audiobookshelf</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -11,8 +11,8 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
-  pod 'ByteowlsCapacitorOauth2', :path => '../../node_modules/@byteowls/capacitor-oauth2'
   pod 'CapacitorApp', :path => '../../node_modules/@capacitor/app'
+  pod 'CapacitorBrowser', :path => '../../node_modules/@capacitor/browser'
   pod 'CapacitorClipboard', :path => '../../node_modules/@capacitor/clipboard'
   pod 'CapacitorDialog', :path => '../../node_modules/@capacitor/dialog'
   pod 'CapacitorHaptics', :path => '../../node_modules/@capacitor/haptics'

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -1,23 +1,25 @@
 PODS:
   - Alamofire (5.6.4)
-  - Capacitor (4.8.0):
+  - Capacitor (5.4.0):
     - CapacitorCordova
-  - CapacitorApp (4.1.1):
+  - CapacitorApp (5.0.6):
     - Capacitor
-  - CapacitorClipboard (4.1.0):
+  - CapacitorBrowser (5.1.0):
     - Capacitor
-  - CapacitorCordova (4.8.0)
-  - CapacitorDialog (4.1.0):
+  - CapacitorClipboard (5.0.6):
     - Capacitor
-  - CapacitorHaptics (4.1.0):
+  - CapacitorCordova (5.4.0)
+  - CapacitorDialog (5.0.6):
     - Capacitor
-  - CapacitorNetwork (4.1.0):
+  - CapacitorHaptics (5.0.6):
     - Capacitor
-  - CapacitorPreferences (4.0.2):
+  - CapacitorNetwork (5.0.6):
     - Capacitor
-  - CapacitorStatusBar (4.1.1):
+  - CapacitorPreferences (5.0.6):
     - Capacitor
-  - CordovaPlugins (4.8.0):
+  - CapacitorStatusBar (5.0.6):
+    - Capacitor
+  - CordovaPlugins (5.4.0):
     - CapacitorCordova
   - Realm (10.36.0):
     - Realm/Headers (= 10.36.0)
@@ -29,6 +31,7 @@ DEPENDENCIES:
   - Alamofire (~> 5.5)
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorApp (from `../../node_modules/@capacitor/app`)"
+  - "CapacitorBrowser (from `../../node_modules/@capacitor/browser`)"
   - "CapacitorClipboard (from `../../node_modules/@capacitor/clipboard`)"
   - "CapacitorCordova (from `../../node_modules/@capacitor/ios`)"
   - "CapacitorDialog (from `../../node_modules/@capacitor/dialog`)"
@@ -50,6 +53,8 @@ EXTERNAL SOURCES:
     :path: "../../node_modules/@capacitor/ios"
   CapacitorApp:
     :path: "../../node_modules/@capacitor/app"
+  CapacitorBrowser:
+    :path: "../../node_modules/@capacitor/browser"
   CapacitorClipboard:
     :path: "../../node_modules/@capacitor/clipboard"
   CapacitorCordova:
@@ -69,19 +74,20 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: 4e95d97098eacb88856099c4fc79b526a299e48c
-  Capacitor: 6002aadd64492438e5242325025045235dcb7e84
-  CapacitorApp: acd42fe8561fe751ad5b5f459aa85e6acd7bee24
-  CapacitorClipboard: 4c092a2608520afb799429e63820256c3a59f1e5
-  CapacitorCordova: c6249dcb2cf04dd835c0e99df1df4b9c8ad997e2
-  CapacitorDialog: c8a6558d29767e76a32a056bb5e0fc9104b985b0
-  CapacitorHaptics: 213b3a1f3efd6dbf6e6b76a1b2bb0399cf43b213
-  CapacitorNetwork: 7126b3d2d23ca60d5ac0d8d2ecccfab0b1f305c6
-  CapacitorPreferences: 1d66dc32299f55ed632c5611f312878979275ea5
-  CapacitorStatusBar: 65933e554bb5d65b361deaa936a93616086a2608
-  CordovaPlugins: b7ac282a1681fad663e14dcbe719249f738b88ce
+  Capacitor: a5cd803e02b471591c81165f400ace01f40b11d3
+  CapacitorApp: 024e1b1bea5f883d79f6330d309bc441c88ad04a
+  CapacitorBrowser: 7a0fb6a1011abfaaf2dfedfd8248f942a8eda3d6
+  CapacitorClipboard: 77edf49827ea21da2a9c05c690a4a6a4d07199c4
+  CapacitorCordova: 66ce22f9976de30fd816f746e9e92e07d6befafd
+  CapacitorDialog: 0f3c15dfe9414b83bc64aef4078f1b92bcfead26
+  CapacitorHaptics: 1fffc1217c7e64a472d7845be50fb0c2f7d4204c
+  CapacitorNetwork: d80b3e79bef6ec37640ee2806c19771f07ff2d0c
+  CapacitorPreferences: f03954bcb0ff09c792909e46bff88e3183c16b10
+  CapacitorStatusBar: 565c0a1ebd79bb40d797606a8992b4a105885309
+  CordovaPlugins: a5db67e5ac1061b9869a0efd754f2c2f776aeccc
   Realm: 3fd136cb4c83a927482a7f1612496d37beed3cf5
   RealmSwift: 513d4dcbf5bfc4d573454088b592685fc48dd716
 
-PODFILE CHECKSUM: 05c80969578f3260e71d903c6ddb969847bcceb2
+PODFILE CHECKSUM: 7a8fc177ef0646dd60a1ee8aa387964975fcc1e3
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.12.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "audiobookshelf-app",
       "version": "0.9.66-beta",
       "dependencies": {
-        "@byteowls/capacitor-oauth2": "^5.0.0",
         "@capacitor/android": "^5.0.0",
-        "@capacitor/app": "^5.0.0",
+        "@capacitor/app": "^5.0.6",
+        "@capacitor/browser": "^5.1.0",
         "@capacitor/clipboard": "^5.0.0",
         "@capacitor/core": "^5.0.0",
         "@capacitor/dialog": "^5.0.0",
@@ -1939,14 +1939,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@byteowls/capacitor-oauth2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@byteowls/capacitor-oauth2/-/capacitor-oauth2-5.0.0.tgz",
-      "integrity": "sha512-yW50GypmyPJcH/95NwR2jJcgT78vBN3FYKL2w6A3vrT04bRLQyw2K0fLqfj8Zws6DJy43Ck1wPs0Bcdvbsub7A==",
-      "peerDependencies": {
-        "@capacitor/core": ">=5"
-      }
-    },
     "node_modules/@capacitor/android": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-5.4.0.tgz",
@@ -1959,6 +1951,14 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-5.0.6.tgz",
       "integrity": "sha512-6ZXVdnNmaYILasC/RjQw+yfTmq2ZO7Q3v5lFcDVfq3PFGnybyYQh+RstBrYri+376OmXOXxBD7E6UxBhrMzXGA==",
+      "peerDependencies": {
+        "@capacitor/core": "^5.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-5.1.0.tgz",
+      "integrity": "sha512-7togqchk2Tvq4SmLaWhcrd4x48ES/GEZsceM+29aun7WhxQEVcDU0cJsVdSU2LNFwNhWgPV2GW90etVd1B3OdQ==",
       "peerDependencies": {
         "@capacitor/core": "^5.0.0"
       }
@@ -21078,12 +21078,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@byteowls/capacitor-oauth2": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@byteowls/capacitor-oauth2/-/capacitor-oauth2-5.0.0.tgz",
-      "integrity": "sha512-yW50GypmyPJcH/95NwR2jJcgT78vBN3FYKL2w6A3vrT04bRLQyw2K0fLqfj8Zws6DJy43Ck1wPs0Bcdvbsub7A==",
-      "requires": {}
-    },
     "@capacitor/android": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-5.4.0.tgz",
@@ -21094,6 +21088,12 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-5.0.6.tgz",
       "integrity": "sha512-6ZXVdnNmaYILasC/RjQw+yfTmq2ZO7Q3v5lFcDVfq3PFGnybyYQh+RstBrYri+376OmXOXxBD7E6UxBhrMzXGA==",
+      "requires": {}
+    },
+    "@capacitor/browser": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-5.1.0.tgz",
+      "integrity": "sha512-7togqchk2Tvq4SmLaWhcrd4x48ES/GEZsceM+29aun7WhxQEVcDU0cJsVdSU2LNFwNhWgPV2GW90etVd1B3OdQ==",
       "requires": {}
     },
     "@capacitor/cli": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "ionic:serve": "npm run start"
   },
   "dependencies": {
-    "@byteowls/capacitor-oauth2": "^5.0.0",
     "@capacitor/android": "^5.0.0",
-    "@capacitor/app": "^5.0.0",
+    "@capacitor/app": "^5.0.6",
+    "@capacitor/browser": "^5.1.0",
     "@capacitor/clipboard": "^5.0.0",
     "@capacitor/core": "^5.0.0",
     "@capacitor/dialog": "^5.0.0",

--- a/plugins/init.client.js
+++ b/plugins/init.client.js
@@ -282,6 +282,14 @@ export default ({ store, app }, inject) => {
       window.history.back()
     }
   })
+
+  /**
+   * @see https://capacitorjs.com/docs/apis/app#addlistenerappurlopen-
+   * Listen for url open events for the app. This handles both custom URL scheme links as well as URLs your app handles
+   */
+  App.addListener('appUrlOpen', (data) => {
+    eventBus.$emit('url-open', data.url)
+  })
 }
 
 export {


### PR DESCRIPTION
This PR Provides oauth2 support

It works out-of-the-box with the current changes in https://github.com/advplyr/audiobookshelf/pull/1636

* Fully works on iOS and Android
* ~~Should work on Android, too. But needs testing (I dont have an dev env for that)~~ (Testing done successfully)
* It should - in theory - also work with Google and co, but needs testing. If there is a error I would check if the callback URLs are correct as first step

It works this way:
1. oauthRequest
    * API request to `audio.example.com/auth/openid`
    * This will try to redirect to the idp/authentik. Instead of redirecting Im catching it and open this link in a browser. Also Im patching the redirect_uri parameter to `&redirect_uri=audiobookshelf://oauth` 
    * Also what its very important (and required by passport - oauth only requires it as GET parameter instead in a Session), it will generate a state variable and also save it into a Cookie. This Cookie needs to be sent in the request later to `audio.example.com/auth/openid/callback`. Saving the Cookie is automatically done with `CapacitorHttp.get` as it uses a native function, it won't work in any case with `fetch` or `axios`
2. Browser.Open
    * This is the redirect to Authentik, sending also the openid parameters and additionally the same state variable from above. The user logs in. In any case authentik will then redirect to audiobookshelf://oauth and pass along a code and state parameter via GET parameters
    * Cookies are not required to be saved or passed (oauth works completely without session but just GET parameters)
3. audiobookshelf://oauth
    * This link will send a message to the app including state and code variable generated by Authentik
4. oauthExchangeCodeForToken
    * This calls `audio.example.com/auth/openid/callback` with the state and the code (and the cookie from the first request bc of passport)
    * Browser is closed
    * Token is returned and then handled like with user/pass login

Error handling is also done:
* this.showAuth = true is not required to be set on error I noticed
* My error handling might not be consistent with the existing code and the toasts might need translation
* The error handling in the backend is currently not sufficient. On a state error the message will be just forbidden without any logs (will post details in the other PR). Can be important when you test google integration or so


I used `App.addListener` on top in `ServerConnectForm.vue`. I'm not really familiar with Vue so I saved the `this` pointer of the component simply in the variable `serverConnectForm`. Maybe there is a better way. Also in the function I catched for other not implemented URLs, given that the function can be called multiple times this catch might not make sense at this point (so probably either  the `else` should be removed or the function should be centrally moved somewhere else in a routing file).

