### PR TITLE
Fix Android Large Download Failure

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -70,13 +70,10 @@ class BinaryFileWriter(outputStream: OutputStream,
       val dataBuffer = ByteArray(CHUNK_SIZE)
       var readBytes: Int
       var totalBytes: Long = initialBytesWritten
-      var i: Int = 0;
       try {
         while (input.read(dataBuffer).also { readBytes = it } != -1) {
           totalBytes += readBytes.toLong()
           outputStream.write(dataBuffer, 0, readBytes)
-          i++;
-          if(i%1000==0) Log.d("Writer","Progress Info: $totalBytes")
           progressCallback.onProgress(totalBytes, (totalBytes * 100L) / length)
         }
         progressCallback.onComplete(false)

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -12,7 +12,7 @@ class InternalDownloadManager(private val file:File, private val progressCallbac
   private val maxRetries: Int = 10  //Not sure what number this should be.  But at least 5
 
   @Throws(IOException::class)
-  fun download(url:String, retryCount: Int=0, initialBytesWritten: Long = 0) {
+  fun download(url:String, retryCount: Int=0) {
     val existingFileSize: Long = if(file.exists())  file.length() else 0;
     val request: Request = Request.Builder()
       .url(url)
@@ -40,7 +40,7 @@ class InternalDownloadManager(private val file:File, private val progressCallbac
 
         } catch(e:IOException){
           Log.e(tag,"Error Writing, Trying again... $retryCount: ${e.message}")
-          if(retryCount<maxRetries) download(url, retryCount+1, existingFileSize)
+          if(retryCount<maxRetries) download(url, retryCount+1)
           else progressCallback.onComplete(true)
         }
 


### PR DESCRIPTION
The updated InternalDownloadManger takes in the downloaded file as the parameter.  This way if it exits, it will use it's byte length as the starting Range parameter for the remaining download.  