### PR TITLE
IOS: Add support for fading out on sleep timer end

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
 
         let configuration = Realm.Configuration(
-            schemaVersion: 18,
+            schemaVersion: 19,
             migrationBlock: { [weak self] migration, oldSchemaVersion in
                 if (oldSchemaVersion < 1) {
                     self?.logger.log("Realm schema version was \(oldSchemaVersion)")
@@ -61,6 +61,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                         newObject?["streamingUsingCellular"] = "ALWAYS"
                     }
                 }
+                if (oldSchemaVersion < 18) {
+                    self?.logger.log("Realm schema version was \(oldSchemaVersion)... Adding disableSleepTimerFadeOut settings")
+                    migration.enumerateObjects(ofType: PlayerSettings.className()) { oldObject, newObject in
+                        newObject?["disableSleepTimerFadeOut"] = false
+                  }
+              }
 
             }
         )

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -246,6 +246,7 @@ public class AbsDatabase: CAPPlugin {
         let languageCode = call.getString("languageCode") ?? "en-us"
         let downloadUsingCellular = call.getString("downloadUsingCellular") ?? "ALWAYS"
         let streamingUsingCellular = call.getString("streamingUsingCellular") ?? "ALWAYS"
+        let disableSleepTimerFadeOut = call.getBool("disableSleepTimerFadeOut") ?? false
         let settings = DeviceSettings()
         settings.disableAutoRewind = disableAutoRewind
         settings.enableAltView = enableAltView
@@ -257,6 +258,7 @@ public class AbsDatabase: CAPPlugin {
         settings.languageCode = languageCode
         settings.downloadUsingCellular = downloadUsingCellular
         settings.streamingUsingCellular = streamingUsingCellular
+        settings.disableSleepTimerFadeOut = disableSleepTimerFadeOut
 
         Database.shared.setDeviceSettings(deviceSettings: settings)
 

--- a/ios/App/Shared/models/DeviceSettings.swift
+++ b/ios/App/Shared/models/DeviceSettings.swift
@@ -19,6 +19,7 @@ class DeviceSettings: Object {
     @Persisted var languageCode: String = "en-us"
     @Persisted var downloadUsingCellular: String = "ALWAYS"
     @Persisted var streamingUsingCellular: String = "ALWAYS"
+    @Persisted var disableSleepTimerFadeOut: Bool = false
 }
 
 func getDefaultDeviceSettings() -> DeviceSettings {
@@ -36,6 +37,7 @@ func deviceSettingsToJSON(settings: DeviceSettings) -> Dictionary<String, Any> {
         "hapticFeedback": settings.hapticFeedback,
         "languageCode": settings.languageCode,
         "downloadUsingCellular": settings.downloadUsingCellular,
-        "streamingUsingCellular": settings.streamingUsingCellular
+        "streamingUsingCellular": settings.streamingUsingCellular,
+        "disableSleepTimerFadeOut": settings.disableSleepTimerFadeOut
     ]
 }

--- a/ios/App/Shared/player/AudioPlayerSleepTimer.swift
+++ b/ios/App/Shared/player/AudioPlayerSleepTimer.swift
@@ -125,7 +125,11 @@ extension AudioPlayer {
         if var sleepTimeRemaining = self.sleepTimeRemaining {
             sleepTimeRemaining -= 1
             self.sleepTimeRemaining = sleepTimeRemaining
-            
+          
+            if sleepTimeRemaining == 60 && self.isSleepTimerFadeOutEnabled() {
+                self.startFadeOut()
+            }
+          
             // Handle the sleep if the timer has expired
             if sleepTimeRemaining <= 0 {
                 self.handleSleepEnd()
@@ -154,5 +158,9 @@ extension AudioPlayer {
     private func isChapterSleepTimerSet() -> Bool {
         return self.sleepTimeChapterStopAt != nil
     }
-    
+  
+    private func isSleepTimerFadeOutEnabled() -> Bool {
+      let deviceSettings = Database.shared.getDeviceSettings()
+      return !deviceSettings.disableSleepTimerFadeOut
+    }
 }

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -84,6 +84,7 @@
           <ui-text-input :value="shakeSensitivityOption" readonly append-icon="expand_more" style="width: 145px; max-width: 145px" />
         </div>
       </div>
+    </template>
       <div class="flex items-center py-3">
         <div class="w-10 flex justify-center" @click="toggleDisableSleepTimerFadeOut">
           <ui-toggle-switch v-model="settings.disableSleepTimerFadeOut" @input="saveSettings" />
@@ -91,6 +92,7 @@
         <p class="pl-4">{{ $strings.LabelDisableAudioFadeOut }}</p>
         <span class="material-icons-outlined ml-2" @click.stop="showInfo('disableSleepTimerFadeOut')">info</span>
       </div>
+    <template v-if="!isiOS">
       <div class="flex items-center py-3">
         <div class="w-10 flex justify-center" @click="toggleDisableSleepTimerResetFeedback">
           <ui-toggle-switch v-model="settings.disableSleepTimerResetFeedback" @input="saveSettings" />


### PR DESCRIPTION
This addresses issue #831 to bring additional parity to the iOS app.
Playback will start to fadeout during last 60 seconds of the sleep timer. Once faded out, playback will be paused, volume reset, and playback seeked to start of fadeout.