### PR TITLE
split groups of save history items that have different status results

### DIFF
--- a/pages/media/_id/history.vue
+++ b/pages/media/_id/history.vue
@@ -71,6 +71,7 @@ export default {
       let lastKey = null
       let numSaves = 0
       let numSyncs = 0
+      let lastSaveName = null
 
       this.mediaEvents.forEach((evt) => {
         const date = this.$formatDate(evt.timestamp, 'MMM dd, yyyy')
@@ -90,7 +91,8 @@ export default {
 
         // Collapse saves
         if (evt.name === 'Save') {
-          if (numSaves > 0 && !keyUpdated) {
+          let saveName = evt.name + "-" + evt.serverSyncAttempted + "-" + evt.serverSyncSuccess
+          if (lastSaveName === saveName && numSaves > 0 && !keyUpdated) {
             include = false
             const totalInGroup = groups[key].length
             groups[key][totalInGroup - 1].num = numSaves
@@ -98,6 +100,7 @@ export default {
           } else {
             numSaves = 1
           }
+          lastSaveName = saveName
         } else {
           numSaves = 0
         }


### PR DESCRIPTION
Simple change to split groups of save history items when the status for items in a group changes.

I noticed that the status (icon) was only showing for the first item in a group, if there were say 150 saves and the last 30 failed then it would still show success.

Example of the changes:

![image](https://github.com/user-attachments/assets/3346091d-4eaa-4a11-a8b5-75c3e45257e9)
