### PR TITLE
Enable constant bitrate seeking to fix AAC seek reset in ExoPlayer

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -480,6 +480,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         val dataSourceFactory = DefaultDataSource.Factory(ctx)
 
         val extractorsFactory = DefaultExtractorsFactory()
+        extractorsFactory.setConstantBitrateSeekingEnabled(true)
+
         if (DeviceManager.deviceData.deviceSettings?.enableMp3IndexSeeking == true) {
           // @see
           // https://exoplayer.dev/troubleshooting.html#why-is-seeking-inaccurate-in-some-mp3-files
@@ -494,6 +496,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         val dataSourceFactory = DefaultHttpDataSource.Factory()
 
         val extractorsFactory = DefaultExtractorsFactory()
+        extractorsFactory.setConstantBitrateSeekingEnabled(true)
+
         if (DeviceManager.deviceData.deviceSettings?.enableMp3IndexSeeking == true) {
           // @see
           // https://exoplayer.dev/troubleshooting.html#why-is-seeking-inaccurate-in-some-mp3-files


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

<!-- Please provide a brief summary of what your PR attempts to achieve. -->
Fixes an Android issue where seeking in certain AAC audio files would reset playback to the beginning of the file. This could also occur when resuming playback partway through a file after the app had been inactive, which effectively behaved the same as a seek.

## Which issue is fixed?

<!-- Which issue number does this PR fix? Ex: "Fixes #1234" -->
Fixes [#1308](https://github.com/advplyr/audiobookshelf-app/issues/1308)

## Pull Request Type

<!--
Does this affect only Android, only iOS, or both?
Does this change the frontend or the backend of the apps?
-->
Android app

## In-depth Description

<!--
Describe your solution in more depth.
How does it work? Why is this the best solution?
Does it solve a problem that affects multiple users or is this an edge case for your setup?
-->

On Android, audiobookshelf uses ExoPlayer for audio playback. For some AAC audio files, ExoPlayer is unable to derive a reliable seek map. When a seek is requested in these cases, ExoPlayer may “adjust” the seek back to position 0, causing playback to jump to the beginning after buffering.

This behavior has been observed with certain AAC files and does not reproduce in the web player, which uses the browser’s media stack. Other formats (such as MP3) generally do not exhibit this issue.

This change enables ExoPlayer’s constant-bitrate seeking mode on the DefaultExtractorsFactory for progressive playback (both local and direct HTTP sources). This allows ExoPlayer to perform approximate seeking for media where a seek map is unavailable, preventing the seek-to-start behavior while preserving normal behavior for formats that provide proper indexing.

Notes:
- Seeking becomes approximate for affected AAC files, which is expected for this fallback.
- No regressions were observed with MP3 or other indexed formats.
- HLS playback is unaffected.

## How have you tested this?

<!-- Please describe in detail with reproducible steps how you tested your changes. -->
I tested this using the TrueNAS Tech Talk podcast (RSS feed: https://www.truenas.com/feed/podcast/truenas-welcome-to-the-open-storage-era/), which publishes episodes encoded as AAC and reliably reproduces the issue.

Testing included:
- Seeking using the playhead
- Using skip forward/back controls
- Pausing playback, exiting the app, and later resuming playback

These tests were performed both while streaming episodes from the server and when playing episodes downloaded locally.

Additional testing was done with audiobooks encoded as m4b and mp3, and no regressions were observed.
## Screenshots

<!-- If your PR includes any changes to the front-end, please include screenshots or a
short video from before and after your changes. -->
