### PR TITLE
[Fix] Prevent crash from force unwrapping nil value in PR-1005

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -583,30 +583,33 @@ class AudioPlayer: NSObject {
         
         commandCenter.playCommand.isEnabled = true
         commandCenter.playCommand.addTarget { [weak self] event in
-            if (self!.isPlaying()) {
-                self?.pause()
+            guard let strongSelf = self else { return .commandFailed }
+            if strongSelf.isPlaying() {
+                strongSelf.pause()
             } else {
-                self?.play(allowSeekBack: true)
+                strongSelf.play(allowSeekBack: true)
             }
             return .success
         }
 
         commandCenter.pauseCommand.isEnabled = true
         commandCenter.pauseCommand.addTarget { [weak self] event in
-            if (self!.isPlaying()) {
-                self?.pause()
+            guard let strongSelf = self else { return .commandFailed }
+            if strongSelf.isPlaying() {
+                strongSelf.pause()
             } else {
-                self?.play(allowSeekBack: true)
+                strongSelf.play(allowSeekBack: true)
             }
             return .success
         }
 
         commandCenter.togglePlayPauseCommand.isEnabled = true
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] event in
-            if (self!.isPlaying()) {
-                self?.pause()
+            guard let strongSelf = self else { return .commandFailed }
+            if strongSelf.isPlaying() {
+                strongSelf.pause()
             } else {
-                self?.play(allowSeekBack: true)
+                strongSelf.play(allowSeekBack: true)
             }
             return .success
         }


### PR DESCRIPTION
In further testing I found a rare case where `self` was not initialized when force unwrapping in the player, causing a runtime crash.
This is now fixed, first `self `is captured weakly using `guard let`, to avoid a strong reference cycle, and then safely unwrapped to a `strongSelf `constant. If `self `is `nil `when the closure is called, it will return `.commandFailed `and exit the closure, avoiding a crash. If `self `is not nil, it will proceed as per PR #1005.

Wasn't expecting self to ever be cleaned up by the memory manager, but it appears it's possible.
[Referenced info on ARC](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/automaticreferencecounting/)
