### PR TITLE
🎧 Add option to remap media next button to create bookmark

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -92,5 +92,9 @@ lint/tmp/
 # Cordova plugins for Capacitor
 capacitor-cordova-android-plugins
 
+# Android Studio project files
+.project
+.settings/
+
 # Copied web assets
 app/src/main/assets/public

--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -143,7 +143,8 @@ data class DeviceSettings(
   var downloadUsingCellular: DownloadUsingCellularSetting,
   var streamingUsingCellular: StreamingUsingCellularSetting,
   var androidAutoBrowseLimitForGrouping: Int,
-  var androidAutoBrowseSeriesSequenceOrder: AndroidAutoBrowseSeriesSequenceOrderSetting
+  var androidAutoBrowseSeriesSequenceOrder: AndroidAutoBrowseSeriesSequenceOrderSetting,
+  var mediaNextButtonCreateBookmark: Boolean
 ) {
   companion object {
     // Static method to get default device settings
@@ -172,7 +173,8 @@ data class DeviceSettings(
         downloadUsingCellular = DownloadUsingCellularSetting.ALWAYS,
         streamingUsingCellular = StreamingUsingCellularSetting.ALWAYS,
         androidAutoBrowseLimitForGrouping = 100,
-        androidAutoBrowseSeriesSequenceOrder = AndroidAutoBrowseSeriesSequenceOrderSetting.ASC
+        androidAutoBrowseSeriesSequenceOrder = AndroidAutoBrowseSeriesSequenceOrderSetting.ASC,
+        mediaNextButtonCreateBookmark = false
       )
     }
   }

--- a/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
@@ -89,6 +89,9 @@ object DeviceManager {
       deviceData.deviceSettings?.androidAutoBrowseSeriesSequenceOrder =
               AndroidAutoBrowseSeriesSequenceOrderSetting.ASC
     }
