### PR TITLE
Andriod `DeviceManager.kt` cleanup

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
@@ -87,8 +87,7 @@ object DeviceManager {
    * @return The ServerConnectionConfig instance or null if not found.
    */
   fun getServerConnectionConfig(id: String?): ServerConnectionConfig? {
-    if (id == null) return null
-    return deviceData.serverConnectionConfigs.find { it.id == id }
+    return id?.let { deviceData.serverConnectionConfigs.find { it.id == id } }
   }
 
   /**

--- a/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
@@ -48,40 +48,24 @@ object DeviceManager {
   init {
     Log.d(tag, "Device Manager Singleton invoked")
 
-    // Initialize new sleep timer settings and shake sensitivity added in v0.9.61
-    if (deviceData.deviceSettings?.autoSleepTimerStartTime == null ||
-                    deviceData.deviceSettings?.autoSleepTimerEndTime == null
-    ) {
-      deviceData.deviceSettings?.autoSleepTimerStartTime = "22:00"
-      deviceData.deviceSettings?.autoSleepTimerStartTime = "06:00"
-      deviceData.deviceSettings?.sleepTimerLength = 900000L
-    }
-    if (deviceData.deviceSettings?.shakeSensitivity == null) {
-      deviceData.deviceSettings?.shakeSensitivity = ShakeSensitivitySetting.MEDIUM
-    }
-    // Initialize auto sleep timer auto rewind added in v0.9.64
-    if (deviceData.deviceSettings?.autoSleepTimerAutoRewindTime == null) {
-      deviceData.deviceSettings?.autoSleepTimerAutoRewindTime = 300000L // 5 minutes
-    }
-
-    // Language added in v0.9.69
-    if (deviceData.deviceSettings?.languageCode == null) {
-      deviceData.deviceSettings?.languageCode = "en-us"
-    }
-
-    if (deviceData.deviceSettings?.downloadUsingCellular == null) {
-      deviceData.deviceSettings?.downloadUsingCellular = DownloadUsingCellularSetting.ALWAYS
-    }
-
-    if (deviceData.deviceSettings?.streamingUsingCellular == null) {
-      deviceData.deviceSettings?.streamingUsingCellular = StreamingUsingCellularSetting.ALWAYS
-    }
-    if (deviceData.deviceSettings?.androidAutoBrowseLimitForGrouping == null) {
-      deviceData.deviceSettings?.androidAutoBrowseLimitForGrouping = 100
-    }
-    if (deviceData.deviceSettings?.androidAutoBrowseSeriesSequenceOrder == null) {
-      deviceData.deviceSettings?.androidAutoBrowseSeriesSequenceOrder =
-              AndroidAutoBrowseSeriesSequenceOrderSetting.ASC
+    // Default settings if they have not been set yet. Removes Elvis operator for null safety due to
+    // variables being non-nullable.
+    deviceData.deviceSettings?.apply {
+      // Sleep timer settings, added v0.9.61
+      autoSleepTimerStartTime = "22:00"
+      autoSleepTimerEndTime = "06:00"
+      sleepTimerLength = 900000L
+      shakeSensitivity = ShakeSensitivitySetting.MEDIUM
+      // Auto sleep timer auto rewind, added v0.9.64
+      autoSleepTimerAutoRewindTime = 300000L // 5 minutes
+      // Langugage code, added v0.9.69
+      languageCode = "en-us"
+      // Download and streaming using cellular, added v0.9.75
+      downloadUsingCellular = DownloadUsingCellularSetting.ALWAYS
+      streamingUsingCellular = StreamingUsingCellularSetting.ALWAYS
+      // Android Auto settings, added v0.9.78
+      androidAutoBrowseLimitForGrouping = 100
+      androidAutoBrowseSeriesSequenceOrder = AndroidAutoBrowseSeriesSequenceOrderSetting.ASC
     }
   }
 


### PR DESCRIPTION
## Overview
This PR cleans up the `DeviceManager.kt` file.

## Detailed description
- No functional changes were made
- Code was autoformatted
- Javadoc-style comments were added
- Some syntax cleanup, particularly in the default device settings
- Fixed `autoSleepTimerStartTime` being set twice instead of `autoSleepTimerEndTime`

## How was this tested?
Tested on Android 15 with a Pixel 6a. I did not test with downgrading and upgrading the versions.