### PR TITLE
Sensible default sort for podcasts

### DIFF
--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -278,6 +278,7 @@ export default {
       return this.$store.getters['user/getUserMediaProgress'](this.libraryItemId, episode.id)
     },
     init() {
+      this.sortDesc = this.mediaMetadata.type === 'episodic'
       this.episodesCopy = this.episodes.map((ep) => {
         return { ...ep }
       })


### PR DESCRIPTION
[Industry convention](https://help.simplecast.com/hc/en-us/articles/21953604877213-The-Difference-Between-Serial-and-Episodic-Podcasts) is that "The serial format arranges podcast episodes from oldest-to-newest". This one-line change sets the default sort for podcast episode list to _Pub Date (Ascending)_ instead of _Pub Date (Descending)_ if the podcast is of type `serial`.