### PR TITLE
Add chapter duration to chapters table on book page

### DIFF
--- a/components/tables/ChaptersTable.vue
+++ b/components/tables/ChaptersTable.vue
@@ -15,6 +15,7 @@
         <tr>
           <th class="text-left">{{ $strings.LabelTitle }}</th>
           <th class="text-center w-16">{{ $strings.LabelStart }}</th>
+          <th class="text-center w-16">{{ $strings.LabelDuration }}</th>
         </tr>
         <tr v-for="chapter in chapters" :key="chapter.id">
           <td>
@@ -22,6 +23,9 @@
           </td>
           <td class="font-mono text-center underline w-16" @click.stop="goToTimestamp(chapter.start)">
             {{ $secondsToTimestamp(chapter.start) }}
+          </td>
+          <td class="font-mono text-center">
+            {{ $secondsToTimestamp(Math.max(0, chapter.end - chapter.start)) }}
           </td>
         </tr>
       </table>


### PR DESCRIPTION
This adds the chapter duration to the chapter table on the book page.

## Brief summary

This aims to resolve #1163 by adding chapter duration to the chapters table on the book page.

## Which issue is fixed?

Fixes #1163.

## Pull Request Type

This changes the front-end of the android and iOS app.

## In-depth Description

It just adds the duration to the ChaptersTable view, the same way it's done on the web page.

## How have you tested this?

I tested this in Android Studio, on 2 different size emulated screens.

## Screenshots

<details><summary>Original table</summary>

pixel5:
<img width="1080" height="2340" alt="Screenshot_px5-chaptersTableOriginal" src="https://github.com/user-attachments/assets/98762b3f-d1ea-47e4-863d-d437c3d4a46b" />
small phone:
<img width="720" height="1280" alt="Screenshot_small-chaptersTableOriginal" src="https://github.com/user-attachments/assets/f35caf59-2eca-4fcc-839a-23c3a6ad8663" />
</details>

<details><summary>Table with Duration</summary>

pixel5:
<img width="1080" height="2340" alt="Screenshot_px5-chaptersTableDuration" src="https://github.com/user-attachments/assets/5d11da10-bc64-4c1d-af73-2e3f3e5c6148" />
small phone:
<img width="720" height="1280" alt="Screenshot_small-chaptersTableDuration" src="https://github.com/user-attachments/assets/fa722556-3f82-470a-b35d-ea98b35aac50" />
</details>
