### PR TITLE
Fix track URL used for transcodes on Android #1635

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -192,7 +192,12 @@ class PlaybackSession(
     // As of v2.22.0 tracks use a different endpoint
     // See: https://github.com/advplyr/audiobookshelf/pull/4263
     if (checkIsServerVersionGte("2.22.0")) {
-      return Uri.parse("$serverAddress/public/session/$id/track/${audioTrack.index}")
+      return if (isDirectPlay) {
+        Uri.parse("$serverAddress/public/session/$id/track/${audioTrack.index}")
+      } else {
+        // Transcode uses HlsRouter on server
+        Uri.parse("$serverAddress${audioTrack.contentUrl}")
+      }
     }
     return Uri.parse("$serverAddress${audioTrack.contentUrl}?token=${DeviceManager.token}")
   }

--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -255,7 +255,7 @@ class AbsAudioPlayerWeb extends WebPlugin {
     if (this.currentTrack.contentUrl?.startsWith('/hls')) {
       sessionTrackUrl = this.currentTrack.contentUrl
     } else {
-      sessionTrackUrl = `/public/session/${this.playbackSession.id}/track/${this.currentTrack.index}`
+      sessionTrackUrl = `/public/session/${this.playbackSession.id}/track/${this.currentTrack.index || 1}`
     }
 
     this.player.src = `${serverHost}${sessionTrackUrl}`


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Transcoding on Android causes a server crash because it is using the direct play endpoint instead of the hls endpoint. This update uses the correct URL for HLS.

## Which issue is fixed?

Fixes #1635

## Pull Request Type

Android

## In-depth Description

A separate bug with podcast episodes was found due to this https://github.com/advplyr/audiobookshelf/pull/4520

