### PR TITLE
Support servers with subdirectory

### DIFF
--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -486,9 +486,8 @@ export default {
     validateServerUrl(url, protocolOverride = null) {
       try {
         var urlObject = new URL(url)
-        var address = `${protocolOverride ? protocolOverride : urlObject.protocol}//${urlObject.hostname}`
-        if (urlObject.port) address += ':' + urlObject.port
-        return address
+        if (protocolOverride) urlObject.protocol = protocolOverride
+        return urlObject.href
       } catch (error) {
         console.error('Invalid URL', error)
         return null

--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -21,7 +21,10 @@ class AbsAudioPlayerWeb extends WebPlugin {
 
   // Use startTime to find current track index
   get currentTrackIndex() {
-    return Math.max(0, this.audioTracks.findIndex(t => Math.floor(t.startOffset) <= this.startTime && Math.floor(t.startOffset + t.duration) > this.startTime))
+    return Math.max(
+      0,
+      this.audioTracks.findIndex((t) => Math.floor(t.startOffset) <= this.startTime && Math.floor(t.startOffset + t.duration) > this.startTime)
+    )
   }
   get currentTrack() {
     return this.audioTracks[this.currentTrackIndex]
@@ -37,7 +40,7 @@ class AbsAudioPlayerWeb extends WebPlugin {
   }
   get totalDuration() {
     var total = 0
-    this.audioTracks.forEach(at => total += at.duration)
+    this.audioTracks.forEach((at) => (total += at.duration))
     return total
   }
   get playerPlaying() {
@@ -194,7 +197,8 @@ class AbsAudioPlayerWeb extends WebPlugin {
     // var lastBufferTime = this.getLastBufferedTime()
   }
   evtEnded() {
-    if (this.currentTrackIndex < this.audioTracks.length - 1) { // Has next track
+    if (this.currentTrackIndex < this.audioTracks.length - 1) {
+      // Has next track
       console.log(`[AbsAudioPlayer] Track ended - loading next track ${this.currentTrackIndex + 1}`)
       var nextTrack = this.audioTracks[this.currentTrackIndex + 1]
       this.playWhenReady = true
@@ -221,7 +225,7 @@ class AbsAudioPlayerWeb extends WebPlugin {
       this.player.play()
     }
   }
-  evtTimeupdate() { }
+  evtTimeupdate() {}
 
   sendPlaybackMetadata(playerState) {
     this.notifyListeners('onMetadata', {
@@ -235,7 +239,9 @@ class AbsAudioPlayerWeb extends WebPlugin {
     if (!this.currentTrack) return
     // When direct play track is loaded current time needs to be set
     this.trackStartTime = Math.max(0, this.startTime - (this.currentTrack.startOffset || 0))
-    this.player.src = `${vuexStore.getters['user/getServerAddress']}${this.currentTrack.contentUrl}?token=${vuexStore.getters['user/getToken']}`
+    const serverAddressUrl = new URL(vuexStore.getters['user/getServerAddress'])
+    const serverHost = `${serverAddressUrl.protocol}//${serverAddressUrl.host}`
+    this.player.src = `${serverHost}${this.currentTrack.contentUrl}?token=${vuexStore.getters['user/getToken']}`
     console.log(`[AbsAudioPlayer] Loading track src ${this.player.src}`)
     this.player.load()
     this.player.playbackRate = this.playbackRate

--- a/plugins/server.js
+++ b/plugins/server.js
@@ -26,14 +26,19 @@ class ServerSocket extends EventEmitter {
     this.serverAddress = serverAddress
     this.token = token
 
-    console.log('[SOCKET] Connect Socket', this.serverAddress)
+    const serverUrl = new URL(serverAddress)
+    const serverHost = `${serverUrl.protocol}//${serverUrl.host}`
+    const serverPath = serverUrl.pathname === '/' ? '' : serverUrl.pathname
+
+    console.log(`[SOCKET] Connecting to ${serverHost} with path ${serverPath}/socket.io`)
 
     const socketOptions = {
       transports: ['websocket'],
       upgrade: false,
+      path: `${serverPath}/socket.io`
       // reconnectionAttempts: 3
     }
-    this.socket = io(this.serverAddress, socketOptions)
+    this.socket = io(serverHost, socketOptions)
     this.setSocketListeners()
   }
 

--- a/store/globals.js
+++ b/store/globals.js
@@ -69,7 +69,7 @@ export const getters = {
       // return `http://localhost:3333/api/items/${libraryItem.id}/cover?token=${userToken}&ts=${lastUpdate}`
     }
 
-    const url = new URL(`/api/items/${libraryItem.id}/cover`, serverAddress)
+    const url = new URL(`${serverAddress}/api/items/${libraryItem.id}/cover`)
     return `${url}?token=${userToken}&ts=${lastUpdate}${raw ? '&raw=1' : ''}`
   },
   getLibraryItemCoverSrcById: (state, getters, rootState, rootGetters) => (libraryItemId, placeholder = null) => {
@@ -79,7 +79,7 @@ export const getters = {
     const serverAddress = rootGetters['user/getServerAddress']
     if (!userToken || !serverAddress) return placeholder
 
-    const url = new URL(`/api/items/${libraryItemId}/cover`, serverAddress)
+    const url = new URL(`${serverAddress}/api/items/${libraryItemId}/cover`)
     return `${url}?token=${userToken}`
   },
   getLocalMediaProgressById: (state) => (localLibraryItemId, episodeId = null) => {


### PR DESCRIPTION
This adds support for connecting to servers with subdirectory, e.g. `https://my.server.com/audiobookself`.

This is the last step in preparing for subdirectory support, based on [the proposed plan](https://github.com/advplyr/audiobookshelf/discussions/3535).

The required changes include:
- Allow paths when specifying the server address in the Connect form
- Fix `this.player.src` in `AbsAudioPlayer.js` (all other changes in this file are due to formatting)
- Connect to the correct WebSocket path
- Fix `getLibraryItemCoverSrc` and `getLibraryItemCoverSrcById` in `globals.js`

I tested this using the web client, as well as on my Android phone against a server running with `RouterBasePath=/audiobookshelf` (which should support both subdirectory and non-subdirectory access). 
- I connected using the standard non-subdirectory address, and made sure everything was working
- I then connected using the subdirectory address, and made sure everything was working.

I _did not_ test on iOS, as I don't have an IOS dev environement nor an iOS phone to test on.