### PR TITLE
Allows widget on Samsung cover screens

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,10 @@
           <meta-data
             android:name="android.appwidget.provider"
             android:resource="@xml/media_player_widget_info" />
+
+          <meta-data
+            android:name="com.samsung.android.appwidget.provider"
+            android:resource="@xml/samsung_cover_widget_info" />
         </receiver>
 
         <!-- Used by Android Auto -->

--- a/android/app/src/main/res/xml/media_player_widget_info.xml
+++ b/android/app/src/main/res/xml/media_player_widget_info.xml
@@ -11,4 +11,4 @@
     android:targetCellWidth="4"
     android:targetCellHeight="1"
     android:updatePeriodMillis="86400000"
-    android:widgetCategory="home_screen" />
+    android:widgetCategory="home_screen|keyguard" />

--- a/android/app/src/main/res/xml/samsung_cover_widget_info.xml
+++ b/android/app/src/main/res/xml/samsung_cover_widget_info.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<samsung-appwidget-provider
+  display="sub_screen"
+  privacyWidget="false" />


### PR DESCRIPTION
## Brief summary
Adds meta-data to the widget, allowing it to be used on the cover screen of Samsung devices such as the Flip.

The widget renders as a 4x4 grid (not an optimal layout) but functions for launching the most recent audiobook or controlling playback.

## Which issue is fixed?

n/a

## Pull Request Type

Android, frontend (widget)

## In-depth Description

(see summary)

## How have you tested this?

Built the APK locally and installed on a Flip 7. I was able to add the widget as page on the cover screen (when the phone is closed) and confirmed the home screen widget remained functional.

## Screenshots

<img width="237" height="262" alt="image" src="https://github.com/user-attachments/assets/c8dd9571-dac4-41e8-a010-4dd504b63fba" />
