### PR TITLE
Fixed a progress saving error when connection to internet is lost

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/media/MediaProgressSyncer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/media/MediaProgressSyncer.kt
@@ -313,10 +313,17 @@ class MediaProgressSyncer(
             failedSyncs = 0
           }
           AbsLogger.error("MediaProgressSyncer", "sync: Progress sync failed (count: $failedSyncs) (title: \"$currentDisplayTitle\") (currentTime: $currentTime) (session id: $currentSessionId) (${DeviceManager.serverConnectionConfigName})")
+
+          // Save progress locally as fallback when server sync fails
+          currentPlaybackSession?.let { saveServerProgressLocally(it) }
         }
         cb(SyncResult(true, syncSuccess, errorMsg))
       }
     } else {
+      // Save progress locally as fallback when network is down
+      currentPlaybackSession?.let { saveServerProgressLocally(it) }
+      lastSyncTime = System.currentTimeMillis()
+
       AbsLogger.info("MediaProgressSyncer", "sync: Not sending progress to server (title: \"$currentDisplayTitle\") (currentTime: $currentTime) (session id: $currentSessionId) (${DeviceManager.serverConnectionConfigName}) (hasNetworkConnection: $hasNetworkConnection)")
       cb(SyncResult(false, null, null))
     }
@@ -350,9 +357,56 @@ class MediaProgressSyncer(
     }
   }
 
+  private var serverOfflineMediaProgress: LocalMediaProgress? = null
+
+  private fun saveServerProgressLocally(playbackSession: PlaybackSession) {
+    val libraryItemId = playbackSession.libraryItemId ?: return
+    val progressId = if (playbackSession.episodeId.isNullOrEmpty()) "server-offline-$libraryItemId"
+      else "server-offline-$libraryItemId-${playbackSession.episodeId}"
+
+    if (serverOfflineMediaProgress == null) {
+      val existing = DeviceManager.dbManager.getLocalMediaProgress(progressId)
+      if (existing != null) {
+        serverOfflineMediaProgress = existing
+        serverOfflineMediaProgress?.updateFromPlaybackSession(playbackSession)
+      } else {
+        serverOfflineMediaProgress = LocalMediaProgress(
+          progressId,
+          progressId, // localLibraryItemId - synthetic since this is a server item
+          playbackSession.localEpisodeId,
+          playbackSession.getTotalDuration(),
+          playbackSession.progress,
+          playbackSession.currentTime,
+          false,
+          null,
+          null,
+          playbackSession.updatedAt,
+          playbackSession.startedAt,
+          null,
+          playbackSession.serverConnectionConfigId,
+          playbackSession.serverAddress,
+          playbackSession.userId,
+          playbackSession.libraryItemId,
+          playbackSession.episodeId
+        )
+      }
+    } else {
+      serverOfflineMediaProgress?.updateFromPlaybackSession(playbackSession)
+    }
+
+    serverOfflineMediaProgress?.let {
+      if (!it.progress.isNaN()) {
+        DeviceManager.dbManager.saveLocalMediaProgress(it)
+        playerNotificationService.clientEventEmitter?.onLocalMediaProgressUpdate(it)
+        Log.d(tag, "Saved server progress locally: ID ${it.id} | ${it.currentTime} | Progress ${it.progressPercent}%")
+      }
+    }
+  }
+
   fun reset() {
     currentPlaybackSession = null
     currentLocalMediaProgress = null
+    serverOfflineMediaProgress = null
     lastSyncTime = 0L
     Log.d(tag, "reset: Set last sync time 0 $lastSyncTime")
     failedSyncs = 0

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -594,9 +594,49 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     mediaSessionConnector.setEnabledPlaybackActions(playbackActions)
   }
 
