### PR TITLE
Android Sleep Timer cleanup part 2

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/SleepTimerManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/SleepTimerManager.kt
@@ -264,7 +264,7 @@ constructor(private val playerNotificationService: PlayerNotificationService) {
   }
 
   /**
-   * Gets the chapter end time for use in End of Chapter timers. If less than 2 seconds remain in
+   * Gets the chapter end time for use in End of Chapter timers. If less than 10 seconds remain in
    * the chapter, then use the next chapter.
    * @return Long? - the chapter end time in milliseconds, or null if there is no current session.
    */
@@ -331,6 +331,14 @@ constructor(private val playerNotificationService: PlayerNotificationService) {
       if (finishedAtDistance > SLEEP_TIMER_WAKE_UP_EXPIRATION) // 2 minutes
       {
         Log.d(tag, "Sleep timer finished over 2 mins ago, clearing it")
+        sleepTimerFinishedAt = 0L
+        return
+      }
+
+      // If timer was cleared by going negative on time, clear the sleep timer length so pressing
+      // play allows playback to continue without the sleep timer continuously setting for 1 second.
+      if (sleepTimerLength == 1000L) {
+        Log.d(tag, "Sleep timer cleared by manually subtracting time, clearing sleep timer")
         sleepTimerFinishedAt = 0L
         return
       }
@@ -466,7 +474,7 @@ constructor(private val playerNotificationService: PlayerNotificationService) {
           // Start an auto sleep timer
           val currentHour = currentCalendar.get(Calendar.HOUR_OF_DAY)
           val currentMin = currentCalendar.get(Calendar.MINUTE)
-          Log.i(tag, "Starting sleep timer at $currentHour:$currentMin")
+          Log.i(tag, "Starting auto sleep timer at $currentHour:$currentMin")
 
           // Automatically rewind in the book if settings is enabled
           tryRewindAutoSleepTimer()

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/SleepTimerManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/SleepTimerManager.kt
@@ -343,9 +343,12 @@ constructor(private val playerNotificationService: PlayerNotificationService) {
     }
   }
 
-  /** Handles the shake event to reset the sleep timer. */
+  /**
+   * Handles the shake event to reset the sleep timer. Shaking to reset only works during the 2
+   * minute grace period after the timer ends or while media is playing.
+   */
   fun handleShake() {
-    if (sleepTimerRunning || sleepTimerFinishedAt > 0L) {
+    if ((sleepTimerRunning && getIsPlaying()) || sleepTimerFinishedAt > 0L) {
       if (DeviceManager.deviceData.deviceSettings?.disableShakeToResetSleepTimer == true) {
         Log.d(tag, "Shake to reset sleep timer is disabled")
         return

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/SleepTimerManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/SleepTimerManager.kt
@@ -276,8 +276,11 @@ constructor(private val playerNotificationService: PlayerNotificationService) {
     }
 
     val timeLeftInChapter = currentChapterEndTimeMs - getCurrentTime()
-    return if (timeLeftInChapter < 2000L) {
-      Log.i(tag, "Getting chapter sleep timer time and current chapter has less than 2s remaining")
+    // If less than 10 seconds remain in the chapter, set the timer to the next chapter or track
+    // This handles the auto-rewind from not playing media for a little bit to select the next
+    // chapter
+    return if (timeLeftInChapter < 10000L) {
+      Log.i(tag, "Getting chapter sleep timer time and current chapter has less than 10s remaining")
       val nextChapterEndTimeMs = playerNotificationService.getEndTimeOfNextChapterOrTrack()
       if (nextChapterEndTimeMs == null || currentChapterEndTimeMs == nextChapterEndTimeMs) {
         Log.e(


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR continues to clean up the Android sleep timer, and fixes an issue introduced by my first PR for cleaning up the sleep timer (https://github.com/advplyr/audiobookshelf-app/pull/1453).

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf-app/issues/1463 (first commit)
Partially fixes https://github.com/advplyr/audiobookshelf-app/issues/1097 (second commit)
Fixes https://github.com/advplyr/audiobookshelf-app/issues/1047 (third commit)

## In-depth Description

The first commit adds a check of whether audio is playing or if we are in the 2 minute grace period before resetting the sleep timer due to a shake. This prevents pausing and then setting the phone down from restarting playback.

The second commit changes the threshold to go to the end of the *next* chapter to be 10 seconds away from the end of the current chapter to help account for auto-rewind preventing the sleep timer from getting stuck selecting the same chapter. I am not sure if the threshold should be higher than this, because I could see the benefit of having it set to the maximum rewind time, but that may be too long when getting to the end of a chapter.

The third commit adds a check to whether `sleepTimeLength` is the minimum value of 1 second to clear the timer. This occurs when the user tries to decrease the remaining time below 0 seconds remaining.

## How have you tested this?

Built and tested on Android 15, Pixel 6a.

Tested by:
- Setting auto sleep timer and manual sleep timers. Shaking with media paused, not started, and playing.
- Manually reducing time past zero, pressing play (resumes correctly) or shaking (does nothing correctly).
- Used end of chapter sleep timer, waited for it to finish, then shook to continue on to next chapter (Without using the auto-sleep timer rewind, just the normal auto rewind)

## Screenshots
N/A