### PR TITLE
Fix Bluetooth remote control input not working as expected

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
@@ -65,26 +65,32 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
   }
 
   override fun onStop() {
+    Log.d(tag, "ON STOP MEDIA SESSION COMPAT")
     playerNotificationService.pause()
   }
 
   override fun onSkipToPrevious() {
-    playerNotificationService.skipToPrevious()
+    Log.d(tag, "ON SKIP TO PREVIOUS MEDIA SESSION COMPAT")
+    playerNotificationService.jumpBackward()
   }
 
   override fun onSkipToNext() {
-    playerNotificationService.skipToNext()
+    Log.d(tag, "ON SKIP TO NEXT MEDIA SESSION COMPAT")
+    playerNotificationService.jumpForward()
   }
 
   override fun onFastForward() {
+    Log.d(tag, "ON FAST FORWARD MEDIA SESSION COMPAT")
     playerNotificationService.jumpForward()
   }
 
   override fun onRewind() {
+    Log.d(tag, "ON REWIND MEDIA SESSION COMPAT")
     playerNotificationService.jumpBackward()
   }
 
   override fun onSeekTo(pos: Long) {
+    Log.d(tag, "ON SEEK TO SESSION COMPAT")
     val currentTrackStartOffset = playerNotificationService.getCurrentTrackStartOffsetMs()
     playerNotificationService.seekPlayer(currentTrackStartOffset + pos)
   }
@@ -228,9 +234,11 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
             handleMediaButtonClickCount()
           }
           KeyEvent.KEYCODE_MEDIA_NEXT -> {
+            Log.d(tag, "handleCallMediaButton: Media Next")
             playerNotificationService.jumpForward()
           }
           KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+            Log.d(tag, "handleCallMediaButton: Media Previous")
             playerNotificationService.jumpBackward()
           }
           KeyEvent.KEYCODE_MEDIA_STOP -> {
@@ -274,6 +282,7 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
 
   override fun onCustomAction(action: String?, extras: Bundle?) {
     super.onCustomAction(action, extras)
+    Log.d(tag, "handleCallMediaButton: CustomAction:${action}")
 
     when (action) {
       CUSTOM_ACTION_JUMP_FORWARD -> onFastForward()


### PR DESCRIPTION



<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This change implements the suggested fix of @ISO-B Ensure consistent media playback behavior across different input methods. Use seek jumps instead of skip to next file.
Skip to next is not equivalent to skip to chapter in the UI and does not work in single file playback.
Improve logging

## Which issue is fixed?

fixes #352

## Pull Request Type

Android backend

## In-depth Description

I did some further digging and here are my observations:
First I considered three different methods on playback skipping. 1) Via the app, 2) Via bluetooth headset 3) Via remote control (in my case a Garmin Fenix smart watch).
Due to lack of hardware I was not able to test this in an android auto environment.
Second I noticed a difference when choosing audiobooks with A) multiple files and B) Single file with chapter marks.
In the following I focus on the case next track (`>|`).

#### 1) Control via the app

Everything tested works as expected, next track (`>|`) jumps to the next chapter and we have buttons to perform a time skip of 10 seconds (configurable).
Here the control input next track (`>|`) enters via `PlayerNotificationService` and the `seekPlayer` function.
Time to skip is provided by the UI, I'm unable to figure out how exactly.

#### 2) Via bluetooth

With this method and my device I have the basic config options: play, pause, next and previous track.
Here the control input next track (`>|`) enters via the `MediaSessionCallback` and handled by the `onMediaButtonEvent`.
A `KEYCODE_MEDIA_NEXT` results in `jumpForward` a time skip of 10 seconds (configurable).

https://github.com/advplyr/audiobookshelf-app/blob/4fb9f6b92dbdb40ec6501f4e84782223806b4c46/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt#L230-L235

#### 3) Via remote control

Here the control input next track (`>|`) enters via `MediaSessionCallback` and handled by the `onSkipToNext`.
The current implementation calls the `skipToNext` function of the `PlayerNotificationService` and this the `currentPlayer.seekToNext()`.

Now comes the root cause of the issue described: **What is 'next**'?

In case A) where we have multiple files the next file is selected.
If the audiobook is chunked into files per chapter the skip works like in case 1) Control via the app

In case B) where we have a single audio file (with chapter marks) nothing happens.
The player internally tries to check `hasNextMediaItem` for the next thing but cannot find anything. 

https://github.com/advplyr/audiobookshelf-app/blob/4fb9f6b92dbdb40ec6501f4e84782223806b4c46/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt#L75-L77

I do not know which control device has buttons for `SkipToNext` and `FastForward` at the same time which would be affected by this change.
But my observation that the behaviour with single files is still different would persists.

And another thing, on case B) with single file: pressing the control input previous track (`|<`) jumps to the start of the file which is really annoying. 

## Conclusion

Form a user view I want to cover the following case:

> "Oh no, I somehow missed the last 40 seconds of my playback, let me quickly press back 4 times."

Thus changing the implementation for case 3) to work as it does in case 2) is sufficient.
Also other apps (AntennaPod) is using exactly the same behavior.
If a user wants to skip a chapter there is always option 1) use the app with all 5 buttons :-)

## How have you tested this?

Play audio book control playback via various input methods
## Screenshots

Not applicable