### PR TITLE
Android: advertise media capabilities properly

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -300,7 +300,11 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
               override fun getSupportedQueueNavigatorActions(player: Player): Long {
                 return PlaybackStateCompat.ACTION_PLAY_PAUSE or
                         PlaybackStateCompat.ACTION_PLAY or
-                        PlaybackStateCompat.ACTION_PAUSE
+                        PlaybackStateCompat.ACTION_PAUSE or
+                        PlaybackStateCompat.ACTION_FAST_FORWARD or
+                        PlaybackStateCompat.ACTION_REWIND or
+                        PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+                        PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS
               }
 
               override fun getMediaDescription(
@@ -582,6 +586,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                     PlaybackStateCompat.ACTION_PAUSE or
                     PlaybackStateCompat.ACTION_FAST_FORWARD or
                     PlaybackStateCompat.ACTION_REWIND or
+                    PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+                    PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
                     PlaybackStateCompat.ACTION_STOP
 
     if (deviceSettings.allowSeekingOnMediaControls) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->

advertises that fastforward/rewind are actually supported for external control.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
fixes #678


## Pull Request Type

Android
<!--
Does this affect only Android, only iOS, or both?
Does this change the frontend or the backend of the apps?
-->

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->
advertises that fastforward/rewind/next/prev are actually supported for external control.


## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
tested on my phone with my watch

## Screenshots

next/prev appear to be required, which changes the notification slightly. tho the watch uses the fast forward/rewind only...

![image](https://github.com/user-attachments/assets/0000d9c8-d10e-4a0f-b3b4-f9265c113597)

<!-- If your PR includes any changes to the front-end, please include screenshots or a
short video from before and after your changes. -->
