### PR TITLE
Add description for local folder usage

### DIFF
--- a/pages/localMedia/folders/index.vue
+++ b/pages/localMedia/folders/index.vue
@@ -1,9 +1,11 @@
 <template>
   <div class="w-full h-full py-6">
-    <h1 class="text-base font-semibold px-2 mb-2">
-      {{ $strings.HeaderLocalFolders }}
-      <span class="material-icons-outlined ml-2" @click.stop="showLocalFolderMoreInfo">info</span>
-    </h1>
+    <div class="flex items-center mb-2">
+      <h1 class="text-base font-semibold px-2">
+        {{ $strings.HeaderLocalFolders }}
+      </h1>
+      <button type="button" class="material-icons-outlined" @click.stop="showLocalFolderMoreInfo">info</button>
+    </div>
 
     <div v-if="!isIos" class="w-full max-w-full px-2 py-2">
       <template v-for="folder in localFolders">

--- a/pages/localMedia/folders/index.vue
+++ b/pages/localMedia/folders/index.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="w-full h-full py-6">
-    <h1 class="text-base font-semibold px-2 mb-2">{{ $strings.HeaderLocalFolders }}</h1>
+    <h1 class="text-base font-semibold px-2 mb-2">
+      {{ $strings.HeaderLocalFolders }}
+      <span class="material-icons-outlined ml-2" @click.stop="showLocalFolderMoreInfo">info</span>
+    </h1>
 
     <div v-if="!isIos" class="w-full max-w-full px-2 py-2">
       <template v-for="folder in localFolders">
@@ -33,6 +36,7 @@
 
 <script>
 import { AbsFileSystem } from '@/plugins/capacitor'
+import { Dialog } from '@capacitor/dialog'
 
 export default {
   data() {
@@ -85,6 +89,16 @@ export default {
         return
       } else {
         this.$toast.success('Folder permission success')
+      }
+    },
+    async showLocalFolderMoreInfo() {
+      const confirmResult = await Dialog.confirm({
+        title: this.$strings.HeaderLocalFolders,
+        message: this.$strings.MessageLocalFolderDescription,
+        cancelButtonTitle: 'View More'
+      })
+      if (!confirmResult.value) {
+        window.open('https://www.audiobookshelf.org/guides/android_app_shared_storage', '_blank')
       }
     },
     async init() {

--- a/strings/en-us.json
+++ b/strings/en-us.json
@@ -296,7 +296,7 @@
   "MessageItemMissing": "Item is missing and must be fixed on the server. Typically an item is marked as missing because the file paths are not accessible.",
   "MessageLoading": "Loading...",
   "MessageLoadingServerData": "Loading server data...",
-  "MessageLocalFolderDescription": "Internal App Storage is only accessible by this app. Other local folders can be used to allow other apps to access media downloaded through this app. This app does not support files added by other apps or manually through the file system.",
+  "MessageLocalFolderDescription": "'Internal App Storage' is only accessible by this app. This app only supports media downloaded directly through the app. Shared storage folders can be used to allow other apps to access media downloaded by this app.",
   "MessageMarkAsFinished": "Mark as Finished",
   "MessageMediaLinkedToADifferentServer": "Media is linked to an Audiobookshelf server on a different address ({0}). Progress will be synced when connected to this server address.",
   "MessageMediaLinkedToADifferentUser": "Media is linked to this server but was downloaded by a different user. Progress will only be synced to the user that downloaded it.",

--- a/strings/en-us.json
+++ b/strings/en-us.json
@@ -296,6 +296,7 @@
   "MessageItemMissing": "Item is missing and must be fixed on the server. Typically an item is marked as missing because the file paths are not accessible.",
   "MessageLoading": "Loading...",
   "MessageLoadingServerData": "Loading server data...",
+  "MessageLocalFolderDescription": "Internal App Storage is only accessible by this app. Other local folders can be used to allow other apps to access media downloaded through this app. This app does not support files added by other apps or manually through the file system.",
   "MessageMarkAsFinished": "Mark as Finished",
   "MessageMediaLinkedToADifferentServer": "Media is linked to an Audiobookshelf server on a different address ({0}). Progress will be synced when connected to this server address.",
   "MessageMediaLinkedToADifferentUser": "Media is linked to this server but was downloaded by a different user. Progress will only be synced to the user that downloaded it.",


### PR DESCRIPTION
## Overview
This PR fixes https://github.com/advplyr/audiobookshelf-app/issues/1472 by adding an info bubble to the Local Folders. I experimented with adding the text below the folder list, but I couldn't get it to look right with a "more info" link.

The confusion can mostly be seen in the following issues (some from before support was removed). Scanning local media is also asked about relatively often on Discord, but not too frequently.
- https://github.com/advplyr/audiobookshelf-app/issues/1362
- https://github.com/advplyr/audiobookshelf-app/issues/827
- https://github.com/advplyr/audiobookshelf-app/issues/810

## Screenshots
![image](https://github.com/user-attachments/assets/0e897873-0ff9-4bcc-b202-b575f61cc2b3)

![image](https://github.com/user-attachments/assets/c96ef22d-bba0-4146-9601-bab866af7dbc)
