### PR TITLE
Update create bookmark to not autofocus input and use placeholder

### DIFF
--- a/components/modals/BookmarksModal.vue
+++ b/components/modals/BookmarksModal.vue
@@ -17,7 +17,7 @@
             <p class="text-xl font-mono">{{ this.$secondsToTimestamp(currentTime / _playbackRate) }}</p>
           </div>
 
-          <ui-text-input-with-label v-model="newBookmarkTitle" ref="noteInput" label="Note" />
+          <ui-text-input-with-label v-model="newBookmarkTitle" :placeholder="bookmarkPlaceholder()" :autofocus="false" ref="noteInput" label="Note" />
           <div class="flex justify-end mt-6">
             <ui-btn color="success" class="w-full" @click.stop="submitBookmark">{{ selectedBookmark ? 'Update' : 'Create' }}</ui-btn>
           </div>
@@ -93,6 +93,10 @@ export default {
     }
   },
   methods: {
+    bookmarkPlaceholder() {
+      // using a method prevents caching the date
+      return this.$formatDate(Date.now(), 'MMM dd, yyyy HH:mm')
+    },
     editBookmark(bm) {
       this.selectedBookmark = bm
       this.newBookmarkTitle = bm.title
@@ -157,18 +161,8 @@ export default {
     },
     createBookmark() {
       this.selectedBookmark = null
-      this.newBookmarkTitle = this.$formatDate(Date.now(), 'MMM dd, yyyy HH:mm')
+      this.newBookmarkTitle = ''
       this.showBookmarkTitleInput = true
-
-      // Auto focus the input and select the text
-      this.$nextTick(() => {
-        if (this.$refs.noteInput?.$refs.input?.$refs.input) {
-          this.$refs.noteInput.$refs.input.$refs.input.focus()
-          setTimeout(() => {
-            this.$refs.noteInput?.$refs.input?.$refs.input?.select()
-          }, 10)
-        }
-      })
     },
     async submitBookmark() {
       await this.$hapticsImpact()

--- a/components/ui/TextInput.vue
+++ b/components/ui/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <input v-model="input" ref="input" autofocus :type="type" :disabled="disabled" :readonly="readonly" autocorrect="off" autocapitalize="none" autocomplete="off" :placeholder="placeholder" class="py-2 w-full outline-none bg-primary disabled:text-fg-muted" :class="inputClass" @keyup="keyup" />
+    <input v-model="input" ref="input" :autofocus="autofocus" :type="type" :disabled="disabled" :readonly="readonly" autocorrect="off" autocapitalize="none" autocomplete="off" :placeholder="placeholder" class="py-2 w-full outline-none bg-primary disabled:text-fg-muted" :class="inputClass" @keyup="keyup" />
     <div v-if="prependIcon" class="absolute top-0 left-0 h-full px-2 flex items-center justify-center">
       <span class="material-symbols text-lg">{{ prependIcon }}</span>
     </div>
@@ -22,6 +22,10 @@ export default {
     disabled: Boolean,
     readonly: Boolean,
     borderless: Boolean,
+    autofocus: {
+      type: Boolean,
+      default: true
+    },
     bg: {
       type: String,
       default: 'bg'

--- a/components/ui/TextInputWithLabel.vue
+++ b/components/ui/TextInputWithLabel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-full">
     <p class="pb-0.5 text-sm font-semibold">{{ label }}</p>
-    <ui-text-input v-model="inputValue" ref="input" :disabled="disabled" :type="type" text-size="base" class="w-full" />
+    <ui-text-input v-model="inputValue" ref="input" :disabled="disabled" :type="type" :placeholder="placeholder" :autofocus="autofocus" text-size="base" class="w-full" />
   </div>
 </template>
 
@@ -14,7 +14,12 @@ export default {
       type: String,
       default: 'text'
     },
-    disabled: Boolean
+    disabled: Boolean,
+    placeholder: String,
+    autofocus: {
+      type: Boolean,
+      default: true
+    }
   },
   data() {
     return {}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

When pressing create bookmark the current functionality is to focus the input and select the input value.

This update removes the autofocus and leaves the input value blank with a placeholder value.

## Which issue is fixed?

No issue but fixes issue mentioned in PR #1611

## Pull Request Type

Both android/ios

## In-depth Description

Auto-focusing and selecting the bookmark input was originally added because when using a custom bookmark note the input value had to be deleted first. By having the input text auto-selected you could start typing for a custom note or press create to use the default note.

This PR removes the need to auto-select the text in the input because the input will be empty. The only downside is the input will have to be pressed to open the keyboard to add a custom note instead of automatically opened.

If it is preferred to auto open the keyboard we could look at a different design that uses a quick create button or uses a similar design to the web app.

## Screenshots

![image](https://github.com/user-attachments/assets/78c5dd2a-2035-4ca3-9d0e-779bf1dcbb43)