+    if (deviceData.deviceSettings?.mediaNextButtonCreateBookmark == null) {
+      deviceData.deviceSettings?.mediaNextButtonCreateBookmark = false
+    }
   }
 
   /**

--- a/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.KeyEvent
 import com.audiobookshelf.app.data.LibraryItemWrapper
 import com.audiobookshelf.app.data.PodcastEpisode
+import com.audiobookshelf.app.device.DeviceManager
 import java.util.*
 import kotlin.concurrent.schedule
 
@@ -228,7 +229,7 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
             handleMediaButtonClickCount()
           }
           KeyEvent.KEYCODE_MEDIA_NEXT -> {
-            playerNotificationService.jumpForward()
+            handleMediaNextButton()
           }
           KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
             playerNotificationService.jumpBackward()
@@ -244,6 +245,16 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
       }
     }
     return true
+  }
+
+  private fun handleMediaNextButton() {
+    val settings = DeviceManager.deviceData.deviceSettings
+    if (settings?.mediaNextButtonCreateBookmark == true) {
+      Log.d(tag, "handleMediaNextButton: Creating bookmark (remapped from media next)")
+      playerNotificationService.createBookmark()
+    } else {
+      playerNotificationService.jumpForward()
+    }
   }
 
   private fun handleMediaButtonClickCount() {

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -1004,6 +1004,27 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     mediaProgressSyncer.currentPlaybackSession?.let { setMediaSessionConnectorCustomActions(it) }
   }
 
+  fun createBookmark() {
+    val session = currentPlaybackSession
+    if (session == null) {
+      Log.w(tag, "createBookmark: No playback session")
+      return
+    }
+    val libraryItemId = session.libraryItemId
+    if (libraryItemId.isNullOrEmpty()) {
+      Log.w(tag, "createBookmark: No library item id")
+      return
+    }
+    val currentTime = getCurrentTimeSeconds()
+    val title = java.text.SimpleDateFormat("MMM dd, yyyy HH:mm", java.util.Locale.getDefault()).format(java.util.Date())
+    Log.d(tag, "createBookmark: Creating bookmark at ${currentTime}s for item $libraryItemId")
+    apiHandler.createBookmark(libraryItemId, currentTime, title) { success ->
+      if (success) {
+        Log.i(tag, "createBookmark: Bookmark created successfully")
+      }
+    }
+  }
+
   fun closePlayback(calledOnError: Boolean? = false) {
     Log.d(tag, "closePlayback")
     val config = DeviceManager.serverConnectionConfig

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -722,6 +722,22 @@ class ApiHandler(var ctx:Context) {
     }
   }
 
+  fun createBookmark(libraryItemId:String, time:Double, title:String, cb: (Boolean) -> Unit) {
+    val payload = JSObject()
+    payload.put("time", Math.floor(time).toLong())
+    payload.put("title", title)
+    postRequest("/api/me/item/$libraryItemId/bookmark", payload, null) {
+      val error = it.getString("error")
+      if (!error.isNullOrEmpty()) {
+        Log.e(tag, "createBookmark: Failed to create bookmark: $error")
+        cb(false)
+      } else {
+        Log.d(tag, "createBookmark: Bookmark created at ${Math.floor(time).toLong()}s")
+        cb(true)
+      }
+    }
+  }
+
   fun authorize(config:ServerConnectionConfig, cb: (MutableList<MediaProgress>?) -> Unit) {
     Log.d(tag, "authorize: Authorizing ${config.address}")
     postRequest("/api/authorize", JSObject(), config) {

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -67,6 +67,13 @@
       </div>
       <p class="pl-4">{{ $strings.LabelAllowSeekingOnMediaControls }}</p>
     </div>
+    <div v-if="!isiOS" class="flex items-center py-3">
+      <div class="w-10 flex justify-center" @click="toggleMediaNextButtonCreateBookmark">
+        <ui-toggle-switch v-model="settings.mediaNextButtonCreateBookmark" @input="saveSettings" />
+      </div>
+      <p class="pl-4">{{ $strings.LabelMediaNextButtonCreateBookmark }}</p>
+      <span class="material-symbols text-xl ml-2" @click.stop="showInfo('mediaNextButtonCreateBookmark')">info</span>
+    </div>
 
     <!-- Sleep timer settings -->
     <template v-if="!isiOS">
@@ -223,7 +230,8 @@ export default {
         downloadUsingCellular: 'ALWAYS',
         streamingUsingCellular: 'ALWAYS',
         androidAutoBrowseLimitForGrouping: 100,
-        androidAutoBrowseSeriesSequenceOrder: 'ASC'
+        androidAutoBrowseSeriesSequenceOrder: 'ASC',
+        mediaNextButtonCreateBookmark: false
       },
       theme: 'dark',
       lockCurrentOrientation: false,
@@ -259,6 +267,10 @@ export default {
         androidAutoBrowseLimitForGrouping: {
           name: this.$strings.LabelAndroidAutoBrowseLimitForGrouping,
           message: this.$strings.LabelAndroidAutoBrowseLimitForGroupingHelp
+        },
+        mediaNextButtonCreateBookmark: {
+          name: this.$strings.LabelMediaNextButtonCreateBookmark,
+          message: this.$strings.LabelMediaNextButtonCreateBookmarkHelp
         }
       },
       hapticFeedbackItems: [
@@ -611,6 +623,10 @@ export default {
       this.settings.allowSeekingOnMediaControls = !this.settings.allowSeekingOnMediaControls
       this.saveSettings()
     },
+    toggleMediaNextButtonCreateBookmark() {
+      this.settings.mediaNextButtonCreateBookmark = !this.settings.mediaNextButtonCreateBookmark
+      this.saveSettings()
+    },
     getCurrentOrientation() {
       const orientation = window.screen?.orientation || {}
       const type = orientation.type || ''
@@ -671,6 +687,7 @@ export default {
 
       this.settings.androidAutoBrowseLimitForGrouping = deviceSettings.androidAutoBrowseLimitForGrouping
       this.settings.androidAutoBrowseSeriesSequenceOrder = deviceSettings.androidAutoBrowseSeriesSequenceOrder || 'ASC'
+      this.settings.mediaNextButtonCreateBookmark = !!deviceSettings.mediaNextButtonCreateBookmark
     },
     async init() {
       this.loading = true

--- a/strings/en-us.json
+++ b/strings/en-us.json
@@ -191,6 +191,8 @@
   "LabelLockOrientation": "Lock orientation",
   "LabelLockPlayer": "Lock Player",
   "LabelLow": "Low",
+  "LabelMediaNextButtonCreateBookmark": "Remap media next button to create bookmark",
+  "LabelMediaNextButtonCreateBookmarkHelp": "When enabled, the media next button (e.g. from a Bluetooth headset) will create a bookmark at the current position instead of jumping forward.",
   "LabelMediaType": "Media Type",
   "LabelMedium": "Medium",
   "LabelMissing": "Missing",


### PR DESCRIPTION
## Brief summary

Allow users to remap the Bluetooth headset "next" button to create a
bookmark at the current playback position instead of jumping forward.
This is useful for headsets that intercept multi-press gestures at the
firmware level, making other trigger mechanisms unreliable.

Adds a new toggle in Settings > Playback Settings, backed by a
`mediaNextButtonCreateBookmark` device setting (defaults to off).
When enabled, `KEYCODE_MEDIA_NEXT` creates a bookmark via the server API;
when disabled, it retains the original jump-forward behavior.

## Which issue is fixed?

Fixes #548

## Pull Request Type

**Does this affect only Android, only iOS, or both?**

Android only. The media button handling (`MediaSessionCallback`, `PlayerNotificationService`) and the bookmark API call (`ApiHandler`) are all in the Android native Kotlin layer. The setting toggle in `settings.vue` is also protected behind `v-if="!isiOS"`.

**Does this change the frontend or the backend of the apps?**

Both. The frontend (Vue/Nuxt) has a new toggle in the Settings page for the user to enable the remapping. The backend (Android native Kotlin) handles the actual media button interception, the bookmark creation logic, and the API call to the audiobookshelf server.

## In-depth Description

The PR is fairly small so I can't give a more in-depth discussion than what's written at the top. In terms of whether this is a general problem or an issue specific to my set-up, I would say is somewhere in between. In issue #548 there are at least 4 users saying they would love to have this ability to create bookmarks without interacting with their phone, so that they can create bookmarks to come back to once they have access to their phone again.

## How have you tested this?

I have built the app locally in Android studio, and connected my own phone (Google Pixel 10) via USB. Tested and validated working with my own bluetooth headphones (both with the new setting on and off).

## Screenshots

The only UI change lies in the settings screen:

<img width="1080" height="1861" alt="Screenshot_20260312-220644" src="https://github.com/user-attachments/assets/d119bd2d-ae0e-4523-bd8f-7d55a0d998bb" />

