### PR TITLE
Update i18n workflow to 1.3.0

### DIFF
--- a/.github/workflows/i18n-check.yml
+++ b/.github/workflows/i18n-check.yml
@@ -19,10 +19,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20'
-    
+
     # The only argument is the `directory`, which is where the i18n files are
     # stored.
     - name: Run Update JSON Files action
-      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.2.0
+      uses: audiobookshelf/audiobookshelf-i18n-updater@v1.3.0
       with:
         directory: 'strings/'  # Adjust the directory path as needed


### PR DESCRIPTION
This PR updates the localization workflow to `1.3.0`. This version removes the unused copying of keys to speed up the workflow, and changes the alphabetical check to be case sensitive to conform to Weblate.