### PR TITLE
fix(InternalDownloadManager): add accept-encoding identity to requests

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -17,16 +17,8 @@ class InternalDownloadManager(
 ) : AutoCloseable {
 
   private val tag = "InternalDownloadManager"
-  private val client: OkHttpClient = OkHttpClient.Builder()
-      .connectTimeout(30, TimeUnit.SECONDS)
-      .addInterceptor { chain ->
-          val originalRequest = chain.request()
-          val newRequest = originalRequest.newBuilder()
-              .header("Accept-Encoding", "identity")
-              .build()
-          chain.proceed(newRequest)
-      }
-      .build()
+  private val client: OkHttpClient =
+          OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS).build()
   private val writer = BinaryFileWriter(outputStream, progressCallback)
 
   /**
@@ -37,7 +29,7 @@ class InternalDownloadManager(
    */
   @Throws(IOException::class)
   fun download(url: String) {
-    val request: Request = Request.Builder().url(url).build()
+    val request: Request = Request.Builder().url(url).addHeader("Accept-Encoding", "identity").build()
     client.newCall(request)
             .enqueue(
                     object : Callback {

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -17,8 +17,16 @@ class InternalDownloadManager(
 ) : AutoCloseable {
 
   private val tag = "InternalDownloadManager"
-  private val client: OkHttpClient =
-          OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS).build()
+  private val client: OkHttpClient = OkHttpClient.Builder()
+      .connectTimeout(30, TimeUnit.SECONDS)
+      .addInterceptor { chain ->
+          val originalRequest = chain.request()
+          val newRequest = originalRequest.newBuilder()
+              .header("Accept-Encoding", "identity")
+              .build()
+          chain.proceed(newRequest)
+      }
+      .build()
   private val writer = BinaryFileWriter(outputStream, progressCallback)
 
   /**


### PR DESCRIPTION
Fixes https://github.com/advplyr/audiobookshelf-app/issues/1553.
@nichwall pointed me in the correct direction for a fix. I've tested this against my server through a reverse proxy with gzip and without the proxy, directly to the container, both work fine. This disables compression for requests using the internal download manager client. As seen in the issue the okhttp client is sending an accept encoding for gzip by default which causes issues.
And more testing you want to do on your end?