### PR TITLE
Use `cast-connected` icon instead of green icon

### DIFF
--- a/components/app/Appbar.vue
+++ b/components/app/Appbar.vue
@@ -22,7 +22,7 @@
 
       <!-- Must be connected to a server to cast, only supports media items on server -->
       <div v-show="isCastAvailable && user" class="mx-2 cursor-pointer flex items-center pt-0.5" @click="castClick">
-        <span class="material-icons" :class="isCasting ? 'text-success' : ''">cast</span>
+        <span class="material-icons">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
       </div>
 
       <nuxt-link v-if="user" class="h-7 mx-1.5" style="padding-top: 3px" to="/search">

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -7,7 +7,7 @@
         <span class="material-icons text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight }" @click="collapseFullscreen">expand_more</span>
       </div>
       <div v-show="showCastBtn" class="top-6 right-16 absolute cursor-pointer">
-        <span class="material-icons text-3xl" :class="isCasting ? (coverBgIsLight ? 'text-successDark' : 'text-success') : coverBgIsLight ? 'text-black' : ''" @click="castClick">cast</span>
+        <span class="material-icons text-3xl" :class="coverBgIsLight ? 'text-successDark' : ''" @click="castClick">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
       </div>
       <div class="top-6 right-4 absolute cursor-pointer">
         <span class="material-icons text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight }" @click="showMoreMenuDialog = true">more_vert</span>

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -7,7 +7,7 @@
         <span class="material-icons text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight }" @click="collapseFullscreen">expand_more</span>
       </div>
       <div v-show="showCastBtn" class="top-6 right-16 absolute cursor-pointer">
-        <span class="material-icons text-3xl" :class="coverBgIsLight ? 'text-successDark' : ''" @click="castClick">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
+        <span class="material-icons text-3xl" :class="coverBgIsLight ? 'text-black' : ''" @click="castClick">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
       </div>
       <div class="top-6 right-4 absolute cursor-pointer">
         <span class="material-icons text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight }" @click="showMoreMenuDialog = true">more_vert</span>


### PR DESCRIPTION
This PR fixes https://github.com/advplyr/audiobookshelf-app/issues/1276. Only the frontend was changed.

## Images
App bar without casting
![image](https://github.com/user-attachments/assets/58628ce9-4a60-49e2-bf1c-55cfbf97a53b)

App bar while casting
![image](https://github.com/user-attachments/assets/db84c5a8-421f-444a-a92c-0a9e8ec4fd7e)

Player while casting
![image](https://github.com/user-attachments/assets/4b6ac5aa-0e4a-4a88-a591-eb723470f17d)

## Testing
This was tested on a Pixel 6a using Android 15.