### PR TITLE
Add: UI Black/OLED theme

### DIFF
--- a/assets/tailwind.css
+++ b/assets/tailwind.css
@@ -22,6 +22,25 @@
     --gradient-minimized-audio-player: linear-gradient(145deg, rgba(38, 38, 38, 0.5) 0%, rgba(38, 38, 38, 0.9) 20%, rgb(38, 38, 38) 60%);
   }
 
+  html[data-theme='black'] {
+      color: white;
+      --color-bg: 0 0 0;
+      --color-bg-hover: 0 0 0;
+      --color-fg: 230 237 243;
+      --color-fg-muted: 120 126 132;
+      --color-primary: 0 0 0;
+      --color-secondary: 0 0 0;
+      --color-border: 55 62 65;
+      --color-bg-toggle: 0 0 0;
+      --color-bg-toggle-selected: 35 35 35;
+      --color-track-cursor: 229 231 235;
+      --color-track: 107 114 128;
+      --color-track-buffered: 75 85 99;
+      --gradient-item-page: rgb(0, 0, 0);
+      --gradient-audio-player: rgb(0, 0, 0);
+      --gradient-minimized-audio-player: rgb(0, 0, 0);
+    }
+  
   html[data-theme='light'] {
     color: black;
     --color-bg: 255 255 255;

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -4,15 +4,15 @@
       <div class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: var(--gradient-audio-player)" />
 
       <div class="top-4 left-4 absolute cursor-pointer">
-        <span class="material-symbols text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight }" @click="collapseFullscreen">keyboard_arrow_down</span>
+        <span class="material-symbols text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="collapseFullscreen">keyboard_arrow_down</span>
       </div>
       <div v-show="showCastBtn" class="top-6 right-16 absolute cursor-pointer">
-        <span class="material-symbols text-3xl" :class="coverBgIsLight ? 'text-black' : ''" @click="castClick">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
+        <span class="material-symbols text-3xl" :class="coverBgIsLight && theme !== 'black' ? 'text-black' : ''" @click="castClick">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
       </div>
       <div class="top-6 right-4 absolute cursor-pointer">
-        <span class="material-symbols text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight }" @click="showMoreMenuDialog = true">more_vert</span>
+        <span class="material-symbols text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="showMoreMenuDialog = true">more_vert</span>
       </div>
-      <p class="top-4 absolute left-0 right-0 mx-auto text-center uppercase tracking-widest text-opacity-75" :class="{ 'text-black text-opacity-75': coverBgIsLight }" style="font-size: 10px">{{ isDirectPlayMethod ? $strings.LabelPlaybackDirect : isLocalPlayMethod ? $strings.LabelPlaybackLocal : $strings.LabelPlaybackTranscode }}</p>
+      <p class="top-4 absolute left-0 right-0 mx-auto text-center uppercase tracking-widest text-opacity-75" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" style="font-size: 10px">{{ isDirectPlayMethod ? $strings.LabelPlaybackDirect : isLocalPlayMethod ? $strings.LabelPlaybackLocal : $strings.LabelPlaybackTranscode }}</p>
     </div>
 
     <div v-if="playerSettings.useChapterTrack && playerSettings.useTotalTrack && showFullscreen" class="absolute total-track w-full z-30 px-6">
@@ -182,6 +182,9 @@ export default {
     }
   },
   computed: {
+    theme() {
+      return document.documentElement.dataset.theme || 'dark'
+    },
     menuItems() {
       const items = []
       // TODO: Implement on iOS

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -364,6 +364,10 @@ export default {
     themeOptionItems() {
       return [
         {
+          text: this.$strings.LabelThemeBlack,
+          value: 'black'
+        },
+        {
           text: this.$strings.LabelThemeDark,
           value: 'dark'
         },


### PR DESCRIPTION
## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

Adds a new "Black/OLED" theme option to the UI, providing a true black background for OLED displays.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
Partially resolves #1006

## Pull Request Type

<!--
Does this affect only Android, only iOS, or both?
Does this change the frontend or the backend of the apps?
-->

This affects both Android and iOS.
This change affects the frontend of the app.

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

This PR adds a new **Black** option to the application's UI. This theme sets the primary background and several other color variables to pure black (`rgb(0, 0, 0)`), which is highly beneficial for devices with OLED screens.

Changes involve:
* Adding a new CSS definition `html[data-theme='black']` in `assets/tailwind.css` to define the specific color variables for the black theme.
* Adding `Black` as a selectable theme option in the settings page `pages/settings.vue`.

**Note:** This PR is focused only on the OLED theme. The system theme following from issue #1006 isn't resolved. 

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

1.  Tested using a phone with an OLED display.
2.  Confirmed that the app's background, player, and other UI components switched to a true black theme.
3.  Confirmed text readability against the black background in different light conditions.

## Screenshots

<!-- If your PR includes any changes to the front-end, please include screenshots or a
short video from before and after your changes. -->

Home page overview:
![Screenshot_20250620-204942](https://github.com/user-attachments/assets/c2b05f59-ebbe-40be-8717-6d28c8165470)
Item page overview:
![Screenshot_20250620-204946](https://github.com/user-attachments/assets/070d1d77-bf0b-440c-9e4a-ede92dc8495f)
Player UI overview:
![Screenshot_20250620-204854](https://github.com/user-attachments/assets/4e5f73d8-f8f6-4565-b2c4-5ee37352c723)
Settings page overview:
![Screenshot_20250620-205935](https://github.com/user-attachments/assets/690dae29-0f03-44b9-8265-7ef37dc08b6c)
