### PR TITLE
Do not call setIconBitmap instead of setIconUri if book is local

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -320,7 +320,6 @@ class PlayerNotificationService : MediaBrowserServiceCompat()  {
         val mediaDescriptionBuilder = MediaDescriptionCompat.Builder()
           .setExtras(extra)
           .setTitle(currentPlaybackSession!!.displayTitle)
-//          .setIconUri(coverUri)
 
         bitmap?.let {
           mediaDescriptionBuilder.setIconBitmap(it)

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -320,11 +320,11 @@ class PlayerNotificationService : MediaBrowserServiceCompat()  {
         val mediaDescriptionBuilder = MediaDescriptionCompat.Builder()
           .setExtras(extra)
           .setTitle(currentPlaybackSession!!.displayTitle)
-          .setIconUri(coverUri)
+//          .setIconUri(coverUri)
 
         bitmap?.let {
           mediaDescriptionBuilder.setIconBitmap(it)
-        }
+        } ?: mediaDescriptionBuilder.setIconUri(coverUri)
 
         return mediaDescriptionBuilder.build()
       }


### PR DESCRIPTION
Addressing issue #141

Call setIconBitmap instead of setIconUri if book is local (bitmap is not null)