### PR TITLE
feat(podcast): play full podcast queue

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -63,6 +63,11 @@
           </div>
 
           <span class="material-symbols text-3xl text-fg cursor-pointer" :class="chapters.length ? 'text-opacity-75' : 'text-opacity-10'" @click="clickChaptersBtn">format_list_bulleted</span>
+
+          <div v-if="isPodcast && playerQueueItems.length" class="relative cursor-pointer" @click.stop="showPlayerQueueItemsModal = true">
+            <span class="material-symbols text-3xl text-fg cursor-pointer text-opacity-75">playlist_play</span>
+            <span class="absolute -top-1 -right-1 bg-success text-black rounded-full px-1" style="font-size: 10px; line-height: 14px">{{ playerQueueItems.length }}</span>
+          </div>
         </div>
       </div>
       <div v-else class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: var(--gradient-minimized-audio-player)" />
@@ -84,7 +89,7 @@
             <span class="material-symbols text-3xl leading-none">forward_media</span>
             <span v-if="showFullscreen" class="jump-label text-[10px] font-semibold leading-tight">{{ jumpForwardLabel }}</span>
           </div>
-          <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="nextChapter && !isLoading ? 'text-opacity-75' : 'text-opacity-10'" @click.stop="jumpNextChapter">last_page</span>
+          <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="hasNext && !isLoading ? 'text-opacity-75' : 'text-opacity-10'" @click.stop="nextClick">last_page</span>
         </div>
       </div>
 
@@ -106,6 +111,7 @@
     </div>
 
     <modals-chapters-modal v-model="showChapterModal" :current-chapter="currentChapter" :chapters="chapters" :playback-rate="currentPlaybackRate" @select="selectChapter" />
+    <modals-podcast-queue-modal v-model="showPlayerQueueItemsModal" :queue-items="playerQueueItems" @play="selectPlayerQueueIndex" @remove="playerQueueItems.splice($event, 1)" />
     <modals-dialog v-model="showMoreMenuDialog" :items="menuItems" width="80vw" @action="clickMenuAction" />
   </div>
 </template>
