### PR TITLE
Connection form "Enter" to submit instead of delete

### DIFF
--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -44,10 +44,11 @@
             <ui-text-input v-model="serverConfig.username" :disabled="processing" :placeholder="$strings.LabelUsername" class="w-full mb-2 text-lg" />
             <ui-text-input v-model="password" type="password" :disabled="processing" :placeholder="$strings.LabelPassword" class="w-full mb-2 text-lg" />
 
-            <div class="flex items-center pt-2">
-              <ui-icon-btn v-if="serverConfig.id" small bg-color="error" icon="delete" @click="removeServerConfigClick" />
-              <div class="flex-grow" />
+            <!-- Display the buttons reversed so pressing Enter targets the submit button -->
+            <div class="flex flex-row-reverse items-center pt-2">
               <ui-btn :disabled="processing || !networkConnected" type="submit" class="mt-1 h-10">{{ networkConnected ? $strings.ButtonSubmit : $strings.MessageNoNetworkConnection }}</ui-btn>
+              <div class="flex-grow" />
+              <ui-icon-btn v-if="serverConfig.id" small bg-color="error" icon="delete" @click="removeServerConfigClick" />
             </div>
           </form>
           <div v-if="isLocalAuthEnabled && isOpenIDAuthEnabled" class="w-full h-px bg-fg/10 my-4" />


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf-app/issues/1158

This PR switches the order of the "delete" and "submit" buttons for editing a server connection, then uses `flex-row-reverse` to keep the UI looking the same.
Pressing "enter" while being focused on the password field now submits and attempts a connection instead of trying to delete the server config.

Tested on Android, Pixel 6a.