### PR TITLE
sort podcasts by filename; display filename in table row

### DIFF
--- a/components/modals/OrderModal.vue
+++ b/components/modals/OrderModal.vue
@@ -119,6 +119,10 @@ export default {
         {
           text: this.$strings.LabelEpisode,
           value: 'episode'
+        },
+        {
+          text: this.$strings.LabelFilename,
+          value: 'audioFile.metadata.filename'
         }
       ]
     }

--- a/components/tables/podcast/EpisodeRow.vue
+++ b/components/tables/podcast/EpisodeRow.vue
@@ -17,8 +17,9 @@
 
       <p class="text-sm text-fg episode-subtitle mt-1.5 mb-0.5" v-html="subtitle" />
 
-      <p v-if="sortKey === 'audioFile.metadata.filename'" class="text-xs text-fg-muted truncate mt-1 mb-0.5">
-        <span class="uppercase">{{ $getString('LabelFilename') }}</span>: <span class="font-mono">{{ episode.audioFile.metadata.filename }}</span>
+      <p v-if="sortKey === 'audioFile.metadata.filename'" class="text-xs text-fg-muted truncate mt-2 mb-0.5">
+        <span class="font-semibold">{{ $getString('LabelFilename') }}</span
+        >: <span class="font-light">{{ episode.audioFile.metadata.filename }}</span>
       </p>
 
       <div v-if="episodeNumber || season || episodeType" class="flex py-2 items-center -mx-0.5">

--- a/components/tables/podcast/EpisodeRow.vue
+++ b/components/tables/podcast/EpisodeRow.vue
@@ -17,6 +17,10 @@
 
       <p class="text-sm text-fg episode-subtitle mt-1.5 mb-0.5" v-html="subtitle" />
 
+      <p v-if="sortKey === 'audioFile.metadata.filename'" class="text-xs text-fg-muted truncate mt-1 mb-0.5">
+        <span class="uppercase">{{ $getString('LabelFilename') }}</span>: <span class="font-mono">{{ episode.audioFile.metadata.filename }}</span>
+      </p>
+
       <div v-if="episodeNumber || season || episodeType" class="flex py-2 items-center -mx-0.5">
         <div v-if="episodeNumber" class="px-2 pt-px pb-0.5 mx-0.5 bg-primary bg-opacity-50 rounded-full text-xs font-light text-fg">Episode #{{ episodeNumber }}</div>
         <div v-if="season" class="px-2 pt-px pb-0.5 mx-0.5 bg-primary bg-opacity-50 rounded-full text-xs font-light text-fg">Season #{{ season }}</div>
@@ -72,7 +76,8 @@ export default {
       type: Object,
       default: () => {}
     },
-    isLocal: Boolean
+    isLocal: Boolean,
+    sortKey: String
   },
   mixins: [cellularPermissionHelpers],
   data() {

--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -39,7 +39,7 @@
     </div>
 
     <template v-for="episode in episodesSorted">
-      <tables-podcast-episode-row :episode="episode" :local-episode="localEpisodeMap[episode.id]" :library-item-id="libraryItemId" :local-library-item-id="localLibraryItemId" :is-local="isLocal" :key="episode.id" @addToPlaylist="addEpisodeToPlaylist" />
+      <tables-podcast-episode-row :episode="episode" :local-episode="localEpisodeMap[episode.id]" :library-item-id="libraryItemId" :local-library-item-id="localLibraryItemId" :is-local="isLocal" :sort-key="sortKey" :key="episode.id" @addToPlaylist="addEpisodeToPlaylist" />
     </template>
 
     <!-- Huhhh?
@@ -133,6 +133,10 @@ export default {
         {
           text: this.$strings.LabelEpisode,
           value: 'episode'
+        },
+        {
+          text: this.$strings.LabelFilename,
+          value: 'audioFile.metadata.filename'
         }
       ]
     },
@@ -181,8 +185,17 @@ export default {
     },
     episodesSorted() {
       return this.episodesFiltered.sort((a, b) => {
-        let aValue = a[this.sortKey]
-        let bValue = b[this.sortKey]
+        let aValue
+        let bValue
+
+        if (this.sortKey.includes('.')) {
+          const getNestedValue = (ob, s) => s.split('.').reduce((o, k) => o?.[k], ob)
+          aValue = getNestedValue(a, this.sortKey)
+          bValue = getNestedValue(b, this.sortKey)
+        } else {
+          aValue = a[this.sortKey]
+          bValue = b[this.sortKey]
+        }
 
         // Sort episodes with no pub date as the oldest
         if (this.sortKey === 'publishedAt') {


### PR DESCRIPTION
Hi there,

this PR basically just adds the recently introduced feature "[new sort option for podcasts view](https://github.com/advplyr/audiobookshelf/pull/4030)" from the webapp to the mobile app.

I tested this with my running ABS server instance and the Android emulator.

Thanks a lot for offering this great piece of open-source software!

I :heart: ABS. :smile: 

---

<img src="https://github.com/user-attachments/assets/4a944801-a7dc-4448-b3e6-a8d28731a571" width="50%" height="50%">

---

<img src="https://github.com/user-attachments/assets/e1d20694-4fcb-42aa-8227-c3136311af74" width="50%" height="50%">
