### PR TITLE
Play Next Episode correctly for serial podcasts

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -535,7 +535,11 @@ export default {
 
       if (this.isPodcast) {
         this.episodes.sort((a, b) => {
-          return String(b.publishedAt).localeCompare(String(a.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
+          if (this.podcastType === 'serial') {
+            return String(a.publishedAt).localeCompare(String(b.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
+          } else {
+            return String(b.publishedAt).localeCompare(String(a.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
+          }
         })
 
         let episode = this.episodes.find((ep) => {


### PR DESCRIPTION
## Brief summary

The default episode sort correctly takes podcast type into account (oldest to newest for serial, newest to oldest for episodic). However the Play Next Episode button uses episodic sorting for all podcast types. This minimal change fixes that.

## Which issue is fixed?

Fixes #1716

## Pull Request Type

Android, iOS, Frontend only

## In-depth Description

The existing behavior was correct for episodic podcasts. The new behavior simply reverses the sort order if the podcast is of type `"serial"`

## How have you tested this?

* Go to an episodic podcast with multiple unplayed episodes
* Click **Play Next Episode**
* Note that newest episode starts playing
* Go to an episodic podcast with multiple unplayed episodes
* Click **Play Next Episode**
* Note that oldest episode starts playing
