### PR TITLE
Don't require listening today for 'Days in a row' stat

### DIFF
--- a/components/stats/DailyListeningChart.vue
+++ b/components/stats/DailyListeningChart.vue
@@ -183,10 +183,16 @@ export default {
     daysInARow() {
       var count = 0
       while (true) {
-        var _date = this.$addDaysToToday(count * -1)
-        var datestr = this.$formatJsDate(_date, 'yyyy-MM-dd')
+        const _date = this.$addDaysToToday(count * -1 - 1)
+        const datestr = this.$formatJsDate(_date, 'yyyy-MM-dd')
 
         if (!this.listeningStatsDays[datestr] || this.listeningStatsDays[datestr] === 0) {
+          // don't require listening today to count towards days in a row, but do count it if already listened today
+          const today = this.$formatJsDate(new Date(), 'yyyy-MM-dd')
+          if (this.listeningStatsDays[today]) {
+            count++
+          }
+
           return count
         }
         count++


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

**Mirror of changes for https://github.com/advplyr/audiobookshelf/pull/4770**

Adjust logic for calculating 'Days in a row' stat to not require listening on the current day.

I usually listen at the end of the day, so this allows viewing the stat before you've listened for the day.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->

N/A - no associated issue currently

## Pull Request Type

<!--
Does this affect only Android, only iOS, or both?
Does this change the frontend or the backend of the apps?
-->

Platform: both

Layer: frontend


## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

Changes day counting logic to start counting from yesterday instead of today, so that there doesn't need to be any activity for the current day.

If there is activity for the current day this is counted at the end once the last day with no activity has been found.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->

Set some temporary test data in the ApiRouter.getUserListeningStatsHelpers method to mock appropriate activity on dates:
<img width="336" height="139" alt="image" src="https://github.com/user-attachments/assets/06fd7fd4-f90b-412c-9d82-5b96585f5234" />

## Screenshots

<!-- If your PR includes any changes to the front-end, please include screenshots or a
short video from before and after your changes. -->

No visual changes, only change is to the value shown for "Days in a row".