### PR TITLE
Optimize notification bar display

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -315,11 +315,14 @@ class PlayerNotificationService : MediaBrowserServiceCompat()  {
         }
 
         val extra = Bundle()
-        extra.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, currentPlaybackSession!!.displayAuthor)
+        extra.putString(
+          MediaMetadataCompat.METADATA_KEY_ARTIST,
+          currentPlaybackSession!!.displayAuthor + " | " + currentPlaybackSession!!.displayTitle
+        )
 
         val mediaDescriptionBuilder = MediaDescriptionCompat.Builder()
           .setExtras(extra)
-          .setTitle(currentPlaybackSession!!.displayTitle)
+          .setTitle(getCurrentBookChapter()?.title)
           .setIconUri(coverUri)
 
         bitmap?.let {
@@ -493,8 +496,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat()  {
     val mediaItems = playbackSession.getMediaItems(ctx)
     val customActionProviders = mutableListOf(
       JumpBackwardCustomActionProvider(),
-      JumpForwardCustomActionProvider(),
-      ChangePlaybackSpeedCustomActionProvider() // Will be pushed to far left
+      JumpForwardCustomActionProvider()
+      // ChangePlaybackSpeedCustomActionProvider() // Will be pushed to far left
     )
     if (playbackSession.mediaPlayer != PLAYER_CAST && mediaItems.size > 1) {
       customActionProviders.addAll(listOf(


### PR DESCRIPTION
Optimize notification bar display
1. Change the main title to the title of the currently playing chapter
2. Combine the author and main title for display
3. Rearrange buttons (remove speed adjustment button)

![0e2fbf3ebfbef116f06c0ba2328288e](https://github.com/user-attachments/assets/fed0b1f0-e54e-47f0-abf3-6c6fce31a6e2)
