### PR TITLE
feat: zoom on pdf

### DIFF
--- a/components/readers/PdfReader.vue
+++ b/components/readers/PdfReader.vue
@@ -1,24 +1,19 @@
 <template>
   <div class="w-full h-full relative">
-    <div v-show="canGoPrev" class="absolute top-0 left-0 h-full w-1/2 hover:opacity-100 opacity-0 z-10 cursor-pointer" @click.stop.prevent="prev" @mousedown.prevent>
-      <div class="flex items-center justify-center h-full w-1/2">
-        <span class="material-symbols text-5xl text-white cursor-pointer text-opacity-30 hover:text-opacity-90">arrow_back_ios</span>
-      </div>
-    </div>
-    <div v-show="canGoNext" class="absolute top-0 right-0 h-full w-1/2 hover:opacity-100 opacity-0 z-10 cursor-pointer" @click.stop.prevent="next" @mousedown.prevent>
-      <div class="flex items-center justify-center h-full w-1/2 ml-auto">
-        <span class="material-symbols text-5xl text-white cursor-pointer text-opacity-30 hover:text-opacity-90">arrow_forward_ios</span>
-      </div>
-    </div>
-
     <div class="h-full flex items-center justify-center">
-      <div :style="{ width: pdfWidth + 'px', height: pdfHeight + 'px' }" class="w-full h-full overflow-auto">
+      <div ref="scrollContainer" class="w-full h-full overflow-auto">
         <div v-if="loadedRatio > 0 && loadedRatio < 1" style="background-color: green; color: white; text-align: center" :style="{ width: loadedRatio * 100 + '%' }">{{ Math.floor(loadedRatio * 100) }}%</div>
-        <pdf v-if="pdfDocInitParams" ref="pdf" class="m-auto z-10 border border-black border-opacity-20 shadow-md bg-white" :src="pdfDocInitParams" :page="page" :rotate="rotate" @progress="loadedRatio = $event" @error="error" @num-pages="numPagesLoaded" @link-clicked="page = $event" @loaded="loadedEvt"></pdf>
+
+        <div :style="spacerStyle">
+          <div ref="pdfWrapper" style="position: absolute; top: 0; left: 0" :style="pdfWrapperStyle">
+            <pdf v-if="pdfDocInitParams" ref="pdf" class="z-10 border border-black border-opacity-20 shadow-md bg-white" style="width: 100%" :src="pdfDocInitParams" :page="page" :rotate="rotate" @progress="loadedRatio = $event" @error="error" @num-pages="numPagesLoaded" @link-clicked="page = $event" @loaded="loadedEvt" />
+          </div>
+        </div>
       </div>
     </div>
 
     <div class="fixed left-0 h-8 w-full bg-bg px-4 flex items-center text-fg-muted" :style="{ bottom: isPlayerOpen ? '120px' : '0px' }">
+      <p class="text-xs">{{ Math.round(zoom * 100) }}%</p>
       <div class="flex-grow" />
       <p class="text-xs">{{ page }} / {{ numPages }}</p>
     </div>
