### PR TITLE
feat: Add more forward/backward durations

### DIFF
--- a/store/globals.js
+++ b/store/globals.js
@@ -15,6 +15,14 @@ export const state = () => ({
       value: 10
     },
     {
+      icon: 'forward_15',
+      value: 15
+    },
+    {
+      icon: 'forward_20',
+      value: 20
+    },
+    {
       icon: 'forward_30',
       value: 30
     }
@@ -27,6 +35,14 @@ export const state = () => ({
     {
       icon: 'replay_10',
       value: 10
+    },
+    {
+      icon: 'replay_15',
+      value: 15
+    },
+    {
+      icon: 'replay_20',
+      value: 20
     },
     {
       icon: 'replay_30',


### PR DESCRIPTION
This PR adds more forward/backward durations (15/20 seconds), as I find 10 too short and 30 too long.

There's a reference to an icon that I'm not exactly sure the location of, any help would be appreciated.