### PR TITLE
Add deep link support for opening library items

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -348,6 +348,14 @@ export default {
         await this.attemptConnection()
       }
 
+      // Navigate to any pending deep link now that the server connection is ready.
+      // Use replace so the bookshelf is not left in the navigation history.
+      const pendingDeepLink = this.$store.state.pendingDeepLink
+      if (pendingDeepLink) {
+        this.$store.commit('setPendingDeepLink', null)
+        this.$router.replace(pendingDeepLink)
+      }
+
       await this.syncLocalSessions(true)
 
       this.hasMounted = true

--- a/plugins/init.client.js
+++ b/plugins/init.client.js
@@ -325,12 +325,45 @@ export default ({ store, app }, inject) => {
     }
   })
 
+  // Extract a library item ID from a deep link URL, or null if not a match
+  function parseItemDeepLink(url) {
+    if (!url) return null
+    const match = url.match(/^audiobookshelf:\/\/item\/([^?#]+)/)
+    if (!match) return null
+    try {
+      return decodeURIComponent(match[1])
+    } catch (e) {
+      console.error('Failed to parse deep link URL', url, e)
+      return null
+    }
+  }
+
   /**
    * @see https://capacitorjs.com/docs/apis/app#addlistenerappurlopen-
    * Listen for url open events for the app. This handles both custom URL scheme links as well as URLs your app handles
    */
   App.addListener('appUrlOpen', (data) => {
+    const libraryItemId = parseItemDeepLink(data.url)
+    if (libraryItemId) {
+      if (app.router) {
+        app.router.push(`/item/${libraryItemId}`)
+      }
+      return
+    }
+
+    // audiobookshelf://oauth and others - handled by component listeners
     eventBus.$emit('url-open', data.url)
+  })
+
+  // Handle deep link that launched the app from a cold start.
+  // Store in Vuex so the default layout can navigate after the server connection is ready.
+  App.getLaunchUrl().then((result) => {
+    const libraryItemId = parseItemDeepLink(result?.url)
+    if (libraryItemId) {
+      store.commit('setPendingDeepLink', `/item/${libraryItemId}`)
+    }
+  }).catch((e) => {
+    console.error('Failed to get launch URL', e)
   })
 }
 

--- a/store/index.js
+++ b/store/index.js
@@ -27,7 +27,8 @@ export const state = () => ({
   isNetworkListenerInit: false,
   serverSettings: null,
   lastBookshelfScrollData: {},
-  lastItemScrollData: {}
+  lastItemScrollData: {},
+  pendingDeepLink: null
 })
 
 export const getters = {
@@ -128,6 +129,9 @@ export const actions = {
 export const mutations = {
   setDeviceData(state, deviceData) {
     state.deviceData = deviceData
+  },
+  setPendingDeepLink(state, route) {
+    state.pendingDeepLink = route
   },
   setLastBookshelfScrollData(state, { scrollTop, path, name }) {
     state.lastBookshelfScrollData[name] = { scrollTop, path }


### PR DESCRIPTION
## Brief summary

Add support for deep linking to library items via the `audiobookshelf://item/<libraryItemId>` custom URL scheme. This allows external apps to open a specific book directly in the Audiobookshelf app.

## Which issue is fixed?

Fixes #1840

## Pull Request Type

Both Android and iOS, frontend.

## In-depth Description

This adds handling for `audiobookshelf://item/<libraryItemId>` deep links, both for when the app is already running and when it's launched from a deep link (cold start).

## How have you tested this?

Tested manually on Android (don't have access to iOS).

## Screenshots

N/A
