### PR TITLE
Bugfix issue 452:  iOS seek issue at end of book

### DIFF
--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -511,13 +511,10 @@ class AudioPlayer: NSObject {
         let audioTrack = playbackSession.audioTracks[currentTrackIndex]
         let startOffset = audioTrack.startOffset ?? 0.0
       
-        // if the currentTrackTime is not a number, then track isn't loaded
-        // fall back on session.
-        var currentTrackTime = self.audioPlayer.currentTime().seconds
+        // if the currentTrackTime isNan, then fall back on session.
+        let currentTrackTime = self.audioPlayer.currentTime().seconds
         if currentTrackTime.isNaN {
-          if let currentChapter = playbackSession.getCurrentChapter() {
-            currentTrackTime = currentChapter.getRelativeChapterCurrentTime(sessionCurrentTime:playbackSession.currentTime)
-          }
+          return playbackSession.currentTime
         }
         return startOffset + currentTrackTime
     }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -424,6 +424,27 @@ class AudioPlayer: NSObject {
         let indexOfSeek = getItemIndexForTime(time: to)
         logger.log("SEEK: Seek to index \(indexOfSeek) | Current index \(self.currentTrackIndex)")
         
+        if self.audioPlayer.currentItem == nil {
+          self.currentTrackIndex = indexOfSeek
+          
+          try? playbackSession.update {
+              playbackSession.currentTime = to
+          }
+          
+          let playerItems = self.allPlayerItems[indexOfSeek..<self.allPlayerItems.count]
+          
+          DispatchQueue.runOnMainQueue {
+              self.audioPlayer.removeAllItems()
+              for item in Array(playerItems) {
+                  self.audioPlayer.insert(item, after:self.audioPlayer.items().last)
+              }
+          }
+
+          seekInCurrentTrack(to: to, playbackSession: playbackSession)
+          setupQueueItemStatusObserver()
+          return
+        }
+        
         // Reconstruct queue if seeking to a different track
         if (self.currentTrackIndex != indexOfSeek) {
             // When we seek to a different track, we need to make sure to seek the old track to 0

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -487,9 +487,17 @@ class AudioPlayer: NSObject {
 
     public func getCurrentTime() -> Double? {
         guard let playbackSession = self.getPlaybackSession() else { return nil }
-        let currentTrackTime = self.audioPlayer.currentTime().seconds
         let audioTrack = playbackSession.audioTracks[currentTrackIndex]
         let startOffset = audioTrack.startOffset ?? 0.0
+      
+        // if the currentTrackTime is not a number, then track isn't loaded
+        // fall back on session.
+        var currentTrackTime = self.audioPlayer.currentTime().seconds
+        if currentTrackTime.isNaN {
+          if let currentChapter = playbackSession.getCurrentChapter() {
+            currentTrackTime = currentChapter.getRelativeChapterCurrentTime(sessionCurrentTime:playbackSession.currentTime)
+          }
+        }
         return startOffset + currentTrackTime
     }
 

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -768,6 +768,11 @@ class AudioPlayer: NSObject {
             if keyPath == #keyPath(AVPlayer.currentItem) {
                 NotificationCenter.default.post(name: NSNotification.Name(PlayerEvents.update.rawValue), object: nil)
                 logger.log("WARNING: Item ended")
+
+                if audioPlayer.currentItem == nil {
+                   logger.log("Player ended or next item is nil, marking ended")
+                   self.markAudioSessionAs(active: false)
+                }
             }
         } else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)


### PR DESCRIPTION
This resolves issue #452 failure to seek back at the end of a book. 
I'm less familiar with the podcast side and honestly haven't tested that. I don't think this would cause any issues, but 78d7ba6 could cause issues as it falls back on session details in the event the player doesn't have a track loaded, which is the case after a book ends. 

This does the following:
1. Ensures the UI  shows paused and session current time stops incrementing.
2. Allows a fall back to session time. 
3. Reloads the track queue if it isn't loaded.