### PR TITLE
Add togglePlayPauseCommand route to iOS

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -583,12 +583,31 @@ class AudioPlayer: NSObject {
         
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { [weak self] event in
-            self?.play(allowSeekBack: true)
+            if (self!.isPlaying()) {
+                self?.pause()
+            } else {
+                self?.play(allowSeekBack: true)
+            }
             return .success
         }
+
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { [weak self] event in
-            self?.pause()
+            if (self!.isPlaying()) {
+                self?.pause()
+            } else {
+                self?.play(allowSeekBack: true)
+            }
+            return .success
+        }
+
+        commandCenter.togglePlayPauseCommand.isEnabled = true
+        commandCenter.togglePlayPauseCommand.addTarget { [weak self] event in
+            if (self!.isPlaying()) {
+                self?.pause()
+            } else {
+                self?.play(allowSeekBack: true)
+            }
             return .success
         }
         


### PR DESCRIPTION
This is just the code from the comments of #622—credit to @KaiStarkk! I ran it on my device and it seems to be working normally, though I don't have old enough headphones to test the actual toggle route. Though if you sideload the APK this PR generates, you might be able to do so. Should, in all theory, work.