### PR TITLE
Fix OIDC button not appearing during re-login when refresh token is missing

### DIFF
--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -471,6 +471,21 @@ export default {
         // Will NOT include access token and refresh token
         this.setUserAndConnection(payload)
       } else {
+        // Authentication failed, fetch server auth methods before showing auth form
+        try {
+          this.processing = true
+          const statusData = await this.getServerAddressStatus(this.serverConfig.address)
+          if (statusData && statusData.data) {
+            this.authMethods = statusData.data.authMethods || []
+            this.oauth.buttonText = statusData.data.authFormData?.authOpenIDButtonText || 'Login with OpenID'
+            this.serverConfig.version = statusData.data.serverVersion
+          }
+        } catch (error) {
+          console.error('[ServerConnectForm] Failed to fetch server auth methods during reconnection:', error)
+          // Continue with empty authMethods array - local auth will still work
+        } finally {
+          this.processing = false
+        }
         this.showAuth = true
       }
     },


### PR DESCRIPTION
## Problem
The OIDC login button was not appearing when manually reconnecting to servers that support OpenID authentication, specifically when refresh tokens were missing or expired.

## Root Cause  
The `connectToServer` method only called `/ping` and `/api/authorize` endpoints during reconnection, but never fetched authentication methods from `/status`, leaving `authMethods` empty.

## Solution
- Added call to `getServerAddressStatus()` when token authentication fails
- Populates `authMethods` array before showing auth form  
- Includes robust error handling for graceful fallback
- Reuses existing proven logic for consistency

## Changes
- **File:** `components/connection/ServerConnectForm.vue` (lines 474-490)
- **Backward Compatible:** ✅ No breaking changes
- **Error Handling:** ✅ Graceful fallback to local auth

## Result
Users can now see and use the OIDC button when reconnecting to servers after refresh token expiration.
