### PR TITLE
Fix issue: 1161 ([Bug]: Mobile app ignores external progress when playing on web)

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -328,12 +328,9 @@ export default {
       if (document.visibilityState === 'visible') {
         const elapsedTimeOutOfFocus = Date.now() - this.timeLostFocus
         console.log(`✅ [default] device visibility: has focus (${elapsedTimeOutOfFocus}ms out of focus)`)
-        // If device out of focus for more than 30s then reload local media progress
-        if (elapsedTimeOutOfFocus > 30000) {
-          console.log(`✅ [default] device visibility: syncing local + server media progress after > 30s out of focus`)
-          await this.syncLocalSessions(false).then(() => this.reloadServerMediaProgress());
-        } else if(!this.$socket?.connected){
-          console.log(`✅ [default] device visibility: syncing local + server media progress after websocket disconnect`)
+        // If device out of focus for more than 30s or websocket disconnected then sync local progress with server progress
+        if (elapsedTimeOutOfFocus > 30000 || !this.$socket?.connected) {
+          console.log(`✅ [default] device visibility: syncing local + server media progress ${elapsedTimeOutOfFocus > 30000 ? 'after being out of focus for more than 30s' : 'after websocket disconnect'}`)
           await this.syncLocalSessions(false).then(() => this.reloadServerMediaProgress());
         }
         if (document.visibilityState === 'visible') {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -295,33 +295,39 @@ export default {
         this.$store.commit('globals/updateLocalMediaProgress', newLocalMediaProgress)
       }
     },
-    async reloadServerMediaProgress(){
+    async reloadServerProgressForCurrentlyPlaying() {
       try {
+        const currentSession = this.$store.state.currentPlaybackSession
+        if (!currentSession || !currentSession.libraryItemId) {
+          return
+        }
+
         const deviceData = await this.$db.getDeviceData()
         let serverConfig = null
         if (deviceData && deviceData.lastServerConnectionConfigId && deviceData.serverConnectionConfigs.length) {
           serverConfig = deviceData.serverConnectionConfigs.find((scc) => scc.id === deviceData.lastServerConnectionConfigId)
         }
-        if (!serverConfig){
-          console.error('[default] No server config found, cannot reload server media progress');
-          return;
+        if (!serverConfig) {
+          AbsLogger.error({ tag: 'default', message: 'reloadServerProgressForCurrentlyPlaying: No server config found, cannot reload server media progress' })
+          return
         }
+
+        const url = `${serverConfig.address}/api/me/progress/${currentSession.libraryItemId}${currentSession.episodeId ? `/${currentSession.episodeId}` : ''}`
         const response = await CapacitorHttp.get({
-          url: `${serverConfig.address}/api/me`,
+          url,
           headers: { Authorization: `Bearer ${serverConfig.token}` },
           connectTimeout: 6000
         })
-        if (response && response.data && response.data.mediaProgress) {
-          console.log('✅ [default] Successfully refreshed user info/media progress from server on visibility change')
-          response.data.mediaProgress.forEach(async (prog) => {
-            // Update local media progress
-            await this.userMediaProgressUpdated({ id: prog.id, data: prog, sessionId: 'visibility-change-sync' })
-          })
+
+        if (response && response.data) {
+          AbsLogger.info({ tag: 'default', message: 'reloadServerProgressForCurrentlyPlaying: Successfully refreshed current item media progress from server on visibility change' })
+          const prog = response.data
+          await this.userMediaProgressUpdated({ id: prog.id, data: prog, sessionId: 'visibility-change-sync' })
         } else {
-          console.warn('[default] No mediaProgress in /api/me response')
+          AbsLogger.info({ tag: 'default', message: 'reloadServerProgressForCurrentlyPlaying: No mediaProgress in /api/me/progress response' })
         }
       } catch (err) {
-        console.error('[default] Failed to refresh user info on visibility change', err)
+        AbsLogger.error({ tag: 'default', message: `reloadServerProgressForCurrentlyPlaying: Failed to refresh user info on visibility change: ${err.message}` })
       }
     },
     async visibilityChanged() {
@@ -331,11 +337,10 @@ export default {
         // If device out of focus for more than 30s or websocket disconnected then sync local progress with server progress
         if (elapsedTimeOutOfFocus > 30000 || !this.$socket?.connected) {
           console.log(`✅ [default] device visibility: syncing local + server media progress ${elapsedTimeOutOfFocus > 30000 ? 'after being out of focus for more than 30s' : 'after websocket disconnect'}`)
-          await this.syncLocalSessions(false).then(() => this.reloadServerMediaProgress());
+          await this.syncLocalSessions(false)
+          await this.reloadServerProgressForCurrentlyPlaying()
         }
-        if (document.visibilityState === 'visible') {
-          this.$eventBus.$emit('device-focus-update', true)
-        }
+        this.$eventBus.$emit('device-focus-update', true)
       } else {
         console.log('⛔️ [default] device visibility: does NOT have focus')
         this.timeLostFocus = Date.now()

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -336,8 +336,7 @@ export default {
         console.log(`✅ [default] device visibility: has focus (${elapsedTimeOutOfFocus}ms out of focus)`)
         // If device out of focus for more than 30s or websocket disconnected then sync local progress with server progress
         if (elapsedTimeOutOfFocus > 30000 || !this.$socket?.connected) {
-          console.log(`✅ [default] device visibility: syncing local + server media progress ${elapsedTimeOutOfFocus > 30000 ? 'after being out of focus for more than 30s' : 'after websocket disconnect'}`)
-          await this.syncLocalSessions(false)
+          console.log(`✅ [default] device visibility: syncing media progress for currently playing item ${elapsedTimeOutOfFocus > 30000 ? 'after being out of focus for more than 30s' : 'after websocket disconnect'}`)
           await this.reloadServerProgressForCurrentlyPlaying()
         }
         this.$eventBus.$emit('device-focus-update', true)


### PR DESCRIPTION
## Brief summary
This PR tries to fix the issue which users were seeing when playing an audiobook on the web and continuing on the app. The server progress would not be visible in the app and it would use the local progress, overwriting any server progress.  

## Which issue is fixed?
https://github.com/advplyr/audiobookshelf-app/issues/1161

## Pull Request Type
Android + iOS, the backend

## In-depth Description
Whenever the websocket is disconnected, or the app has not been visible for 30 seconds, it syncs the local progress to the server and vice versa. 

## How have you tested this?
Played an audiobook on the server/web with app opened on my Android Phone
Scrolled through the audiobook in web, app progress was synced
Closed app for > 30 seconds
Saw a websocket disconnect in the logs
Opened app again, progress was synced -> This is not the case without this PR. 
