### PR TITLE
Auto skip intro by chapter start and end property

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -158,7 +158,8 @@ export default {
       coverRgb: 'rgb(55, 56, 56)',
       coverBgIsLight: false,
       titleMarquee: null,
-      isRefreshingUI: false
+      isRefreshingUI: false,
+      introSkipping: false
     }
   },
   watch: {
@@ -565,6 +566,7 @@ export default {
 
       this.updateTimestamp()
       this.updateTrack()
+      this.updateIntroSkip()
     },
     updateTrack() {
       // Update progress track UI
@@ -591,6 +593,24 @@ export default {
       if (this.playerSettings.useChapterTrack) {
         if (this.$refs.totalPlayedTrack) this.$refs.totalPlayedTrack.style.width = Math.round(totalPercentDone * this.trackWidth) + 'px'
         if (this.$refs.totalBufferedTrack) this.$refs.totalBufferedTrack.style.width = Math.round(totalBufferedPercent * this.trackWidth) + 'px'
+      }
+    },
+    updateIntroSkip() {
+      if(!this.currentChapter && !this.nextChapter) return
+      if(!this.currentChapter && this.currentTime < this.nextChapter.start) {
+        if (this.introSkipping) return
+        this.introSkipping = true
+        this.seek(this.nextChapter.start)
+      } else if(this.currentChapter && this.currentTime < this.currentChapter.start) {
+        if (this.introSkipping) return
+        this.introSkipping = true
+        this.seek(this.currentChapter.start)
+      } else if(this.currentChapter && this.nextChapter && this.currentTime > this.currentChapter.end) {
+        if (this.introSkipping) return
+        this.introSkipping = true
+        this.seek(this.nextChapter.start)
+      } else {
+        this.introSkipping = false
       }
     },
     seek(time) {


### PR DESCRIPTION
## Brief summary
Add a player logic, when currentTime is not within the chapter's begin and end, skip to next chapter's beginning.

## Which issue is fixed?
Implements https://github.com/advplyr/audiobookshelf-app/issues/749

## Pull Request Type
Player's seek logic for both IOS and Android App

## In-depth Description
The solution is a partial logic of mobile side to auto skip op and ed. Currently, we need a extra script to modify book's metadata to modify chapter's begin and end properties.

Here is the script i'm using now (need to rescan to let audiobookshelf read the change):
```
import json
import os
import shutil
import sys

def modify_json_file(file_path, offset_a, offset_b):
    # backup original file
    backup_path = file_path + '.bak'
    shutil.copy2(file_path, backup_path)
    
    # read json file
    with open(file_path, 'r', encoding='utf-8') as f:
        data = json.load(f)
    
    # modify chapters start and end property
    if 'chapters' in data:
        for chapter in data['chapters']:
            if 'start' in chapter:
                chapter['start'] += offset_a
            if 'end' in chapter:
                chapter['end'] -= offset_b
    
    # write back
    with open(file_path, 'w', encoding='utf-8') as f:
        json.dump(data, f, indent=4, ensure_ascii=False)

if __name__ == '__main__':
    if len(sys.argv) != 4:
        print("Usage: python json_modifier.py <json_file_path> <offset_A> <offset_B>")
        sys.exit(1)
    
    try:
        json_path = sys.argv[1]
        offset_a = float(sys.argv[2])
        offset_b = float(sys.argv[3])
        
        if not os.path.exists(json_path):
            raise FileNotFoundError(f"JSON file not found: {json_path}")
            
        modify_json_file(json_path, offset_a, offset_b)
        print(f"Successfully modified {json_path} and created backup")
        
    except Exception as e:
        print(f"Error: {str(e)}")
        sys.exit(1)
```



## How have you tested this?
* Started App in Android device
* Connected to Server
* Opened Book
* Play to chapter's ending
* Wait untill it auto skip to next chapter's beginning
