### PR TITLE
[Enhancment] Implimented mTLS user certificate for Android

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
@@ -20,6 +20,7 @@ import com.anggrayudi.storage.SimpleStorageHelper
 import com.audiobookshelf.app.managers.DbManager
 import com.audiobookshelf.app.player.PlayerNotificationService
 import com.audiobookshelf.app.plugins.AbsAudioPlayer
+import com.audiobookshelf.app.plugins.AbsCertificate
 import com.audiobookshelf.app.plugins.AbsDatabase
 import com.audiobookshelf.app.plugins.AbsDownloader
 import com.audiobookshelf.app.plugins.AbsFileSystem
@@ -52,6 +53,7 @@ class MainActivity : BridgeActivity() {
     registerPlugin(AbsFileSystem::class.java)
     registerPlugin(AbsDatabase::class.java)
     registerPlugin(AbsLogger::class.java)
+    registerPlugin(AbsCertificate::class.java)
 
     super.onCreate(savedInstanceState)
     Log.d(tag, "onCreate")

--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -43,7 +43,8 @@ data class ServerConnectionConfig(
   var userId:String,
   var username:String,
   var token:String,
-  var customHeaders:Map<String, String>?
+  var customHeaders:Map<String, String>?,
+  var certificateAlias:String? = null // Added for client certificate alias (Android only currently)
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -1,8 +1,8 @@
 package com.audiobookshelf.app.managers
 
 import android.util.Log
+import com.audiobookshelf.app.server.HttpClientProvider
 import java.io.*
-import java.util.concurrent.TimeUnit
 import okhttp3.*
 
 /**
@@ -17,8 +17,7 @@ class InternalDownloadManager(
 ) : AutoCloseable {
 
   private val tag = "InternalDownloadManager"
-  private val client: OkHttpClient =
-          OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS).build()
+  private val client: OkHttpClient = HttpClientProvider.getDownloadClient()
   private val writer = BinaryFileWriter(outputStream, progressCallback)
 
   /**

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsCertificate.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsCertificate.kt
@@ -1,0 +1,33 @@
+package com.audiobookshelf.app.plugins
+
+import android.security.KeyChain
+import android.security.KeyChainAliasCallback
+import android.security.keystore.KeyProperties
+import android.util.Log
+import com.getcapacitor.*
+import com.getcapacitor.annotation.CapacitorPlugin
+
+@CapacitorPlugin(name = "AbsCertificate")
+class AbsCertificate : Plugin() {
+  private val TAG = "AbsCertificate"
+
+  @PluginMethod
+  fun pickCertificate(call: PluginCall) {
+    val activity = activity
+    // Restrict to common key algorithms to avoid showing incompatible certs
+    val keyTypes = arrayOf(KeyProperties.KEY_ALGORITHM_RSA, KeyProperties.KEY_ALGORITHM_EC)
+    KeyChain.choosePrivateKeyAlias(activity, object : KeyChainAliasCallback {
+      override fun alias(alias: String?) {
+        if (alias == null) {
+          call.reject("User canceled")
+          return
+        }
+        Log.d(TAG, "Picked alias $alias")
+        val ret = JSObject()
+        ret.put("alias", alias)
+        call.resolve(ret)
+      }
+    }, null, null, null, -1, null)
+
+  }
+}

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsCertificate.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsCertificate.kt
@@ -28,6 +28,5 @@ class AbsCertificate : Plugin() {
         call.resolve(ret)
       }
     }, null, null, null, -1, null)
-
   }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDatabase.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDatabase.kt
@@ -30,7 +30,7 @@ class AbsDatabase : Plugin() {
   data class LocalMediaProgressPayload(val value:List<LocalMediaProgress>)
   data class LocalLibraryItemsPayload(val value:List<LocalLibraryItem>)
   data class LocalFoldersPayload(val value:List<LocalFolder>)
-  data class ServerConnConfigPayload(val id:String?, val index:Int, val name:String?, val userId:String, val username:String, var version:String, val token:String, val refreshToken:String?, val address:String?, val customHeaders:Map<String,String>?)
+  data class ServerConnConfigPayload(val id:String?, val index:Int, val name:String?, val userId:String, val username:String, var version:String, val token:String, val refreshToken:String?, val address:String?, val customHeaders:Map<String,String>?, val certificateAlias:String? = null)
 
   override fun load() {
     mainActivity = (activity as MainActivity)
@@ -145,7 +145,7 @@ class AbsDatabase : Plugin() {
         }
         Log.d(tag, "Refresh token secured = $hasRefreshToken")
 
-        serverConnectionConfig = ServerConnectionConfig(sscId, sscIndex, "$serverAddress ($username)", serverAddress, serverVersion, userId, username, accessToken, serverConfigPayload.customHeaders)
+        serverConnectionConfig = ServerConnectionConfig(sscId, sscIndex, "$serverAddress ($username)", serverAddress, serverVersion, userId, username, accessToken, serverConfigPayload.customHeaders, serverConfigPayload.certificateAlias)
 
         // Add and save
         DeviceManager.deviceData.serverConnectionConfigs.add(serverConnectionConfig!!)
@@ -171,6 +171,12 @@ class AbsDatabase : Plugin() {
         // Set last connection config
         if (DeviceManager.deviceData.lastServerConnectionConfigId != serverConfigPayload.id) {
           DeviceManager.deviceData.lastServerConnectionConfigId = serverConfigPayload.id
+          shouldSave = true
+        }
+
+        // Persist certificate alias (read-only once set)
+        if (serverConnectionConfig?.certificateAlias == null && serverConfigPayload.certificateAlias != null) {
+          serverConnectionConfig?.certificateAlias = serverConfigPayload.certificateAlias
           shouldSave = true
         }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/server/HttpClientProvider.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/HttpClientProvider.kt
@@ -1,29 +1,20 @@
 package com.audiobookshelf.app.server
 
 import android.content.Context
-import android.security.KeyChain
-import android.security.KeyChainException
-import java.security.KeyStore
-import java.security.PrivateKey
-import java.security.SecureRandom
-import java.security.cert.X509Certificate
-import java.util.concurrent.TimeUnit
-import javax.net.ssl.*
 import okhttp3.OkHttpClient
-import java.security.Principal
-import java.net.Socket
+import java.util.concurrent.TimeUnit
 
 /**
- * Central provider for OkHttpClient instances used by the app.
+ * Central singleton provider for OkHttpClient instances used by the app.
  *
  * Responsibilities:
  * - Provide shared default client
  * - Provide a low-timeout "ping" client for quick connectivity checks
- * - Support dynamic configuration of mutual TLS (mTLS) using ONLY AndroidKeyStore / KeyChain alias
+ * - Support dynamic configuration of mutual TLS (mTLS) using ONLY AndroidKeyStore alias
  * - Rebuild underlying clients when security configuration changes
  */
-object HttpClientProvider {
-  // Stored alias for client cert (mTLS enabled iff not null)
+object HttpClientProvider { // Kotlin 'object' already guarantees singleton semantics
+  // Stored alias for client cert (mTLS enabled if not null / not blank)
   @Volatile private var clientCertAlias: String? = null
   @Volatile private var appContext: Context? = null
 
@@ -35,16 +26,31 @@ object HttpClientProvider {
     .writeTimeout(3, TimeUnit.SECONDS)
     .build()
 
+  @Volatile private var downloadClient: OkHttpClient? = null
   fun getDefaultClient(): OkHttpClient = defaultClient
   fun getPingClient(): OkHttpClient = pingClient
+  fun getDownloadClient(): OkHttpClient {
+    return downloadClient ?: synchronized(this) {
+      downloadClient ?: defaultClient.newBuilder()
+        .callTimeout(30, TimeUnit.SECONDS) // no timeout
+        .build().also { downloadClient = it }
+    }
+  }
 
+  /**
+   * Update the currently active mTLS alias. Passing null (or blank) disables mTLS.
+   */
   @Synchronized
   fun updateMtlsConfig(alias: String?) {
-    if (clientCertAlias == alias) return
-    clientCertAlias = alias?.takeIf { it.isNotBlank() }
+    val normalized = alias?.takeIf { it.isNotBlank() }
+    if (clientCertAlias == normalized) return
+    clientCertAlias = normalized
     rebuildClients()
   }
 
+  /**
+   * Overload that allows updating (or initially supplying) the application context.
+   */
   @Synchronized
   fun updateMtlsConfig(alias: String?, context: Context?) {
     if (context != null) appContext = context.applicationContext
@@ -61,92 +67,9 @@ object HttpClientProvider {
       .readTimeout(3, TimeUnit.SECONDS)
       .writeTimeout(3, TimeUnit.SECONDS)
       .build()
+    downloadClient = null
   }
 
-  private class AliasMaterial(val privateKey: PrivateKey?, val chain: Array<X509Certificate>?)
-
-  private fun fetchAliasMaterial(alias: String): AliasMaterial? {
-    // Try AndroidKeyStore first
-    try {
-      val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
-      val entry = ks.getEntry(alias, null) as? KeyStore.PrivateKeyEntry
-      if (entry != null) {
-        return AliasMaterial(entry.privateKey, entry.certificateChain.map { it as X509Certificate }.toTypedArray())
-      }
-    } catch (e: Exception) { e.printStackTrace() }
-
-    // Fallback to KeyChain
-    val ctx = appContext ?: return null
-    try {
-      val privateKey: PrivateKey? = KeyChain.getPrivateKey(ctx, alias)
-      val chain: Array<X509Certificate>? = KeyChain.getCertificateChain(ctx, alias)
-      if (privateKey != null && chain != null) {
-        return AliasMaterial(privateKey, chain)
-      }
-    } catch (e: KeyChainException) { e.printStackTrace() }
-      catch (_: InterruptedException) { Thread.currentThread().interrupt() }
-      catch (e: Exception) { e.printStackTrace() }
-    return null
-  }
-
-  private fun buildBaseClient(): OkHttpClient {
-    val builder = OkHttpClient.Builder()
-    val alias = clientCertAlias
-
-    if (alias != null) {
-      try {
-        val material = fetchAliasMaterial(alias)
-        if (material?.privateKey != null && material.chain != null) {
-          val km = SingleAliasKeyManager(alias, material.privateKey, material.chain)
-          var trustManagers: Array<TrustManager>? = null
-          try {
-            val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null) }
-            material.chain.forEachIndexed { index, cert -> keyStore.setCertificateEntry("ca$index", cert) }
-            val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-            tmf.init(keyStore)
-            trustManagers = tmf.trustManagers
-          } catch (e: Exception) {
-            e.printStackTrace()
-            trustManagers = null
-          }
-          val sslContext = SSLContext.getInstance("TLS")
-          sslContext.init(arrayOf(km), trustManagers ?: systemDefaultTrustManagers(), SecureRandom())
-          val trustManagerForSocketFactory = (trustManagers?.firstOrNull() as? X509TrustManager) ?: systemDefaultX509TrustManager()
-          builder.sslSocketFactory(sslContext.socketFactory, trustManagerForSocketFactory)
-        }
-      } catch (e: Exception) {
-        e.printStackTrace() // fallback to system defaults
-      }
-    }
-
-    return builder.build()
-  }
-
-  private class SingleAliasKeyManager(
-    private val alias: String,
-    private val privateKey: PrivateKey,
-    private val certChain: Array<X509Certificate>
-  ) : X509KeyManager {
-    override fun getClientAliases(keyType: String?, issuers: Array<Principal>): Array<String>? =
-      if (keyType != null && keyType.equals(privateKey.algorithm, ignoreCase = true)) arrayOf(alias) else null
-
-    override fun chooseClientAlias(keyTypes: Array<String>, issuers: Array<Principal>, socket: Socket): String? =
-      keyTypes.firstOrNull { it.equals(privateKey.algorithm, ignoreCase = true) }?.let { alias }
-
-    override fun getServerAliases(keyType: String?, issuers: Array<Principal>?): Array<String>? = null
-    override fun chooseServerAlias(keyType: String?, issuers: Array<Principal>, socket: Socket): String? = null
-    override fun getCertificateChain(alias: String?): Array<X509Certificate>? = if (this.alias == alias) certChain else null
-    override fun getPrivateKey(alias: String?): PrivateKey? = if (this.alias == alias) privateKey else null
-  }
-
-  private fun systemDefaultTrustManagers(): Array<TrustManager> {
-    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
-    tmf.init(null as KeyStore?)
-    return tmf.trustManagers
-  }
-
-  private fun systemDefaultX509TrustManager(): X509TrustManager {
-    val trustManagers = systemDefaultTrustManagers()
-    return trustManagers.first { it is X509TrustManager } as X509TrustManager
-  }
+  private fun buildBaseClient(): OkHttpClient =
+    MtlsOkHttpClientFactory.create(clientCertAlias)
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/server/HttpClientProvider.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/HttpClientProvider.kt
@@ -1,0 +1,152 @@
+package com.audiobookshelf.app.server
+
+import android.content.Context
+import android.security.KeyChain
+import android.security.KeyChainException
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.*
+import okhttp3.OkHttpClient
+import java.security.Principal
+import java.net.Socket
+
+/**
+ * Central provider for OkHttpClient instances used by the app.
+ *
+ * Responsibilities:
+ * - Provide shared default client
+ * - Provide a low-timeout "ping" client for quick connectivity checks
+ * - Support dynamic configuration of mutual TLS (mTLS) using ONLY AndroidKeyStore / KeyChain alias
+ * - Rebuild underlying clients when security configuration changes
+ */
+object HttpClientProvider {
+  // Stored alias for client cert (mTLS enabled iff not null)
+  @Volatile private var clientCertAlias: String? = null
+  @Volatile private var appContext: Context? = null
+
+  @Volatile private var defaultClient: OkHttpClient = buildBaseClient()
+  @Volatile private var pingClient: OkHttpClient = buildBaseClient().newBuilder()
+    .callTimeout(3, TimeUnit.SECONDS)
+    .connectTimeout(3, TimeUnit.SECONDS)
+    .readTimeout(3, TimeUnit.SECONDS)
+    .writeTimeout(3, TimeUnit.SECONDS)
+    .build()
+
+  fun getDefaultClient(): OkHttpClient = defaultClient
+  fun getPingClient(): OkHttpClient = pingClient
+
+  @Synchronized
+  fun updateMtlsConfig(alias: String?) {
+    if (clientCertAlias == alias) return
+    clientCertAlias = alias?.takeIf { it.isNotBlank() }
+    rebuildClients()
+  }
+
+  @Synchronized
+  fun updateMtlsConfig(alias: String?, context: Context?) {
+    if (context != null) appContext = context.applicationContext
+    updateMtlsConfig(alias)
+  }
+
+  @Synchronized
+  private fun rebuildClients() {
+    val base = buildBaseClient()
+    defaultClient = base
+    pingClient = base.newBuilder()
+      .callTimeout(3, TimeUnit.SECONDS)
+      .connectTimeout(3, TimeUnit.SECONDS)
+      .readTimeout(3, TimeUnit.SECONDS)
+      .writeTimeout(3, TimeUnit.SECONDS)
+      .build()
+  }
+
+  private class AliasMaterial(val privateKey: PrivateKey?, val chain: Array<X509Certificate>?)
+
+  private fun fetchAliasMaterial(alias: String): AliasMaterial? {
+    // Try AndroidKeyStore first
+    try {
+      val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+      val entry = ks.getEntry(alias, null) as? KeyStore.PrivateKeyEntry
+      if (entry != null) {
+        return AliasMaterial(entry.privateKey, entry.certificateChain.map { it as X509Certificate }.toTypedArray())
+      }
+    } catch (e: Exception) { e.printStackTrace() }
+
+    // Fallback to KeyChain
+    val ctx = appContext ?: return null
+    try {
+      val privateKey: PrivateKey? = KeyChain.getPrivateKey(ctx, alias)
+      val chain: Array<X509Certificate>? = KeyChain.getCertificateChain(ctx, alias)
+      if (privateKey != null && chain != null) {
+        return AliasMaterial(privateKey, chain)
+      }
+    } catch (e: KeyChainException) { e.printStackTrace() }
+      catch (_: InterruptedException) { Thread.currentThread().interrupt() }
+      catch (e: Exception) { e.printStackTrace() }
+    return null
+  }
+
+  private fun buildBaseClient(): OkHttpClient {
+    val builder = OkHttpClient.Builder()
+    val alias = clientCertAlias
+
+    if (alias != null) {
+      try {
+        val material = fetchAliasMaterial(alias)
+        if (material?.privateKey != null && material.chain != null) {
+          val km = SingleAliasKeyManager(alias, material.privateKey, material.chain)
+          var trustManagers: Array<TrustManager>? = null
+          try {
+            val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null) }
+            material.chain.forEachIndexed { index, cert -> keyStore.setCertificateEntry("ca$index", cert) }
+            val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+            tmf.init(keyStore)
+            trustManagers = tmf.trustManagers
+          } catch (e: Exception) {
+            e.printStackTrace()
+            trustManagers = null
+          }
+          val sslContext = SSLContext.getInstance("TLS")
+          sslContext.init(arrayOf(km), trustManagers ?: systemDefaultTrustManagers(), SecureRandom())
+          val trustManagerForSocketFactory = (trustManagers?.firstOrNull() as? X509TrustManager) ?: systemDefaultX509TrustManager()
+          builder.sslSocketFactory(sslContext.socketFactory, trustManagerForSocketFactory)
+        }
+      } catch (e: Exception) {
+        e.printStackTrace() // fallback to system defaults
+      }
+    }
+
+    return builder.build()
+  }
+
+  private class SingleAliasKeyManager(
+    private val alias: String,
+    private val privateKey: PrivateKey,
+    private val certChain: Array<X509Certificate>
+  ) : X509KeyManager {
+    override fun getClientAliases(keyType: String?, issuers: Array<Principal>): Array<String>? =
+      if (keyType != null && keyType.equals(privateKey.algorithm, ignoreCase = true)) arrayOf(alias) else null
+
+    override fun chooseClientAlias(keyTypes: Array<String>, issuers: Array<Principal>, socket: Socket): String? =
+      keyTypes.firstOrNull { it.equals(privateKey.algorithm, ignoreCase = true) }?.let { alias }
+
+    override fun getServerAliases(keyType: String?, issuers: Array<Principal>?): Array<String>? = null
+    override fun chooseServerAlias(keyType: String?, issuers: Array<Principal>, socket: Socket): String? = null
+    override fun getCertificateChain(alias: String?): Array<X509Certificate>? = if (this.alias == alias) certChain else null
+    override fun getPrivateKey(alias: String?): PrivateKey? = if (this.alias == alias) privateKey else null
+  }
+
+  private fun systemDefaultTrustManagers(): Array<TrustManager> {
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    tmf.init(null as KeyStore?)
+    return tmf.trustManagers
+  }
+
+  private fun systemDefaultX509TrustManager(): X509TrustManager {
+    val trustManagers = systemDefaultTrustManagers()
+    return trustManagers.first { it is X509TrustManager } as X509TrustManager
+  }
+}

--- a/android/app/src/main/java/com/audiobookshelf/app/server/MtlsOkHttpClientFactory.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/MtlsOkHttpClientFactory.kt
@@ -1,0 +1,103 @@
+package com.audiobookshelf.app.server
+
+import okhttp3.OkHttpClient
+import java.net.Socket
+import java.security.KeyStore
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509KeyManager
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Factory responsible for producing OkHttpClient instances configured for mTLS using an
+ * AndroidKeyStore alias. If alias is null or the key material cannot be loaded, a default
+ * client (no client cert) is produced.
+ */
+object MtlsOkHttpClientFactory {
+
+  fun create(alias: String?): OkHttpClient { // removed unused context param
+    val builder = OkHttpClient.Builder()
+    if (alias.isNullOrBlank()) return builder.build()
+
+    return try {
+      val material = loadKeyMaterial(alias)
+      if (material == null) {
+        builder.build()
+      } else {
+        val keyManager = SingleAliasKeyManager(alias, material.privateKey, material.chain)
+        val trustManagers = buildTrustManagersFromChain(material.chain) ?: systemDefaultTrustManagers()
+        val x509Trust = (trustManagers.firstOrNull { it is X509TrustManager } as? X509TrustManager)
+          ?: systemDefaultX509TrustManager()
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(arrayOf(keyManager), trustManagers, SecureRandom())
+        builder.sslSocketFactory(sslContext.socketFactory, x509Trust).build()
+      }
+    } catch (e: Exception) {
+      e.printStackTrace()
+      builder.build() // fallback to default client
+    }
+  }
+
+  private class KeyMaterial(val privateKey: PrivateKey, val chain: Array<X509Certificate>) // not a data class (Array equality warning removed)
+
+  /**
+   * Load private key + full certificate chain from AndroidKeyStore for the given alias.
+   */
+  private fun loadKeyMaterial(alias: String): KeyMaterial? = try {
+    val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+    val entry = ks.getEntry(alias, null) as? KeyStore.PrivateKeyEntry ?: return null
+    val chain = entry.certificateChain.map { it as X509Certificate }.toTypedArray()
+    KeyMaterial(entry.privateKey, chain)
+  } catch (e: Exception) {
+    e.printStackTrace(); null
+  }
+
+  /**
+   * Build trust managers from the provided certificate chain. We add the entire chain so that
+   * the trust manager will trust servers presenting certs issued by the chain's roots/intermediates.
+   * If anything fails we return null to allow fallback to system defaults.
+   */
+  private fun buildTrustManagersFromChain(chain: Array<X509Certificate>): Array<TrustManager>? = try {
+    val keyStore = KeyStore.getInstance(KeyStore.getDefaultType()).apply { load(null) }
+    chain.forEachIndexed { index, cert -> keyStore.setCertificateEntry("ca$index", cert) }
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    tmf.init(keyStore)
+    tmf.trustManagers
+  } catch (e: Exception) {
+    e.printStackTrace(); null
+  }
+
+  private fun systemDefaultTrustManagers(): Array<TrustManager> {
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    tmf.init(null as KeyStore?)
+    return tmf.trustManagers
+  }
+
+  private fun systemDefaultX509TrustManager(): X509TrustManager =
+    systemDefaultTrustManagers().first { it is X509TrustManager } as X509TrustManager
+
+  /**
+   * KeyManager that exposes only the selected alias.
+   */
+  private class SingleAliasKeyManager(
+    private val alias: String,
+    private val privateKey: PrivateKey,
+    private val certChain: Array<X509Certificate>
+  ) : X509KeyManager {
+    override fun getClientAliases(keyType: String?, issuers: Array<Principal>): Array<String>? =
+      if (keyType != null && keyType.equals(privateKey.algorithm, ignoreCase = true)) arrayOf(alias) else null
+
+    override fun chooseClientAlias(keyTypes: Array<String>, issuers: Array<Principal>, socket: Socket): String? =
+      keyTypes.firstOrNull { it.equals(privateKey.algorithm, ignoreCase = true) }?.let { alias }
+
+    override fun getServerAliases(keyType: String?, issuers: Array<Principal>?): Array<String>? = null
+    override fun chooseServerAlias(keyType: String?, issuers: Array<Principal>, socket: Socket): String? = null
+    override fun getCertificateChain(alias: String?): Array<X509Certificate>? = if (this.alias == alias) certChain else null
+    override fun getPrivateKey(alias: String?): PrivateKey? = if (this.alias == alias) privateKey else null
+  }
+}

--- a/plugins/capacitor/AbsCertificate.js
+++ b/plugins/capacitor/AbsCertificate.js
@@ -1,0 +1,14 @@
+import { registerPlugin, WebPlugin } from '@capacitor/core'
+
+class AbsCertificateWeb extends WebPlugin {
+  async pickCertificate() {
+    return Promise.reject(new Error('Client certificate selection not supported on this platform'))
+  }
+}
+
+const AbsCertificate = registerPlugin('AbsCertificate', {
+  web: () => new AbsCertificateWeb()
+})
+
+export { AbsCertificate }
+

--- a/plugins/capacitor/AbsDatabase.js
+++ b/plugins/capacitor/AbsDatabase.js
@@ -11,6 +11,8 @@ import { registerPlugin, Capacitor, WebPlugin } from '@capacitor/core'
  * @property {string} username
  * @property {string} token
  * @property {string} [refreshToken] - Only passed in when setting config, then stored in secure storage
+ * @property {string} [customHeaders]
+ * @property {string} [certificateAlias] // Optional client certificate alias (Android only)
  */
 
 class AbsDatabaseWeb extends WebPlugin {
@@ -49,6 +51,9 @@ class AbsDatabaseWeb extends WebPlugin {
       ssc.username = serverConnectionConfig.username
       ssc.version = serverConnectionConfig.version
       ssc.customHeaders = serverConnectionConfig.customHeaders || {}
+      if (serverConnectionConfig.certificateAlias && !ssc.certificateAlias) {
+        ssc.certificateAlias = serverConnectionConfig.certificateAlias
+      }
 
       if (serverConnectionConfig.refreshToken) {
         console.log('[AbsDatabase] Updating refresh token...', serverConnectionConfig.refreshToken)
@@ -67,7 +72,8 @@ class AbsDatabaseWeb extends WebPlugin {
         address: serverConnectionConfig.address,
         token: serverConnectionConfig.token,
         version: serverConnectionConfig.version,
-        customHeaders: serverConnectionConfig.customHeaders || {}
+        customHeaders: serverConnectionConfig.customHeaders || {},
+        certificateAlias: serverConnectionConfig.certificateAlias || null
       }
 
       if (serverConnectionConfig.refreshToken) {

--- a/plugins/capacitor/index.js
+++ b/plugins/capacitor/index.js
@@ -4,8 +4,9 @@ import { AbsDownloader } from './AbsDownloader'
 import { AbsFileSystem } from './AbsFileSystem'
 import { AbsDatabase } from './AbsDatabase'
 import { AbsLogger } from './AbsLogger'
+import { AbsCertificate } from './AbsCertificate'
 import { Capacitor } from '@capacitor/core'
 
 Vue.prototype.$platform = Capacitor.getPlatform()
 
-export { AbsAudioPlayer, AbsDownloader, AbsFileSystem, AbsLogger, AbsDatabase }
+export { AbsAudioPlayer, AbsDownloader, AbsFileSystem, AbsLogger, AbsDatabase, AbsCertificate }


### PR DESCRIPTION
## Brief summary

Implementation of Mutual TLS support on the Android platform

## Which issue is fixed?

Resolves #1419 
Resolves #353 

## Pull Request Type

Affects Android, Both front and back end

## In-depth Description

My plans as it stands is,
- Build UI Client cert selector for each server
  - [x] Select a cert per server
  - [ ] Edit a cert for existing servers
- Update Kotlin API to make use of the selected cert
  - [x] Separate the client builder and encapsulate mTLS usage
  - [x] Redirect API calls into this new builder
  - [ ] Add plugin to accept request form frontend and route them through the new builder
  - [ ] Tested that this actually works
- Update the VUE components to make use of the cert
  - [ ] Isolate all http calls into a central class
  - [ ] Add logic to detect if call can be redirected into the backend
  - [ ] Add ability to execute calls should backend not exist

### 1. UI Selection
That was a bit of a failed investigation, the SSL handshake in mTLS pipeline should allow for the server contacted to request the client (App) to send its user cert prompting the app to pop up a dialog listing installed certificate to choose from during the connection process. This would be an ideal situation as no extra UI would be needed, if the server needs a cert the user is prompted for on automatically

Sadly documentation for mTLS heavily favours hard-coded cert and keys where the app developer provide their own server and only want verified apps to be able to communicate with their server. i have been unable to find a way of getting the process to be automated thus have fallen to the backup of getting the user to manually select a cert when setting up the server connection.
<details>
<summary>ScreenShot</summary>
<img width="370" height="357" alt="Image" src="https://github.com/user-attachments/assets/f185434d-3e3e-4604-b272-407c04018d3e" />
<img width="370" height="357" alt="Image" src="https://github.com/user-attachments/assets/207d49aa-3167-40bc-918b-a04cd4c06bda" />
<img width="370" height="357" alt="Image" src="https://github.com/user-attachments/assets/b347dad2-8181-4926-9686-c9b5a878a4e4" />
</details>

### 2. Kotlin API
Updating the Kotlin code to use mTLS based on a pre-selected certificate is well documented, so implementing this wasn't overly difficult, the main issue is ensuring that all calls in the Kotlin code based is routed via a client that has the mTLS certificate set. While this code is mostly done i haven't been able to test it properly due to the next section.

### 3. VUE API
The app is split in two, Kotlin and vue, both have their own client that independently send requests to the server, after doing some research into the possibility of keeping this split and support the ability of the vue client to use mTLS certificates; it inst builtin to the client currently in use (CapacitorHTTP), although there is a plugin that can add this support, it seems its not easy to add this into the app. 

So the solution i am working towards is redirecting the requests into the kotlin code via the use of a custom capacitor plugin. this will allow the vue code to detect the presence of the plugin and thus the ability to reroute request via the Kotlin. for IOS this plugin wont exists and the vue will fallback to existing clients without mTLS support.


Comment and suggestion are welcome, I'm not a native app developer, so I'm bundling through this a lot with trial and error.


## How have you tested this?

TBD