@@ -50,7 +45,39 @@ export default {
       windowWidth: 0,
       windowHeight: 0,
       pdfDocInitParams: null,
-      isRefreshing: false
+      isRefreshing: false,
+
+      renderScale: 2.5,
+
+      zoom: 1,
+      liveZoom: 1,
+
+      isPinching: false,
+      pinch: {
+        enableTransform: false,
+        startDistance: 0,
+        startZoom: 1,
+        baseContentX: 0,
+        baseContentY: 0,
+        lastCenterClientX: 0,
+        lastCenterClientY: 0,
+        wrapperStartLeft: 0,
+        wrapperStartTop: 0,
+        startLocalX: 0,
+        startLocalY: 0,
+        translateX: 0,
+        translateY: 0,
+        rafId: null
+      },
+      swipe: {
+        startX: 0,
+        startY: 0,
+        startTime: 0
+      },
+      lastTapTime: 0,
+      touchStartedOnLink: false,
+      pendingZoomCommit: null,
+      singleTapTimeoutId: null
     }
   },
   computed: {
@@ -85,12 +112,43 @@ export default {
     pdfHeight() {
       return this.pdfWidth * 1.667
     },
-    canGoNext() {
-      return this.page < this.numPages
+    minZoom() {
+      return 1
     },
-    canGoPrev() {
-      return this.page > 1
+    maxZoom() {
+      return 4
     },
+
+    spacerStyle() {
+      // Defines the scrollable content size at the current zoom.
+      return {
+        position: 'relative',
+        width: this.pdfWidth * this.zoom + 'px',
+        height: this.pdfHeight * this.zoom + 'px'
+      }
+    },
+
+    pdfWrapperStyle() {
+      // Renders the PDF at renderScale, then CSS-scales it to zoom.
+      // During pinch we apply translate+scale for a smooth live zoom.
+
+      const style = {
+        width: this.pdfWidth * this.renderScale + 'px',
+        transformOrigin: '0 0',
+        willChange: 'transform'
+      }
+
+      if (this.isPinching && this.pinch.enableTransform) {
+        const scale = this.liveZoom / this.renderScale
+        style.transform = `translate(${this.pinch.translateX}px, ${this.pinch.translateY}px) scale(${scale})`
+      } else {
+        const scale = this.zoom / this.renderScale
+        style.transform = `translate(0px, 0px) scale(${scale})`
+      }
+
+      return style
+    },
+
     userItemProgress() {
       if (this.isLocal) return this.localItemProgress
       return this.serverItemProgress
@@ -117,6 +175,354 @@ export default {
     }
   },
   methods: {
+    clamp(num, min, max) {
+      return Math.max(min, Math.min(max, num))
+    },
+    getTouchDistance(touchA, touchB) {
+      const dx = touchA.clientX - touchB.clientX
+      const dy = touchA.clientY - touchB.clientY
+      return Math.sqrt(dx * dx + dy * dy)
+    },
+    getTouchCenter(touchA, touchB) {
+      return {
+        clientX: (touchA.clientX + touchB.clientX) / 2,
+        clientY: (touchA.clientY + touchB.clientY) / 2
+      }
+    },
+    isLinkTarget(event) {
+      const target = event && event.target
+      if (!target) return false
+      if (target.tagName === 'A') return true
+      return typeof target.closest === 'function' && !!target.closest('a')
+    },
+
+    clearSingleTapTimeout() {
+      if (!this.singleTapTimeoutId) return
+      clearTimeout(this.singleTapTimeoutId)
+      this.singleTapTimeoutId = null
+    },
+    resetZoom() {
+      this.zoom = 1
+      this.liveZoom = 1
+      this.pendingZoomCommit = null
+      this.pinch.enableTransform = false
+      this.clearSingleTapTimeout()
+      this.$nextTick(() => {
+        const container = this.$refs.scrollContainer
+        if (!container) return
+        container.scrollLeft = 0
+        container.scrollTop = 0
+      })
+    },
+
+    applyPendingZoomCommit() {
+      if (!this.pendingZoomCommit) return
+
+      const container = this.$refs.scrollContainer
+      if (!container) return
+
+      const { committedZoom, baseX, baseY, centerClientX, centerClientY } = this.pendingZoomCommit
+
+      const containerRect = container.getBoundingClientRect()
+      const centerXInContainer = centerClientX - containerRect.left
+      const centerYInContainer = centerClientY - containerRect.top
+
+      const desiredLocalX = baseX * committedZoom
+      const desiredLocalY = baseY * committedZoom
+
+      let desiredScrollLeft = desiredLocalX - centerXInContainer
+      let desiredScrollTop = desiredLocalY - centerYInContainer
+
+      const maxScrollLeft = Math.max(0, container.scrollWidth - container.clientWidth)
+      const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
+
+      desiredScrollLeft = this.clamp(desiredScrollLeft, 0, maxScrollLeft)
+      desiredScrollTop = this.clamp(desiredScrollTop, 0, maxScrollTop)
+
+      container.scrollLeft = desiredScrollLeft
+      container.scrollTop = desiredScrollTop
+
+      this.pendingZoomCommit = null
+    },
+
+    finalizeZoomCommit() {
+      this.applyPendingZoomCommit()
+      this.pinch.translateX = 0
+      this.pinch.translateY = 0
+      this.pinch.enableTransform = false
+    },
+    afterLayout(cb) {
+      this.$nextTick(() => requestAnimationFrame(() => requestAnimationFrame(cb)))
+    },
+    zoomToClientPoint(committedZoom, clientX, clientY) {
+      const container = this.$refs.scrollContainer
+      if (!container) return
+
+      const rect = container.getBoundingClientRect()
+      const xInContainer = clientX - rect.left
+      const yInContainer = clientY - rect.top
+
+      const baseX = (container.scrollLeft + xInContainer) / this.zoom
+      const baseY = (container.scrollTop + yInContainer) / this.zoom
+
+      this.zoom = committedZoom
+      this.liveZoom = committedZoom
+      this.pendingZoomCommit = {
+        committedZoom,
+        baseX,
+        baseY,
+        centerClientX: clientX,
+        centerClientY: clientY
+      }
+
+      this.afterLayout(() => this.finalizeZoomCommit())
+    },
+
+    registerTouchListeners() {
+      const container = this.$refs.scrollContainer
+      if (!container) return
+
+      if (!this._onTouchStart) {
+        this._onTouchStart = this.onTouchStart.bind(this)
+        this._onTouchMove = this.onTouchMove.bind(this)
+        this._onTouchEnd = this.onTouchEnd.bind(this)
+      }
+
+      container.addEventListener('touchstart', this._onTouchStart, { passive: true })
+      container.addEventListener('touchmove', this._onTouchMove, { passive: false })
+      container.addEventListener('touchend', this._onTouchEnd, { passive: true })
+      container.addEventListener('touchcancel', this._onTouchEnd, { passive: true })
+    },
+
+    unregisterTouchListeners() {
+      const container = this.$refs.scrollContainer
+      if (!container || !this._onTouchStart) return
+
+      container.removeEventListener('touchstart', this._onTouchStart)
+      container.removeEventListener('touchmove', this._onTouchMove)
+      container.removeEventListener('touchend', this._onTouchEnd)
+      container.removeEventListener('touchcancel', this._onTouchEnd)
+    },
+
+    handlePinchStart(e) {
+      const container = this.$refs.scrollContainer
+      if (!container) return
+
+      const [touchA, touchB] = e.touches
+
+      this.isPinching = true
+      this.pinch.enableTransform = this.zoom > 1
+      this.pinch.startDistance = this.getTouchDistance(touchA, touchB)
+      this.pinch.startZoom = this.zoom
+      this.liveZoom = this.zoom
+
+      const rect = container.getBoundingClientRect()
+      const center = this.getTouchCenter(touchA, touchB)
+      const centerXInContainer = center.clientX - rect.left
+      const centerYInContainer = center.clientY - rect.top
+
+      this.pinch.lastCenterClientX = center.clientX
+      this.pinch.lastCenterClientY = center.clientY
+
+      const wrapper = this.$refs.pdfWrapper
+      if (wrapper) {
+        const wrapperRect = wrapper.getBoundingClientRect()
+        this.pinch.wrapperStartLeft = wrapperRect.left
+        this.pinch.wrapperStartTop = wrapperRect.top
+
+        this.pinch.startLocalX = centerXInContainer + container.scrollLeft
+        this.pinch.startLocalY = centerYInContainer + container.scrollTop
+
+        this.pinch.baseContentX = this.pinch.startLocalX / this.pinch.startZoom
+        this.pinch.baseContentY = this.pinch.startLocalY / this.pinch.startZoom
+      }
+
+      this.pinch.translateX = 0
+      this.pinch.translateY = 0
+    },
+    handlePinchMove(e) {
+      e.preventDefault()
+
+      const container = this.$refs.scrollContainer
+      if (!container || !this.pinch.startDistance) return
+
+      const [touchA, touchB] = e.touches
+      const newDistance = this.getTouchDistance(touchA, touchB)
+      const desiredZoom = this.pinch.startZoom * (newDistance / this.pinch.startDistance)
+      const newZoom = this.clamp(desiredZoom, this.minZoom, this.maxZoom)
+
+      if (!this.pinch.enableTransform && this.pinch.startZoom === 1 && Math.abs(newZoom - this.pinch.startZoom) > 0.03) {
+        this.pinch.enableTransform = true
+      }
+
+      if (!this.pinch.enableTransform && this.pinch.startZoom === 1) return
+
+      const center = this.getTouchCenter(touchA, touchB)
+      this.pinch.lastCenterClientX = center.clientX
+      this.pinch.lastCenterClientY = center.clientY
+
+      if (this.pinch.rafId) cancelAnimationFrame(this.pinch.rafId)
+      // Throttle DOM updates during pinch.
+      this.pinch.rafId = requestAnimationFrame(() => {
+        this.liveZoom = newZoom
+
+        const sx = this.pinch.wrapperStartLeft + this.pinch.startLocalX * (newZoom / this.pinch.startZoom)
+        const sy = this.pinch.wrapperStartTop + this.pinch.startLocalY * (newZoom / this.pinch.startZoom)
+
+        this.pinch.translateX = center.clientX - sx
+        this.pinch.translateY = center.clientY - sy
+      })
+    },
+    handlePinchEnd() {
+      // Convert the temporary pinch translate into scroll offset and commit the zoom.
+      if (!this.pinch.enableTransform) {
+        this.isPinching = false
+        return
+      }
+
+      const container = this.$refs.scrollContainer
+      const committedZoom = this.clamp(this.liveZoom, this.minZoom, this.maxZoom)
+
+      const translateX = this.pinch.translateX
+      const translateY = this.pinch.translateY
+
+      if (container) {
+        container.scrollLeft = container.scrollLeft - translateX
+        container.scrollTop = container.scrollTop - translateY
+      }
+
+      this.pinch.translateX = 0
+      this.pinch.translateY = 0
+      this.pinch.enableTransform = false
+      this.isPinching = false
+
+      this.zoom = committedZoom
+      this.liveZoom = committedZoom
+
+      this.pendingZoomCommit = {
+        committedZoom,
+        baseX: this.pinch.baseContentX,
+        baseY: this.pinch.baseContentY,
+        centerClientX: this.pinch.lastCenterClientX,
+        centerClientY: this.pinch.lastCenterClientY
+      }
+
+      this.afterLayout(() => this.finalizeZoomCommit())
+
+      if (this.pinch.rafId) {
+        cancelAnimationFrame(this.pinch.rafId)
+        this.pinch.rafId = null
+      }
+    },
+    handleDoubleTap(touch) {
+      // Double-tap toggles zoom: zoom in to 2x, or reset back to 1x.
+      this.clearSingleTapTimeout()
+      this.lastTapTime = 0
+
+      if (this.zoom > 1) {
+        this.resetZoom()
+        return
+      }
+
+      this.zoomToClientPoint(2, touch.clientX, touch.clientY)
+    },
+    handleSingleTap(touch, now) {
+      // Single tap is delayed so we can detect double-tap.
+      // Edge paging runs in the timer so it doesn't steal a double-tap.
+      this.lastTapTime = now
+      this.clearSingleTapTimeout()
+
+      this.singleTapTimeoutId = setTimeout(() => {
+        this.singleTapTimeoutId = null
+
+        // Single tap is delayed so we can detect double-tap.
+        // Edge paging runs in the timer so it doesn't steal a double-tap.
+        if (this.zoom === 1) {
+          const container = this.$refs.scrollContainer
+          if (container) {
+            const rect = container.getBoundingClientRect()
+            const tapX = touch.clientX - rect.left
+            const edgeWidth = Math.min(120, rect.width * 0.2)
+            if (tapX <= edgeWidth) return this.prev()
+            if (tapX >= rect.width - edgeWidth) return this.next()
+          }
+        }
+
+        this.$emit('pdf-tap')
+      }, 320)
+    },
+    handleSwipe(dx) {
+      this.clearSingleTapTimeout()
+      this.lastTapTime = 0
+      if (dx < 0) this.next()
+      else this.prev()
+    },
+    handleTapOrSwipeEnd(e) {
+      if (!e.changedTouches || !e.changedTouches.length) return
+
+      const now = Date.now()
+      const touch = e.changedTouches[0]
+
+      const dx = touch.clientX - this.swipe.startX
+      const dy = touch.clientY - this.swipe.startY
+      const dt = now - this.swipe.startTime
+
+      const tapDistance = Math.sqrt(dx * dx + dy * dy)
+      const isTap = tapDistance < 20 && dt < 350
+      const isSwipe = dt < 600 && Math.abs(dx) > 80 && Math.abs(dy) < 70 && Math.abs(dx) > Math.abs(dy) * 1.2
+
+      const isOnLink = this.touchStartedOnLink || this.isLinkTarget(e)
+      const action =
+        isTap && !isOnLink
+          ? this.lastTapTime && now - this.lastTapTime < 300
+            ? 'DOUBLE_TAP'
+            : 'SINGLE_TAP'
+          : this.zoom === 1 && !this.isPinching && isSwipe
+            ? 'SWIPE'
+            : 'NONE'
+
+      switch (action) {
+        case 'DOUBLE_TAP':
+          this.handleDoubleTap(touch)
+          return
+        case 'SINGLE_TAP':
+          this.handleSingleTap(touch, now)
+          return
+        case 'SWIPE':
+          this.handleSwipe(dx)
+          return
+        default:
+          return
+      }
+    },
+    onTouchStart(e) {
+      if (!e || !e.touches) return
+
+      if (e.touches.length === 2) {
+        this.handlePinchStart(e)
+        return
+      }
+
+      if (e.touches.length === 1) {
+        this.swipe.startX = e.touches[0].clientX
+        this.swipe.startY = e.touches[0].clientY
+        this.swipe.startTime = Date.now()
+        this.touchStartedOnLink = this.isLinkTarget(e)
+      }
+    },
+    onTouchMove(e) {
+      if (!e || !e.touches) return
+      if (this.isPinching && e.touches.length === 2) this.handlePinchMove(e)
+    },
+    onTouchEnd(e) {
+      if (this.isPinching && (!e.touches || e.touches.length < 2)) {
+        this.handlePinchEnd()
+        return
+      }
+
+      this.handleTapOrSwipeEnd(e)
+    },
+
     async updateProgress() {
       if (!this.keepProgress) return
 
@@ -156,7 +562,6 @@ export default {
     },
     numPagesLoaded(e) {
       if (!e) return
-
       this.numPages = e
     },
     prev() {
@@ -247,8 +652,13 @@ export default {
     window.addEventListener('resize', this.screenOrientationChange)
 
     this.init()
+    this.registerTouchListeners()
   },
+
   beforeDestroy() {
+    this.clearSingleTapTimeout()
+    this.unregisterTouchListeners()
+
     if (screen.orientation) {
       // Not available on ios
       screen.orientation.removeEventListener('change', this.screenOrientationChange)

--- a/components/readers/Reader.vue
+++ b/components/readers/Reader.vue
@@ -22,7 +22,7 @@
     </div>
 
     <!-- ereader -->
-    <component v-if="readerComponentName" ref="readerComponent" :is="readerComponentName" :url="ebookUrl" :library-item="selectedLibraryItem" :is-local="isLocal" :keep-progress="keepProgress" :showing-toolbar="showingToolbar" @touchstart="touchstart" @touchend="touchend" @loaded="readerLoaded" @hook:mounted="readerMounted" />
+    <component v-if="readerComponentName" ref="readerComponent" :is="readerComponentName" :url="ebookUrl" :library-item="selectedLibraryItem" :is-local="isLocal" :keep-progress="keepProgress" :showing-toolbar="showingToolbar" @touchstart="touchstart" @touchend="touchend" @pdf-tap="toggleToolbar" @loaded="readerLoaded" @hook:mounted="readerMounted" />
 
     <!-- table of contents modal -->
     <modals-fullscreen-modal v-model="showTOCModal" :theme="ereaderTheme">
@@ -392,6 +392,8 @@ export default {
       }
     },
     handleGesture() {
+      if (this.isPdf) return
+
       // Touch must be less than 1s. Must be > 60px drag and X distance > Y distance
       const touchTimeMs = Date.now() - this.touchstartTime
       if (touchTimeMs >= 1000) {
@@ -436,6 +438,8 @@ export default {
       else this.showToolbar()
     },
     touchstart(e) {
+      if (this.isPdf) return
+
       // Ignore rapid touch
       if (this.touchstartTime && Date.now() - this.touchstartTime < 250) {
         return
@@ -447,6 +451,8 @@ export default {
       this.touchIdentifier = e.touches[0].identifier
     },
     touchend(e) {
+      if (this.isPdf) return
+
       if (this.touchIdentifier !== e.changedTouches[0].identifier) {
         return
       }


### PR DESCRIPTION
## Brief summary

This PR adds mobile-friendly PDF reading gestures (zoom/pan/swipe/tap) to the integrated in-app PDF viewer.

## Which issue is fixed?
#1567 (only zoom)

## Pull Request Type
- Platforms: Android + iOS
- PdfReader.vue touch gestures

## In-depth Description
This PR contains one main change:
 Zoom/Pan/Swipe/Tap in the integrated PDF viewer  

## Known issue
- In the integrated (web) viewer, after releasing a pinch-to-zoom gesture there can be a noticeable UI glitch: for ~1 second the scroll position appears to jump upward and then returns to the correct position. I was not able to fully resolve this in this PR.
- 
## How have you tested this?
- Tested only on Android (real device).

##Screenshots
https://github.com/user-attachments/assets/002c5bf8-4c76-46a4-acaa-c1216c13c976

this code in genrate on vibe coding