### PR TITLE
Build apk workflow update

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -13,41 +13,41 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout sources
-      uses: actions/checkout@v3
+      - name: checkout sources
+        uses: actions/checkout@v3
 
-    - name: use Node.js 20.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 20
+      - name: use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
 
-    - name: Set up Java
-      uses: actions/setup-java@v2
-      with:
-        distribution: "temurin"
-        java-version: 17
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
 
-    - name: install dependencies
-      run: npm ci
+      - name: install dependencies
+        run: npm ci
 
-    - name: build Nuxt project
-      run: npm run generate
+      - name: build Nuxt project
+        run: npm run generate
 
-    - name: copy to Android project
-      run: npx cap sync
+      - name: copy to Android project
+        run: npx cap sync
 
-    - name: build Android app
-      run: ./android/gradlew assembleDebug -p android --no-daemon
+      - name: build Android app
+        run: ./android/gradlew assembleDebug -p android --no-daemon
 
-    - name: rename apk
-      working-directory: android/app/build/outputs/apk/debug/
-      run: |
-        build="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
-        name="audiobookshelf-${build}.apk"
-        mv -v app-debug.apk "${name}"
+      - name: rename apk
+        working-directory: android/app/build/outputs/apk/debug/
+        run: |
+          build="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
+          name="audiobookshelf-${build}.apk"
+          mv -v app-debug.apk "${name}"
 
-    - name: upload app
-      uses: actions/upload-artifact@v3
-      with:
-        name: audiobookshelf-apk
-        path: android/app/build/outputs/apk/debug/*.apk
+      - name: upload app
+        uses: actions/upload-artifact@v4
+        with:
+          name: audiobookshelf-apk
+          path: android/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -12,57 +12,57 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout sources
-      uses: actions/checkout@v3
+      - name: checkout sources
+        uses: actions/checkout@v3
 
-    - name: use Node.js 20.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: 20
+      - name: use Node.js 20.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
 
-    - name: Set up Java
-      uses: actions/setup-java@v2
-      with:
-        distribution: "temurin"
-        java-version: 17
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
 
-    - name: install dependencies
-      run: npm ci
+      - name: install dependencies
+        run: npm ci
 
-    - name: build Nuxt project
-      run: npm run generate
+      - name: build Nuxt project
+        run: npm run generate
 
-    - name: copy to Android project
-      run: npx cap sync
+      - name: copy to Android project
+        run: npx cap sync
 
-    - name: build Android app
-      run: ./android/gradlew assembleDebug -p android --no-daemon
+      - name: build Android app
+        run: ./android/gradlew assembleDebug -p android --no-daemon
 
-    - name: rename apk
-      working-directory: android/app/build/outputs/apk/debug/
-      run: |
-        build="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
-        name="audiobookshelf-${build}.apk"
-        mv -v app-debug.apk "${name}"
+      - name: rename apk
+        working-directory: android/app/build/outputs/apk/debug/
+        run: |
+          build="$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
+          name="audiobookshelf-${build}.apk"
+          mv -v app-debug.apk "${name}"
 
-    - name: prepare test page ressources
-      run: |
-        mkdir ghpages
-        cp android/app/build/outputs/apk/debug/*apk ghpages/
-        cp static/Logo.png ghpages/logo.png
-        cp .github/testing-page-template.html ghpages/index.html
+      - name: prepare test page ressources
+        run: |
+          mkdir ghpages
+          cp android/app/build/outputs/apk/debug/*apk ghpages/
+          cp static/Logo.png ghpages/logo.png
+          cp .github/testing-page-template.html ghpages/index.html
 
-    - name: build test page
-      working-directory: ghpages
-      run: |
-        sed -i "s/__DATE__/$(date)/g" index.html
-        sed -i "s/__COMMIT__/$(git rev-parse --short HEAD)/g" index.html
-        sed -i "s/__APK__/$(ls *apk)/g" index.html
+      - name: build test page
+        working-directory: ghpages
+        run: |
+          sed -i "s/__DATE__/$(date)/g" index.html
+          sed -i "s/__COMMIT__/$(git rev-parse --short HEAD)/g" index.html
+          sed -i "s/__APK__/$(ls *apk)/g" index.html
 
-    - name: upload test page artifact
-      uses: actions/upload-pages-artifact@v1
-      with:
-        path: ./ghpages
+      - name: upload test page artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./ghpages
 
   deploy:
     needs: build
@@ -79,4 +79,4 @@ jobs:
     steps:
       - name: deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR updates the Android build workflows to use `upload-artifact@v4` due to `@v3` being deprecated on January 30, 2025 (which is tomorrow at the time of this writing). The `upload-artifact` changes can be seen in this GitHub blog post: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The `upload-pages-artifact` is also updated according to https://github.com/actions/upload-pages-artifact to ensure that is on the most up to date version. This workflow updates the page hosted at https://advplyr.github.io/audiobookshelf-app/. I wonder if we still need this page because it is not really advertised anywhere and the APK can be downloaded from the workflow itself. However, the page is very nice and looks professional, but not sure about maintaining it if it breaks. A screenshot of the page is shown below.
![APK download page](https://github.com/user-attachments/assets/3867d558-4d45-4d4f-b140-40ce13f2f4fa)