+  fun switchToLocalCopyIfAvailable(): Boolean {
+    val session = currentPlaybackSession ?: return false
+    if (session.isLocal) return false
+
+    val libraryItemId = session.libraryItemId ?: return false
+    val localLibraryItem = DeviceManager.dbManager.getLocalLibraryItemByLId(libraryItemId) ?: return false
+
+    // For podcasts, find the matching local episode
+    var episode: PodcastEpisode? = null
+    if (!session.episodeId.isNullOrEmpty() && localLibraryItem.isPodcast) {
+      val podcast = localLibraryItem.media as Podcast
+      episode = podcast.episodes?.find { it.serverEpisodeId == session.episodeId }
+      if (episode == null) return false
+    }
+
+    if (!localLibraryItem.hasTracks(episode)) return false
+
+    val currentTime = getCurrentTimeSeconds()
+    val playbackRate = currentPlayer.playbackParameters.speed
+
+    AbsLogger.info("PlayerNotificationService", "switchToLocalCopy: Switching to local copy for \"${session.displayTitle}\" at position $currentTime")
+
+    // Build local playback session preserving current position
+    val localSession = localLibraryItem.getPlaybackSession(episode, getDeviceInfo())
+    localSession.currentTime = currentTime
+
+    mediaProgressSyncer.stop(false) {
+      Handler(Looper.getMainLooper()).post {
+        preparePlayer(localSession, true, playbackRate)
+      }
+    }
+    return true
+  }
+
   fun handlePlayerPlaybackError(errorMessage: String) {
-    // On error and was attempting to direct play - fallback to transcode
     currentPlaybackSession?.let { playbackSession ->
+      // First, try switching to a downloaded local copy
+      if (!playbackSession.isLocal && switchToLocalCopyIfAvailable()) {
+        AbsLogger.info("PlayerNotificationService", "handlePlayerPlaybackError: Switched to local copy for \"${playbackSession.displayTitle}\"")
+        return
+      }
+
+      // On error and was attempting to direct play - fallback to transcode
       if (playbackSession.isDirectPlay) {
         val playItemRequestPayload = getPlayItemRequestPayload(true)
         Log.d(tag, "Fallback to transcode $playItemRequestPayload.mediaPlayer")
@@ -2054,6 +2094,25 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
 
   private val networkCallback =
           object : ConnectivityManager.NetworkCallback() {
+            override fun onLost(network: Network) {
+              super.onLost(network)
+              hasNetworkConnectivity = false
+              Log.w(tag, "Network lost")
+
+              // If currently streaming from server, try to switch to local copy
+              currentPlaybackSession?.let { session ->
+                if (!session.isLocal && currentPlayer.isPlaying) {
+                  Handler(Looper.getMainLooper()).post {
+                    if (switchToLocalCopyIfAvailable()) {
+                      AbsLogger.info("PlayerNotificationService", "Network lost: Switched to local copy for \"${session.displayTitle}\"")
+                    } else {
+                      Log.w(tag, "Network lost: No local copy available for \"${session.displayTitle}\"")
+                    }
+                  }
+                }
+              }
+            }
+
             // Network capabilities have changed for the network
             override fun onCapabilitiesChanged(
                     network: Network,

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -2101,11 +2101,11 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
 
               // If currently streaming from server, try to switch to local copy
               currentPlaybackSession?.let { session ->
-                if (!session.isLocal && currentPlayer.isPlaying) {
+                if (!session.isLocal) {
                   Handler(Looper.getMainLooper()).post {
-                    if (switchToLocalCopyIfAvailable()) {
+                    if (currentPlayer.isPlaying && switchToLocalCopyIfAvailable()) {
                       AbsLogger.info("PlayerNotificationService", "Network lost: Switched to local copy for \"${session.displayTitle}\"")
-                    } else {
+                    } else if (currentPlayer.isPlaying) {
                       Log.w(tag, "Network lost: No local copy available for \"${session.displayTitle}\"")
                     }
                   }


### PR DESCRIPTION
## Brief summary

When streaming an audiobook from the server and the network connection drops, playback progress is lost and the app does not automatically switch to a downloaded local copy. This PR fixes both issues by saving server progress locally as a fallback and by automatically switching to a local copy when the network is lost.

## Which issue is fixed?

<!-- TODO: Link issue number if applicable, e.g. Fixes #1234 -->

## Pull Request Type

- Affects: Android only
- Changes: Backend (native Kotlin player/sync logic)

## In-depth Description

There are two problems when streaming from the server and the network drops mid-playback:

### Problem 1: Progress is lost

In `MediaProgressSyncer.sync()`, the server-item code path only syncs progress to the server. When the network is down, it logs "Not sending progress to server" and discards the progress entirely -- nothing is saved locally. This means the user loses their listening position and has to manually find their place again.

**Fix:** When a server item cannot sync (network down or server sync failure), the progress is now saved to the local database as a `LocalMediaProgress` entry with a `server-offline-` prefixed ID. This ensures the listening position is always persisted. These offline entries are cleaned up naturally by the existing DB cleanup cycle after the progress is synced back to the server.

### Problem 2: No automatic fallback to local copy

When the network drops during server streaming, the player stalls and eventually errors out. The only existing fallback is direct play to transcode (HLS), which also requires a server connection. There is no fallback to a downloaded local copy of the same audiobook.

**Fix:** A new `switchToLocalCopyIfAvailable()` method checks if a local copy of the currently streaming audiobook exists (via `getLocalLibraryItemByLId`). If found, it seamlessly switches playback to the local copy at the same position. This is triggered in two places:

1. **Proactively** in the `networkCallback.onLost()` -- when the system detects network loss, the app immediately switches to the local copy before the player buffers run out.
2. **Reactively** in `handlePlayerPlaybackError()` -- if a playback error occurs on a server item, the app tries switching to a local copy before falling back to transcode or failing.

For podcasts, the correct local episode is matched via `serverEpisodeId`. The playback position (`currentTime`) is preserved across the switch since both server and local sessions use the same absolute time coordinate system.

### Files changed

- `MediaProgressSyncer.kt` -- Added `saveServerProgressLocally()` method; called when network is down or server sync fails in the non-local branch
- `PlayerNotificationService.kt` -- Added `switchToLocalCopyIfAvailable()` method; added `onLost` to `networkCallback`; modified `handlePlayerPlaybackError()` to try local copy first

## How have you tested this?

1. Stream an audiobook from the server that also has a downloaded local copy
2. Disable network (airplane mode / WiFi off) during playback
3. Verify: playback switches seamlessly to the local copy at the same position
4. Verify: progress is saved locally and visible in the app
5. Re-enable network
6. Verify: progress syncs back to the server

Also tested:
- Streaming without a local copy available: player behaves as before (stalls/errors, no crash)
- Network loss while not playing: no unnecessary switch attempt
- Podcast episode streaming with local copy: correct episode matched and switched

## Screenshots

N/A -- backend changes only, no UI modifications.
