### PR TITLE
Reuse the existing ObjectMapper

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/ItemInProgress.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/ItemInProgress.kt
@@ -5,9 +5,7 @@
 package com.audiobookshelf.app.data
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.json.JSONObject
 

--- a/android/app/src/main/java/com/audiobookshelf/app/data/ItemInProgress.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/ItemInProgress.kt
@@ -6,6 +6,7 @@ package com.audiobookshelf.app.data
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.core.json.JsonReadFeature
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.json.JSONObject
@@ -18,8 +19,7 @@ data class ItemInProgress(
   val isLocal: Boolean
 ) {
   companion object {
-    fun makeFromServerObject(serverItem: JSONObject):ItemInProgress {
-      val jacksonMapper = jacksonObjectMapper().enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
+    fun makeFromServerObject(serverItem: JSONObject, jacksonMapper: ObjectMapper):ItemInProgress {
       val libraryItem = jacksonMapper.readValue<LibraryItem>(serverItem.toString())
 
       var episode:PodcastEpisode? = null

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -334,8 +334,7 @@ class ApiHandler(var ctx:Context) {
         val array = it.getJSONArray("libraryItems")
         for (i in 0 until array.length()) {
           val jsobj = array.get(i) as JSONObject
-
-          val itemInProgress = ItemInProgress.makeFromServerObject(jsobj)
+          val itemInProgress = ItemInProgress.makeFromServerObject(jsobj, jacksonMapper)
           items.add(itemInProgress)
         }
       }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Reuse Jackson ObjectMapper when rendering the "Continue" Android Auto tab.

## Which issue is fixed?

Fixes partially #1570

## Pull Request Type

Android backend-only change

## In-depth Description

I took a deeper look at the issue. The same performance problem plagues the "Recent" tab as well. I believe this is the relevant discussion in the Jackson itself:

https://github.com/FasterXML/jackson-module-kotlin/issues/69

TLDR: deserialization that uses reflection will be slow on Android on the first run because reflection itself is slow. Only when the deserializer is initialized on the first run and cached can Jackson speed up. And it does speed up, in my test, after warming-up the subsequent deserializations are over an order of magnitude faster then the first one.

This PR is just a quick bandaid that removes one of the performance bottlenecks: reuses the ObjectMapper.

Unfortunately that does not really help with the issue itself. You can see below that the processing in `getAllItemsInProgress` is now fast enough, but unfortunately this just highlights the same issue with the "Recent" tab, it just takes too long. And there are no such low-hanging fruits there. That would require migrating from Jackson to something not based on reflection like Moshi or kotlinx.serialization.


## How have you tested this?

With Desktop Head Unit and a real device (Pixel 6a, android 15).

Using real data and a few log instructions, the following is the performance improvement in the loop in `getAllItemsInProgress` (numbers are ms on each iteration and for the whole loop).

```
2025-05-17 20:47:40.988 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1520
2025-05-17 20:47:42.337 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1349
2025-05-17 20:47:43.682 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1345
2025-05-17 20:47:44.969 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1287
2025-05-17 20:47:46.327 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1358
2025-05-17 20:47:47.595 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1268
2025-05-17 20:47:48.700 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1105
2025-05-17 20:47:49.667 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  967
2025-05-17 20:47:50.728 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  1061
2025-05-17 20:47:51.166 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E  438
2025-05-17 20:47:51.166 11100-11814 getAllItemsInProgress   com.audiobookshelf.app.debug         E     11698
```

```
2025-05-17 20:44:54.971  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  70
2025-05-17 20:44:54.974  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  3
2025-05-17 20:44:54.975  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  1
2025-05-17 20:44:54.977  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  1
2025-05-17 20:44:54.979  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  2
2025-05-17 20:44:54.980  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  1
2025-05-17 20:44:54.982  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  2
2025-05-17 20:44:54.986  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  4
2025-05-17 20:44:54.988  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  2
2025-05-17 20:44:54.992  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E  4
2025-05-17 20:44:54.992  7411-9008  getAllItemsInProgress   com.audiobookshelf.app.debug         E     91
```