### PR TITLE
feat: Add Time Marker Detection in Episode Descriptions

### DIFF
--- a/pages/item/_id/_episode/index.vue
+++ b/pages/item/_id/_episode/index.vue
@@ -314,21 +314,20 @@ export default {
   },
   methods: {
     parseDescription(description) {
-      const timeMarkerRegex = /\d{1,2}:\d{1,2}(:\d{1,2})?/g
+      const timeMarkerLinkRegex = /<a href="#([^"]*?\b\d{1,2}:\d{1,2}(?::\d{1,2})?)">(.*?)<\/a>/g
+      const timeMarkerRegex = /\b\d{1,2}:\d{1,2}(?::\d{1,2})?\b/g
 
-      return description.replace(timeMarkerRegex, (match) => {
-        const time = match.replace(/[()]/g, '')
+      function convertToSeconds(time) {
         const timeParts = time.split(':').map(Number)
-        let seekTimeInSeconds
+        return timeParts.reduce((acc, part, index) => acc * 60 + part, 0)
+      }
 
-        if (timeParts.length === 2) {
-          const [minutes, seconds] = timeParts
-          seekTimeInSeconds = minutes * 60 + seconds
-        } else {
-          const [hours, minutes, seconds] = timeParts
-          seekTimeInSeconds = hours * 3600 + minutes * 60 + seconds
-        }
-
+      return description.replace(timeMarkerLinkRegex, (match, href, displayTime) => {
+        const time = displayTime.match(timeMarkerRegex)[0]
+        const seekTimeInSeconds = convertToSeconds(time)
+        return `<span class="time-marker cursor-pointer text-blue-400 hover:text-blue-300" data-time="${seekTimeInSeconds}">${displayTime}</span>`
+      }).replace(timeMarkerRegex, (match) => {
+        const seekTimeInSeconds = convertToSeconds(match)
         return `<span class="time-marker cursor-pointer text-blue-400 hover:text-blue-300" data-time="${seekTimeInSeconds}">${match}</span>`
       })
     },


### PR DESCRIPTION
Here's the corrected text for your pull request:

Several podcast apps, such as Overcast and Pocket Cast, have a feature that detects Time Markers in the episode description. This feature provides a way to jump directly to that time. It's very similar to chapters, but the time markers aren't embedded in the files; they are automatically detected from the description.

<img width="385" alt="Screenshot 2024-05-19 at 14 23 50" src="https://github.com/advplyr/audiobookshelf-app/assets/814828/609d35f0-defd-48c6-81e5-c5d260a393ab">


This PR adds support for detecting time markers in the AudioBookShelf app as well.

<img width="400" alt="image" src="https://github.com/advplyr/audiobookshelf-app/assets/814828/a96ea856-3011-468d-9bc1-99302716c1c9">


The detector identifies time markers in multiple formats (at least minutes and seconds):

```
H:M:SS
H:MM:SS
HH:MM:SS
H:M:SS
```

----

Demo


https://github.com/advplyr/audiobookshelf-app/assets/814828/431ea9b9-2a5f-4b09-aac8-29dc4349c31b