@@ -135,6 +141,7 @@ export default {
       windowWidth: 0,
       playbackSession: null,
       showChapterModal: false,
+      showPlayerQueueItemsModal: false,
       showFullscreen: false,
       totalDuration: 0,
       currentPlaybackRate: 1,
@@ -166,7 +173,8 @@ export default {
       coverRgb: 'rgb(55, 56, 56)',
       coverBgIsLight: false,
       titleMarquee: null,
-      isRefreshingUI: false
+      isRefreshingUI: false,
+      playerQueueItems: []
     }
   },
   watch: {
@@ -285,6 +293,9 @@ export default {
     isPodcast() {
       return this.mediaType === 'podcast'
     },
+    hasNext() {
+      return !!this.playerQueueItems?.length || !!this.nextChapter
+    },
     mediaMetadata() {
       return this.playbackSession?.mediaMetadata || null
     },
@@ -395,6 +406,34 @@ export default {
     }
   },
   methods: {
+    selectPlayerQueueIndex(index) {
+      const i = Number(index)
+      if (isNaN(i) || !this.playerQueueItems?.[i]) return
+
+      const payload = this.playerQueueItems[i]
+      this.playerQueueItems = this.playerQueueItems.slice(i + 1)
+      this.showPlayerQueueItemsModal = false
+
+      this.$store.commit('setPlayerIsStartingPlayback', payload.episodeId || payload.libraryItemId)
+      this.$eventBus.$emit('play-item', { ...payload, queueItems: this.playerQueueItems })
+    },
+    nextClick() {
+      if (!this.hasNext || this.isLoading) return
+      if (this.playerQueueItems?.length) return this.playNextItemInQueue()
+      return this.jumpNextChapter()
+    },
+    playNextItemInQueue() {
+      if (!this.playerQueueItems?.length) return
+
+      const nextPayload = this.playerQueueItems.shift()
+      if (!nextPayload) return
+
+      this.$store.commit('setPlayerIsStartingPlayback', nextPayload.episodeId || nextPayload.libraryItemId)
+      this.$eventBus.$emit('play-item', { ...nextPayload, queueItems: this.playerQueueItems })
+    },
+    onPlayItem(payload) {
+      this.playerQueueItems = Array.isArray(payload?.queueItems) ? payload.queueItems : []
+    },
     showSyncsFailedDialog() {
       Dialog.alert({
         title: this.$strings.HeaderProgressSyncFailed,
@@ -842,7 +881,16 @@ export default {
       if (data.playerState === 'ENDED') {
         console.log('[AudioPlayer] Playback ended')
       }
-      this.isEnded = data.playerState === 'ENDED'
+      const ended = data.playerState === 'ENDED'
+      const endedNow = !this.isEnded && ended
+      this.isEnded = ended
+
+      if (endedNow && this.isPodcast && this.playerQueueItems?.length) {
+        setTimeout(() => {
+          // Auto play next item in queue
+          this.playNextItemInQueue()
+        }, 250)
+      }
 
       console.log('received metadata update', data)
 
@@ -964,6 +1012,7 @@ export default {
     window.addEventListener('resize', this.screenOrientationChange)
 
     this.$eventBus.$on('minimize-player', this.minimizePlayerEvt)
+    this.$eventBus.$on('play-item', this.onPlayItem)
     document.body.addEventListener('touchstart', this.touchstart, { passive: false })
     document.body.addEventListener('touchend', this.touchend)
     document.body.addEventListener('touchmove', this.touchmove)
@@ -985,6 +1034,7 @@ export default {
 
     this.forceCloseDropdownMenu()
     this.$eventBus.$off('minimize-player', this.minimizePlayerEvt)
+    this.$eventBus.$off('play-item', this.onPlayItem)
     document.body.removeEventListener('touchstart', this.touchstart)
     document.body.removeEventListener('touchend', this.touchend)
     document.body.removeEventListener('touchmove', this.touchmove)

--- a/components/modals/PodcastQueueModal.vue
+++ b/components/modals/PodcastQueueModal.vue
@@ -1,0 +1,198 @@
+<template>
+  <modals-modal v-model="show" :width="800" :height="'unset'">
+    <template #outer>
+      <div class="absolute top-0 left-0 p-5 w-2/3 overflow-hidden">
+        <p class="text-3xl text-white truncate">Queue</p>
+      </div>
+    </template>
+
+    <div class="w-full rounded-lg bg-bg box-shadow-md overflow-y-auto overflow-x-hidden py-4" style="max-height: 80vh">
+      <div v-if="show" class="w-full h-full">
+        <div class="pb-4 px-4 flex items-center">
+          <p class="text-base text-fg">Queue</p>
+          <p class="text-base text-fg-muted px-4">{{ queueItems.length }} Items</p>
+          <div class="grow" />
+        </div>
+
+        <transition-group name="queue" tag="div">
+          <div v-for="(item, index) in queueItems" :key="itemKey(item, index)" class="relative overflow-hidden">
+            <div class="absolute top-0 right-0 h-full w-60 bg-error/70 pointer-events-none" :style="{ opacity: (offsets[itemKey(item, index)] || 0) < 0 ? 1 : 0, transition: 'opacity 120ms ease' }" />
+
+            <div
+              class="w-full flex items-center px-4 py-2 select-none"
+              :class="wrapperClass(item, index)"
+              :style="rowStyle(item, index)"
+              @click.stop="playClick(index)"
+              @touchstart.passive="touchStart(item, index, $event)"
+              @touchmove="touchMove(item, index, $event)"
+              @touchend="touchEnd(item, index)"
+              @touchcancel="touchCancel(item, index)"
+            >
+              <covers-preview-cover :src="coverUrl(item)" :width="48" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" />
+
+              <div class="grow px-2 py-1 truncate" style="max-width: calc(100% - 48px - 112px)">
+                <p class="text-gray-200 text-sm truncate">{{ itemTitle(item) }}</p>
+              </div>
+
+              <div class="w-24">
+                <button class="outline-none w-full flex items-center justify-end" @click.stop="removeClick(item, index)">
+                  <span class="material-symbols text-2xl text-error">delete</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </transition-group>
+      </div>
+    </div>
+  </modals-modal>
+</template>
+
+<script>
+export default {
+  props: {
+    value: Boolean,
+    queueItems: {
+      type: Array,
+      default: () => []
+    }
+  },
+  data() {
+    return {
+      startX: 0,
+      startY: 0,
+      swipingKey: null,
+      isSwiping: false,
+      offsets: {},
+      removeToastId: null
+    }
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value
+      },
+      set(val) {
+        this.$emit('input', val)
+      }
+    },
+    bookCoverAspectRatio() {
+      return this.$store.getters['libraries/getBookCoverAspectRatio']
+    }
+  },
+  methods: {
+    itemKey(item, index) {
+      return `${item?.serverLibraryItemId || item?.libraryItemId || 'x'}:${item?.serverEpisodeId || item?.episodeId || 'y'}:${index}`
+    },
+    isOpenInPlayer(item) {
+      if (!item?.libraryItemId) return false
+      return this.$store.getters['getIsMediaStreaming'](item.libraryItemId, item.episodeId)
+    },
+    wrapperClass(item, index) {
+      if (this.isOpenInPlayer(item)) return 'bg-yellow-400/10'
+      if (index % 2 === 0) return 'bg-gray-300/5 hover:bg-gray-300/10'
+      return 'bg-bg hover:bg-gray-300/10'
+    },
+    rowStyle(item, index) {
+      const key = this.itemKey(item, index)
+      const x = this.offsets[key] || 0
+      const dragging = this.swipingKey === key && this.isSwiping
+      return {
+        transform: `translate3d(${x}px, 0, 0)`,
+        transition: dragging ? 'none' : 'transform 180ms ease'
+      }
+    },
+    itemTitle(item) {
+      return item?.queueText || item?.title || item?.episodeTitle || item?.episodeId || item?.serverEpisodeId || 'Item'
+    },
+    coverUrl(item) {
+      const lid = item?.serverLibraryItemId || item?.libraryItemId
+      return this.$store.getters['globals/getLibraryItemCoverSrcById'](lid)
+    },
+    playClick(index) {
+      this.$emit('play', index)
+    },
+    removeClick(item, index) {
+      const key = this.itemKey(item, index)
+
+      const name = this.itemTitle(item) || 'Item'
+      if (this.removeToastId) this.$toast.dismiss(this.removeToastId)
+      this.removeToastId = this.$toast.error(`${name} removed`)
+
+      this.$set(this.offsets, key, -240)
+      setTimeout(() => {
+        this.$emit('remove', index)
+      }, 180)
+    },
+    touchStart(item, index, evt) {
+      const t = evt.touches?.[0]
+      if (!t) return
+      this.startX = t.clientX
+      this.startY = t.clientY
+      this.swipingKey = this.itemKey(item, index)
+      this.isSwiping = false
+    },
+    touchMove(item, index, evt) {
+      const key = this.itemKey(item, index)
+      if (this.swipingKey !== key) return
+
+      const t = evt.touches?.[0]
+      if (!t) return
+      const dx = t.clientX - this.startX
+      const dy = t.clientY - this.startY
+
+      if (!this.isSwiping) {
+        if (Math.abs(dx) < 10) return
+        if (Math.abs(dy) > Math.abs(dx)) {
+          this.swipingKey = null
+          return
+        }
+        this.isSwiping = true
+      }
+
+      evt.preventDefault()
+      const x = Math.max(-240, Math.min(0, dx))
+      this.$set(this.offsets, key, x)
+    },
+    touchEnd(item, index) {
+      const key = this.itemKey(item, index)
+      if (this.swipingKey !== key) return
+
+      const x = this.offsets[key] || 0
+      this.swipingKey = null
+
+      if (!this.isSwiping) return
+      this.isSwiping = false
+
+      if (x <= -160) {
+        this.removeClick(item, index)
+      } else {
+        this.$set(this.offsets, key, 0)
+      }
+    },
+    touchCancel(item, index) {
+      const key = this.itemKey(item, index)
+      if (this.swipingKey === key) {
+        this.swipingKey = null
+        this.isSwiping = false
+        this.$set(this.offsets, key, 0)
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.queue-enter-active,
+.queue-leave-active {
+  transition: opacity 180ms ease, transform 180ms ease, max-height 180ms ease;
+}
+.queue-enter {
+  opacity: 0;
+  transform: translate3d(0, 6px, 0);
+}
+.queue-leave-to {
+  opacity: 0;
+  transform: translate3d(0, -6px, 0);
+  max-height: 0;
+}
+</style>

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -146,7 +146,7 @@
         </div>
 
         <!-- tables -->
-        <tables-podcast-episodes-table v-if="isPodcast" :library-item="libraryItem" :local-library-item-id="localLibraryItemId" :episodes="episodes" :local-episodes="localLibraryItemEpisodes" :is-local="isLocal" />
+        <tables-podcast-episodes-table ref="episodesTable" v-if="isPodcast" :library-item="libraryItem" :local-library-item-id="localLibraryItemId" :episodes="episodes" :local-episodes="localLibraryItemEpisodes" :is-local="isLocal" />
 
         <tables-chapters-table v-if="numChapters" :library-item="libraryItem" @playAtTimestamp="playAtTimestamp" />
 
@@ -534,15 +534,22 @@ export default {
       if (this.playerIsStartingPlayback) return
 
       if (this.isPodcast) {
-        this.episodes.sort((a, b) => {
-          if (this.podcastType === 'serial') {
-            return String(a.publishedAt).localeCompare(String(b.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
-          } else {
-            return String(b.publishedAt).localeCompare(String(a.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
-          }
-        })
+        const episodesSorted = this.$refs.episodesTable?.episodesSorted
+        const hasEpisodesSorted = Array.isArray(episodesSorted)
 
-        let episode = this.episodes.find((ep) => {
+        if (!hasEpisodesSorted) {
+          this.episodes.sort((a, b) => {
+            if (this.podcastType === 'serial') {
+              return String(a.publishedAt).localeCompare(String(b.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
+            } else {
+              return String(b.publishedAt).localeCompare(String(a.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
+            }
+          })
+        }
+
+        const episodesInOrder = hasEpisodesSorted ? episodesSorted : this.episodes
+
+        let episode = episodesInOrder.find((ep) => {
           var podcastProgress = null
           if (!this.isLocal) {
             podcastProgress = this.$store.getters['user/getUserMediaProgress'](this.libraryItemId, ep.id)
@@ -552,7 +559,8 @@ export default {
           return !podcastProgress?.isFinished
         })
 
-        if (!episode) episode = this.episodes[0]
+        if (!episode) episode = episodesInOrder[0]
+        if (!episode) return
 
         const episodeId = episode.id
 
@@ -564,15 +572,53 @@ export default {
         }
         const serverEpisodeId = !this.isLocal ? episodeId : localEpisode?.serverEpisodeId || null
 
+        const buildQueuePayload = (ep) => {
+          const epId = ep.id
+          const queueText = ep.episodeDisplayTitle || ep.title || ep.episodeTitle || epId
+
+          let localEp = null
+          if (this.hasLocal && !this.isLocal) {
+            localEp = this.localLibraryItem.media.episodes.find((le) => le.serverEpisodeId == epId)
+          } else if (this.isLocal) {
+            localEp = ep
+          }
+          const serverEpId = !this.isLocal ? epId : localEp?.serverEpisodeId || null
+
+          if (serverEpId && this.serverLibraryItemId && this.isCasting) {
+            return { libraryItemId: this.serverLibraryItemId, episodeId: serverEpId, queueText }
+          } else if (localEp) {
+            return {
+              libraryItemId: this.localLibraryItem.id,
+              episodeId: localEp.id,
+              serverLibraryItemId: this.serverLibraryItemId,
+              serverEpisodeId: serverEpId,
+              queueText
+            }
+          }
+          return { libraryItemId: this.libraryItemId, episodeId: epId, queueText }
+        }
+
+        const episodeIndex = episodesInOrder.findIndex((ep) => ep.id === episodeId)
+        const queueEpisodes = (episodeIndex >= 0 ? episodesInOrder.slice(episodeIndex + 1) : episodesInOrder).filter((ep) => {
+          var podcastProgress = null
+          if (!this.isLocal) {
+            podcastProgress = this.$store.getters['user/getUserMediaProgress'](this.libraryItemId, ep.id)
+          } else {
+            podcastProgress = this.$store.getters['globals/getLocalMediaProgressById'](this.libraryItemId, ep.id)
+          }
+          return !podcastProgress?.isFinished
+        })
+        const queueItems = queueEpisodes.map(buildQueuePayload)
+
         this.episodeStartingPlayback = serverEpisodeId
         this.$store.commit('setPlayerIsStartingPlayback', serverEpisodeId)
+
         if (serverEpisodeId && this.serverLibraryItemId && this.isCasting) {
-          // If casting and connected to server for local library item then send server library item id
-          this.$eventBus.$emit('play-item', { libraryItemId: this.serverLibraryItemId, episodeId: serverEpisodeId })
+          this.$eventBus.$emit('play-item', { libraryItemId: this.serverLibraryItemId, episodeId: serverEpisodeId, queueItems })
         } else if (localEpisode) {
-          this.$eventBus.$emit('play-item', { libraryItemId: this.localLibraryItem.id, episodeId: localEpisode.id, serverLibraryItemId: this.serverLibraryItemId, serverEpisodeId })
+          this.$eventBus.$emit('play-item', { libraryItemId: this.localLibraryItem.id, episodeId: localEpisode.id, serverLibraryItemId: this.serverLibraryItemId, serverEpisodeId, queueItems })
         } else {
-          this.$eventBus.$emit('play-item', { libraryItemId: this.libraryItemId, episodeId })
+          this.$eventBus.$emit('play-item', { libraryItemId: this.libraryItemId, episodeId, queueItems })
         }
       } else {
         // Audiobook

--- a/strings/it.json
+++ b/strings/it.json
@@ -31,7 +31,7 @@
   "ButtonManageLocalFiles": "Gestisci file locali",
   "ButtonMaskServerAddress": "Nascondi l'indirizzo server",
   "ButtonNewFolder": "Nuova cartella",
-  "ButtonNextEpisode": "Prossimo episodio",
+  "ButtonNextEpisode": "Riproduci",
   "ButtonOk": "D'accordo",
   "ButtonOpenFeed": "Apri il flusso",
   "ButtonOverride": "Oltrepassa",


### PR DESCRIPTION
<!--
For Pull Requests in development, use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for more details.

Failure to follow this pattern may result in the PR being closed without review.

Make sure all checks have passed.
If you are a new contributor, workflows will need to be manually approved before being executed.
-->

### Does this issue only affect Android, iOS, or both?

Android and iOS (but only tested on Android)
Backend
-

## Detailed Description

When you click the green play button at the top of the podcast, a queue is created based on the filter and all podcasts are added.
This allows for continuous listening.
(You can also delete episodes by scrolling.)
This feature is already present in the web client; the only thing missing from the app is the app itself.

## How did you test it?

Open the app
Select the podcast
Click the green "Play" button at the top, following the filter order.
An icon with the complete list of podcast episodes appears in the player.
If playback ends, you'll skip directly to the next episode.

## Screenshot