### PR TITLE
Add: settings for gradle project in subfolder

### DIFF
--- a/android/.vscode/settings.json
+++ b/android/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "java.project.root": "android",
+  "java.import.gradle.enabled": true,
+  "java.import.gradle.wrapper.enabled": true,
+  "java.import.gradle.user.home": "${workspaceFolder}/.gradle"
+}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds a new VS Code settings file to allow the gradle project to be in a subfolder (in our case, `android/`).

## Which issue is fixed?

No specific issue

## In-depth Description

This allows VS Code to recognize the `android/` folder as the gradle root. I am not sure if this is the best way to do this, but could not figure out how to do this only from `.vscode/settings.json`.

## How have you tested this?

VS Code no longer complains about imports being incorrect/not existing.

## Screenshots

Prior to adding this new VS Code settings file
![image](https://github.com/user-attachments/assets/4fda42b2-14a3-4daa-8c0f-519de258717c)
