### PR TITLE
fix: session resumption issues

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationListener.kt
@@ -41,6 +41,7 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
     if (dismissedByUser) {
       Log.d(tag, "onNotificationCancelled dismissed by user")
       playerNotificationService.stopSelf()
+      isForegroundService = false
     } else {
       Log.d(tag, "onNotificationCancelled not dismissed by user")
 
@@ -51,6 +52,5 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
         PlayerNotificationService.isSwitchingPlayer = false
       }
     }
-    isForegroundService = false
   }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -203,8 +203,6 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   override fun onTaskRemoved(rootIntent: Intent?) {
     super.onTaskRemoved(rootIntent)
     Log.d(tag, "onTaskRemoved")
-
-    stopSelf()
   }
 
   override fun onCreate() {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary
Fixes session resumption problems by altering logic when updating notification and when user swipes away application.

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

## Which issue is fixed?
Should fix
https://github.com/advplyr/audiobookshelf-app/issues/1309
<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

## Pull Request Type
Only android
<!--
Does this affect only Android, only iOS, or both?
Does this change the frontend or the backend of the apps?
-->

## In-depth Description
I've pinpointed the logic error in PlayerNotificationListener.kt. The isForegroundService flag was being set to false even when the notification was just being updated, not dismissed by the user. This made the service vulnerable to being killed by the system. Moved the isForegroundService = false line to be within the if (dismissedByUser) block. This change ensures that the service remains in a foreground state when paused, which is the correct behavior. This should resolve the issue where Android Auto fails to resume playback.

The current onTaskRemoved implementation is too aggressive and stops the service even when paused. The correct approach is to let the service continue running when the app is swiped from the recents list. The service's lifecycle is already correctly managed by the PlayerNotificationManager, which will stop the service when the user dismisses the notification (which is only possible when playback is paused).

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
Still testing since it is intermittent. Also want to see the affects on battery life if any.

Update: tested after overnight and killing the app. The book resumes in android auto just fine now. I did test with https://github.com/advplyr/audiobookshelf-app/pull/1641 at the same time.
## Screenshots

<!-- If your PR includes any changes to the front-end, please include screenshots or a
short video from before and after your changes. -->
