### PR TITLE
Pause and end playback if the Vue layer receives a progress update wh…

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -551,9 +551,7 @@ export default {
     timeupdate() {
       if (!this.$refs.playedTrack) {
         console.error('Invalid no played track ref')
-        this.pause()
         this.closePlayback()
-        // TODO: Attempt to rehydrate Vue session without interrupting native playback.
         return
       }
       this.$emit('updateTime', this.currentTime)


### PR DESCRIPTION
…ile having no played track ref.

## Brief summary

#1385 contains repro steps for disassociating the native player from the vue layer. While not technically the trigger users are experiencing in the wild, it's a good method for triggering a similar state, and one that we should be resilient towards. After using it to harden the Native/Vue sync behavior, I will send a patch to address that specific trigger.

This change recognizes when the native audio player is sending updates while the the Vue layer does not believe audio is being played. Regardless of how we got into that state, I believe we should pause and close playback to avoid losing progress. Fwiw, if this state is expected under normal conditions (and recoverable) then we shouldn't land my PR.

## Which issue is fixed?

Fixes #1385 (progress will not be lost any more).

Pressing "play" from native/bluetooth controls in this state will still result in an error toast (because the native and Vue players have become disassociated). Looking into a follow up to restore/rehydrate the Vue layer from a playing native audio player, but I think this fix should go in first as it at least avoids the outcome where progress is lost.

## Pull Request Type

It affects both I believe because it changes the Vue behavior. I have tested this on iOS, but in theory the change makes sense for both platforms (we probably don't want native playback to continue when the Vue layer believes it to have stopped).

## In-depth Description

Not much more to say than what's above.

## How have you tested this?

Tested on iOS using the repro steps provided on #1385 to trigger disassociation of Native/Vue layers and verify remediation.

## Screenshots

N/A.
