### PR TITLE
IOS: Support autoRewind and disableAutoRewind setting

### DIFF
--- a/ios/App/AudiobookshelfUnitTests/Shared/player/util/PlayerTimeUtilsTests.swift
+++ b/ios/App/AudiobookshelfUnitTests/Shared/player/util/PlayerTimeUtilsTests.swift
@@ -12,9 +12,41 @@ final class PlayerTimeUtilsTests: XCTestCase {
     
     func testCalcSeekBackTime() {
         let currentTime: Double = 1000
-        let threeSecondsAgo = Date(timeIntervalSinceNow: -3)
-        let lastPlayedMs = threeSecondsAgo.timeIntervalSince1970 * 1000
-        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: lastPlayedMs), 998)
+        
+        // 1. Nil lastPlayedMs → should seek back 5s
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: nil), 995)
+        
+        // 2. Played ~3s ago (<6s) → should seek back 2s
+        let played3sAgo = Date(timeIntervalSinceNow: -3).timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: played3sAgo), 998)
+        
+        // 3. Played ~8s ago (6-12s range) → should seek back 10s
+        let played8sAgo = Date(timeIntervalSinceNow: -8).timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: played8sAgo), 990)
+        
+        // 4. Played ~20s ago (12-30s range) → should seek back 15s
+        let played20sAgo = Date(timeIntervalSinceNow: -20).timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: played20sAgo), 985)
+        
+        // 5. Played ~60s ago (30-180s range) → should seek back 20s
+        let played60sAgo = Date(timeIntervalSinceNow: -60).timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: played60sAgo), 980)
+        
+        // 6. Played ~300s ago (180-3600s range) → should seek back 25s
+        let played300sAgo = Date(timeIntervalSinceNow: -300).timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: played300sAgo), 975)
+        
+        // 7. Played ~4000s ago (>3600s range) → should seek back 29s
+        let played4000sAgo = Date(timeIntervalSinceNow: -4000).timeIntervalSince1970 * 1000
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: played4000sAgo), 971)
+        
+        // 8. Edge case where currentTime is small and would go negative
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: 3, lastPlayedMs: played3sAgo), 1)
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: 1, lastPlayedMs: played3sAgo), 0)
+        
+        // 9. Edge case: negative lastPlayedMs (should be treated as an old timestamp)
+        XCTAssertEqual(PlayerTimeUtils.calcSeekBackTime(currentTime: currentTime, lastPlayedMs: -5000), 971)
+      
     }
     
     func testCalcSeekBackTimeWithZeroCurrentTime() {
@@ -27,7 +59,7 @@ final class PlayerTimeUtilsTests: XCTestCase {
     func testTimeSinceLastPlayed() throws {
         let fiveSecondsAgo = Date(timeIntervalSinceNow: -5)
         let lastPlayedMs = fiveSecondsAgo.timeIntervalSince1970 * 1000
-        XCTAssertEqual(PlayerTimeUtils.timeSinceLastPlayed(lastPlayedMs)!, -5, accuracy: 1.0)
+        XCTAssertEqual(PlayerTimeUtils.timeSinceLastPlayed(lastPlayedMs)!, 5, accuracy: 1.0)
         XCTAssertNil(PlayerTimeUtils.timeSinceLastPlayed(nil))
     }
     

--- a/ios/App/Shared/player/util/PlayerTimeUtils.swift
+++ b/ios/App/Shared/player/util/PlayerTimeUtils.swift
@@ -21,10 +21,13 @@ class PlayerTimeUtils {
     static internal func timeSinceLastPlayed(_ lastPlayedMs: Double?) -> TimeInterval? {
         guard let lastPlayedMs = lastPlayedMs else { return nil }
         let lastPlayed = Date(timeIntervalSince1970: lastPlayedMs / 1000)
-        return lastPlayed.timeIntervalSinceNow
+        return Date().timeIntervalSince(lastPlayed)
     }
     
     static internal func timeToSeekBackForSinceLastPlayed(_ sinceLastPlayed: TimeInterval?) -> TimeInterval {
+        if isAutoRewindDisabled(){
+          return 0
+        }
         if let sinceLastPlayed = sinceLastPlayed {
             if sinceLastPlayed < 6 {
                 return 2
@@ -42,6 +45,11 @@ class PlayerTimeUtils {
         } else {
             return 5
         }
+    }
+    
+    static internal func isAutoRewindDisabled() -> Bool {
+      let deviceSettings = Database.shared.getDeviceSettings()
+      return deviceSettings.disableAutoRewind
     }
     
 }

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -36,7 +36,7 @@
 
     <!-- Playback settings -->
     <p class="uppercase text-xs font-semibold text-fg-muted mb-2 mt-10">{{ $strings.HeaderPlaybackSettings }}</p>
-    <div v-if="!isiOS" class="flex items-center py-3">
+    <div class="flex items-center py-3">
       <div class="w-10 flex justify-center" @click="toggleDisableAutoRewind">
         <ui-toggle-switch v-model="settings.disableAutoRewind" @input="saveSettings" />
       </div>


### PR DESCRIPTION
This addresses issue #1447. Most of the code to support this was added in 2022, but in practice it isn't working as intended, it looks like the tests didn't test that the resultant code when used completely would result in the correct time, just components that passed tests correctly.

This request does the following:
1. Updates the PlayerTimeUtils handle time intervals correctly.
2. Updates the test suite to test the PlayerTimeUtils.calcSeekBackTime at all ranges.
3. Enables the setting for disable auto rewind in iOS UI.
4. Updates PlayerTimeUtils such that the disable auto rewind setting is used.
