### PR TITLE
perf: use server-side extraction for remote comic books

### DIFF
--- a/components/readers/ComicReader.vue
+++ b/components/readers/ComicReader.vue
@@ -324,7 +324,7 @@ export default {
         this.fileIno = response.fileIno
         this.extractedItemId = itemId  // Store for use in getServerPageUrl
 
-        this.$toast.success(`Server extraction: ${this.numPages} pages`)
+        console.log(`[ComicReader] Server extraction ready: ${this.numPages} pages`)
         this.loading = false
 
         const startPage = this.savedPage > 0 && this.savedPage <= this.numPages ? this.savedPage : 1
@@ -505,12 +505,12 @@ export default {
       console.log('[ComicReader] init - isLocal:', this.isLocal, 'serverLibraryItemId:', this.serverLibraryItemId)
       if (this.isLocal || !this.serverLibraryItemId) {
         console.log('[ComicReader] Using client-side comic extraction (local file)')
-        this.$toast.info('Using client-side extraction (slow)')
+        console.log('[ComicReader] Using client-side extraction')
         this.useServerExtraction = false
         await this.extract()
       } else {
         console.log('[ComicReader] Using server-side comic extraction')
-        this.$toast.info('Trying server-side extraction...')
+        console.log('[ComicReader] Trying server-side extraction')
         this.useServerExtraction = true
         await this.initServerExtraction()
       }

--- a/components/readers/ComicReader.vue
+++ b/components/readers/ComicReader.vue
@@ -15,7 +15,7 @@
 
     <div class="overflow-hidden m-auto comicwrapper relative">
       <div class="h-full flex justify-center">
-        <img v-if="mainImg" :src="mainImg" class="object-contain comicimg" />
+        <img v-if="mainImg" :src="mainImg" class="object-contain comicimg" @error="onImageError" />
       </div>
 
       <div v-show="loading" class="w-full h-full absolute top-0 left-0 flex items-center justify-center z-10">
@@ -65,14 +65,21 @@ export default {
       loadTimeout: null,
       loadedFirstPage: false,
       comicMetadata: null,
-      pageMenuWidth: 256
+      pageMenuWidth: 256,
+      // Server-side extraction support
+      useServerExtraction: false,
+      serverPagesData: null,
+      fileIno: null,
+      // Preloading for smooth navigation
+      preloadedPages: {},
+      preloadQueue: []
     }
   },
   watch: {
     url: {
       immediate: true,
       handler() {
-        this.extract()
+        this.init()
       }
     }
   },
@@ -203,22 +210,122 @@ export default {
       if (!this.canGoPrev) return
       this.setPage(this.page - 1)
     },
-    setPage(page) {
+    async setPage(page) {
       if (page <= 0 || page > this.numPages) {
         return
       }
       this.showPageMenu = false
-      const filename = this.pages[page - 1]
       this.page = page
 
       this.updateProgress()
-      return this.extractFile(filename)
+
+      if (this.useServerExtraction) {
+        await this.loadServerPage(page)
+        this.preloadAdjacentPages(page)
+      } else {
+        const filename = this.pages[page - 1]
+        await this.extractFile(filename)
+      }
     },
     setLoadTimeout() {
       this.loadTimeout = setTimeout(() => {
         this.loading = true
       }, 150)
     },
+    onImageError(e) {
+      console.error('Failed to load image', e)
+      this.$toast.error('Failed to load page')
+      this.loading = false
+    },
+
+    // ===== Server-side extraction methods =====
+    async loadServerPage(pageNum) {
+      // Check if already preloaded
+      if (this.preloadedPages[pageNum]) {
+        this.mainImg = this.preloadedPages[pageNum]
+        this.loading = false
+        return
+      }
+
+      this.setLoadTimeout()
+
+      try {
+        const pageUrl = this.getServerPageUrl(pageNum)
+        // For server pages, we can use the URL directly as img src
+        // The server handles extraction and returns the image
+        this.mainImg = pageUrl
+        this.loading = false
+        clearTimeout(this.loadTimeout)
+      } catch (error) {
+        console.error('Failed to load server page:', error)
+        this.$toast.error('Failed to load page')
+        this.loading = false
+        clearTimeout(this.loadTimeout)
+      }
+    },
+    getServerPageUrl(pageNum) {
+      const baseUrl = `/api/items/${this.serverLibraryItemId}/comic-page/${pageNum}`
+      if (this.fileIno) {
+        return `${baseUrl}/${this.fileIno}`
+      }
+      return baseUrl
+    },
+    preloadAdjacentPages(currentPage) {
+      // Preload 2 pages ahead and 1 behind
+      const pagesToPreload = [
+        currentPage + 1,
+        currentPage + 2,
+        currentPage - 1
+      ].filter(p => p > 0 && p <= this.numPages && !this.preloadedPages[p])
+
+      pagesToPreload.forEach(pageNum => {
+        const img = new Image()
+        img.onload = () => {
+          this.preloadedPages[pageNum] = img.src
+        }
+        img.src = this.getServerPageUrl(pageNum)
+      })
+    },
+    async initServerExtraction() {
+      this.loading = true
+
+      try {
+        // Get comic metadata from server
+        let pagesUrl = `/api/items/${this.serverLibraryItemId}/comic-pages`
+        
+        // Extract file ino from URL if present (for supplementary ebooks)
+        const urlMatch = this.url.match(/\/ebook\/([^/]+)$/)
+        if (urlMatch) {
+          this.fileIno = urlMatch[1]
+          pagesUrl += `/${this.fileIno}`
+        }
+
+        const response = await this.$nativeHttp.get(pagesUrl)
+        this.serverPagesData = response.data
+
+        this.pages = response.data.pages.map(p => p.filename)
+        this.numPages = response.data.numPages
+        this.fileIno = response.data.fileIno
+
+        this.loading = false
+
+        const startPage = this.savedPage > 0 && this.savedPage <= this.numPages ? this.savedPage : 1
+        await this.setPage(startPage)
+        this.loadedFirstPage = true
+
+        this.$emit('loaded', {
+          hasMetadata: false // Server extraction doesn't include comic metadata yet
+        })
+      } catch (error) {
+        console.error('Failed to init server extraction:', error)
+        // Fall back to client-side extraction
+        console.log('Falling back to client-side extraction')
+        this.useServerExtraction = false
+        await this.extract()
+      }
+    },
+
+    // ===== Client-side extraction methods (for local files) =====
     extractFile(filename) {
       return new Promise(async (resolve) => {
         this.setLoadTimeout()
@@ -359,6 +466,31 @@ export default {
       orderedImages = orderedImages.concat(noNumImages.map((i) => i.filename))
 
       this.pages = orderedImages
+    },
+
+    // ===== Initialization =====
+    async init() {
+      // Reset state
+      this.preloadedPages = {}
+      this.filesObject = null
+      this.serverPagesData = null
+      this.fileIno = null
+      this.page = 0
+      this.numPages = 0
+      this.mainImg = null
+      this.loadedFirstPage = false
+
+      // Determine whether to use server-side or client-side extraction
+      // Use server-side for remote files, client-side for local files
+      if (this.isLocal || !this.serverLibraryItemId) {
+        console.log('Using client-side comic extraction (local file)')
+        this.useServerExtraction = false
+        await this.extract()
+      } else {
+        console.log('Using server-side comic extraction')
+        this.useServerExtraction = true
+        await this.initServerExtraction()
+      }
     }
   },
   mounted() {},

--- a/components/readers/ComicReader.vue
+++ b/components/readers/ComicReader.vue
@@ -264,11 +264,12 @@ export default {
       }
     },
     getServerPageUrl(pageNum) {
+      const serverAddress = this.$store.getters['user/getServerAddress']
       const baseUrl = `/api/items/${this.serverLibraryItemId}/comic-page/${pageNum}`
       if (this.fileIno) {
-        return `${baseUrl}/${this.fileIno}`
+        return `${serverAddress}${baseUrl}/${this.fileIno}`
       }
-      return baseUrl
+      return `${serverAddress}${baseUrl}`
     },
     preloadAdjacentPages(currentPage) {
       // Preload 2 pages ahead and 1 behind
@@ -300,7 +301,9 @@ export default {
           pagesUrl += `/${this.fileIno}`
         }
 
+        console.log('[ComicReader] Fetching comic pages from:', pagesUrl)
         const response = await this.$nativeHttp.get(pagesUrl)
+        console.log('[ComicReader] Got response:', response.data)
         this.serverPagesData = response.data
 
         this.pages = response.data.pages.map(p => p.filename)
@@ -317,9 +320,10 @@ export default {
           hasMetadata: false // Server extraction doesn't include comic metadata yet
         })
       } catch (error) {
-        console.error('Failed to init server extraction:', error)
+        console.error('[ComicReader] Failed to init server extraction:', error)
+        console.error('[ComicReader] Error details:', error.response?.status, error.response?.data)
         // Fall back to client-side extraction
-        console.log('Falling back to client-side extraction')
+        console.log('[ComicReader] Falling back to client-side extraction')
         this.useServerExtraction = false
         await this.extract()
       }
@@ -482,12 +486,13 @@ export default {
 
       // Determine whether to use server-side or client-side extraction
       // Use server-side for remote files, client-side for local files
+      console.log('[ComicReader] init - isLocal:', this.isLocal, 'serverLibraryItemId:', this.serverLibraryItemId)
       if (this.isLocal || !this.serverLibraryItemId) {
-        console.log('Using client-side comic extraction (local file)')
+        console.log('[ComicReader] Using client-side comic extraction (local file)')
         this.useServerExtraction = false
         await this.extract()
       } else {
-        console.log('Using server-side comic extraction')
+        console.log('[ComicReader] Using server-side comic extraction')
         this.useServerExtraction = true
         await this.initServerExtraction()
       }


### PR DESCRIPTION
## Summary
Large comic files (300+ MB CBR/CBZ) were causing 30-60 second load times because the entire file was downloaded to the mobile client before extraction could begin.

## Changes
- Uses new server-side `/api/items/:id/comic-pages` and `/api/items/:id/comic-page/:page` endpoints
- Pages are extracted and cached on the server, then sent individually to the client
- Preloads 2 pages ahead, 1 behind for smooth page turning
- Falls back to client-side extraction for local/downloaded files (file already on device)

## Dependencies
**Requires server PR:** advplyr/audiobookshelf#5078

The server PR adds the comic-pages and comic-page endpoints that this mobile app PR depends on. Both PRs need to be merged for the full fix.

## Testing
1. Merge server PR first (or test against a server with that PR applied)
2. Open a large CBR/CBZ comic from the server (not downloaded locally)
3. Pages should load quickly instead of waiting for full file download
4. Page navigation should be smooth with preloading

## Related
Fixes: advplyr/audiobookshelf#3505