### PR TITLE
fix sorting of next epsiode

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/DataClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DataClasses.kt
@@ -118,7 +118,7 @@ class Podcast(
 
   @JsonIgnore
   fun getNextUnfinishedEpisode(libraryItemId:String, mediaManager: MediaManager):PodcastEpisode? {
-    val sortedEpisodes = episodes?.sortedByDescending { it.publishedAt }
+    val sortedEpisodes = episodes?.sortedBy { it.publishedAt }
     val podcastEpisode = sortedEpisodes?.find { episode ->
       val progress = mediaManager.serverUserMediaProgress.find { it.libraryItemId == libraryItemId && it.episodeId == episode.id }
       progress == null || !progress.isFinished


### PR DESCRIPTION
## Brief summary

To fix that the newest episode is played, when the next episode should be played, i reversed the sorting before filtering.  

## Which issue is fixed?

Fixes: #1716

## Pull Request Type
Affects iOS and Android.  
Changes behavior of podcasts

## In-depth Description

The newest episode is played, because the newest non-played episode was selected.  
I reversed the sorting, so the oldest non-finished episode gets played.  
This matches the sorting in the web-ui.  

## How have you tested this?

Edit: i just tested this localy on my Device (Android 16)

## Screenshots

There are no visual changes.  