### PR TITLE
Always show cast button on Android

### DIFF
--- a/components/app/Appbar.vue
+++ b/components/app/Appbar.vue
@@ -21,7 +21,7 @@
       <widgets-download-progress-indicator />
 
       <!-- Must be connected to a server to cast, only supports media items on server -->
-      <button type="button" aria-label="Cast" v-show="isCastAvailable && user" class="mx-2 cursor-pointer flex items-center" @click="castClick">
+      <button type="button" aria-label="Cast" v-show="$platform === 'android' && user" class="mx-2 cursor-pointer flex items-center" @click="castClick">
         <span class="material-symbols text-2xl leading-none">
           {{ isCasting ? 'cast_connected' : 'cast' }}
         </span>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Very minor code change to always show the cast button instead of conditionally showing it based on 'isCastAvailable'.  This ensures Android users can always cast their audio, despite state changes.

## Which issue is fixed?

Fixes Issue #1130 

Although marked as closed, this could have been the underlying issue with #817 

## Pull Request Type

Platform: Android
Frontend Component - Appbar.vue

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

Previously, the cast button would disappear (or not show at all) if booting the app while off the network, or when changing state such as using Bluetooth. See comments in #1130 .  

This change is no longer conditional on 'isCastAvailable', and now always displays while on Android, and will use the Google Cast SDK to run scans.  Device discovery now happens on demand rather than upon app startup, ensuring the user doesn't have to reboot the app in order to continue their listening session on a castable device.

From what I can tell, iOS uses AirPlay, and this functionality only affected Android devices. As a result, if we wanted to dive further, we could likely retire all of the logic around the 'isCastAvailable' and instead rely entirely on the Cast SDK.

This is a change that solves a problem for all Android users using Google Cast.  This is the best solution because it is now triggered by the user at their discretion.

## How have you tested this?

I compiled the code change in Android Studio and sideloaded onto my Google Pixel 6.  Given the minor change, I tested the sideloaded app alongside the current release and was able to successfully connect to castable devices without the need for rebooting with these code changes.  In the current release, the cast button would not show when connecting to a new network or when previously on Bluetooth.  With the changes, the cast button is always visible and can be polled whenever the user chooses.

## Screenshots

No real change to the UI, as now the cast button is always visible.


Note: This is my first open source contribution, so apologies if I missed any steps.
