### PR TITLE
fix #1759: compact media controls in Android 16 incorrect actions

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -558,12 +558,12 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
 
   private fun setMediaSessionConnectorCustomActions(playbackSession: PlaybackSession) {
     val mediaItems = playbackSession.getMediaItems(ctx)
-    val customActionProviders =
-            mutableListOf(
-                    JumpBackwardCustomActionProvider(),
-                    JumpForwardCustomActionProvider(),
-                    ChangePlaybackSpeedCustomActionProvider() // Will be pushed to far left
-            )
+    val customActionProviders = mutableListOf(
+            ChangePlaybackSpeedCustomActionProvider(),
+            JumpBackwardCustomActionProvider(),
+            JumpForwardCustomActionProvider()
+    )
+
     if (playbackSession.mediaPlayer != PLAYER_CAST && mediaItems.size > 1) {
       customActionProviders.addAll(
               listOf(


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Compact media controls in Android 16 perform incorrect actions ("previous" button fast-forwards, "next" button changes playback speed)

## Which issue is fixed?

Fixes #1759

## Pull Request Type

Android app

## In-depth Description

Changing the order of the providers fixes the issue. It also changes the order of the buttons in the panel, though.
I haven't been able to find documentation on this change for Android 16.

## How have you tested this?

Tested on my Realme GT7 Pro and emulators for Android 15 and 16. See #1759 for reproduction steps.

I wasn't able to display the compact media control panel in the stock Android images, so this issue may be limited to customized images that use this style of media controls.

The buttons work as expected in all versions, including the emulators at the greatest available level of zoom.

## Screenshots
Compact media controls
![IMG_20251218_143751](https://github.com/user-attachments/assets/6ab2216e-888b-4444-80fd-19b2c9f89fde)

Expanded media controls, showing the order of the buttons
![Screenshot_2025-12-18-14-36-49-42_67d7f8591eff9881972c1169b8bca2d8](https://github.com/user-attachments/assets/92bb54cc-afaf-49b1-ae51-a5bd02f519f9)

Lock-screen media controls, showing the order of the buttons
![IMG_20251218_143735](https://github.com/user-attachments/assets/0b61b3a3-bbb2-4fcc-afcf-9c97deee0cd8)

