### PR TITLE
Android cast: stabilize MediaSession volume handling; simplify Google…

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -732,32 +732,21 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   }
 
   private fun setMediaSessionToCastVolume() {
-    val currentVol = try { castPlayer?.getDeviceVolume() ?: 0 } catch (e: Exception) { 0 }
+    val currentVol = try { castPlayer?.getDeviceVolume() ?: 0 } catch (_: Exception) { 0 }
     val provider = object : VolumeProviderCompat(VolumeProviderCompat.VOLUME_CONTROL_ABSOLUTE, 100, currentVol) {
       override fun onSetVolumeTo(volume: Int) {
+        // Clamp, update UI immediately, then send to device
         val clamped = volume.coerceIn(0, 100)
-        try {
-          castPlayer?.setDeviceVolume(clamped)
-          val actual = castPlayer?.getDeviceVolume() ?: clamped
-          setCurrentVolume(actual)
-        } catch (_: Exception) {}
+        setCurrentVolume(clamped)
+        try { castPlayer?.setDeviceVolume(clamped) } catch (_: Exception) {}
       }
+
       override fun onAdjustVolume(direction: Int) {
-        val current = try { castPlayer?.getDeviceVolume() ?: currentVolume } catch (_: Exception) { currentVolume }
-        val step = if (direction > 0) 1 else if (direction < 0) -1 else 0
-        if (step == 0) return
-        var target = (current + step).coerceIn(0, 100)
-        try {
-          castPlayer?.setDeviceVolume(target)
-          var actual = castPlayer?.getDeviceVolume() ?: current
-          // If device ignored tiny step, try nudging up to 3 steps total.
-          if (actual == current) {
-            target = (current + step * 3).coerceIn(0, 100)
-            castPlayer?.setDeviceVolume(target)
-            actual = castPlayer?.getDeviceVolume() ?: current
-          }
-          setCurrentVolume(actual)
-        } catch (_: Exception) {}
+        // Use Android-provided step (−1, 0, +1). Clamp, update UI immediately, then send.
+        val current = currentVolume
+        val target = (current + direction).coerceIn(0, 100)
+        setCurrentVolume(target)
+        try { castPlayer?.setDeviceVolume(target) } catch (_: Exception) {}
       }
     }
     remoteVolumeProvider = provider


### PR DESCRIPTION
… Cast volume

## Brief summary

Improves the Google Cast functionality to control the volume via a casting device

## Which issue is fixed?

Google Cast should now work properly, increment by 1 step and reflect the correct volume.

## Pull Request Type

Android

## In-depth Description

Use immediate UI updates via VolumeProvider (setCurrentVolume) and dispatch device volume changes without relying on async callbacks.

Simplify Cast volume: remove even-value quantization and step-2 enforcement; add short pending cache (~100ms) to bridge async setVolume.

Align increase/decrease to ±1 to match platform step; clamp to 0..100.

## How have you tested this?

APK install -> Cast -> Change volume

## Screenshots

N/A
