### PR TITLE
Seek to millisecond rather than flooring to second

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -325,10 +325,10 @@ class AbsAudioPlayer : Plugin() {
 
   @PluginMethod
   fun seek(call: PluginCall) {
-    val time:Int = call.getInt("value", 0) ?: 0 // Value in seconds
+    val time: Double = call.getDouble("value", 0.0) ?: 0.0 // Value in seconds, fractional
     Log.d(tag, "seek action to $time")
     Handler(Looper.getMainLooper()).post {
-      playerNotificationService.seekPlayer(time * 1000L) // convert to ms
+      playerNotificationService.seekPlayer((time * 1000L).toLong())
       call.resolve()
     }
   }

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -615,7 +615,8 @@ export default {
       this.seekedTime = time
       this.seekLoading = true
 
-      AbsAudioPlayer.seek({ value: Math.floor(time) })
+      // Pass fractional seconds so seeks to non-integer chapter starts don't truncate
+      AbsAudioPlayer.seek({ value: time })
 
       if (this.$refs.playedTrack) {
         const perc = time / this.totalDuration

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -226,7 +226,7 @@ export default {
         console.log('Already streaming item', startTime)
         if (startTime !== undefined && startTime !== null) {
           // seek to start time
-          AbsAudioPlayer.seek({ value: Math.floor(startTime) })
+          AbsAudioPlayer.seek({ value: startTime })
         } else if (this.$refs.audioPlayer) {
           this.$refs.audioPlayer.play()
         }


### PR DESCRIPTION
## Brief summary
Fixes the "next chapter" button in the in-app player not advancing when a chapter starts at a non-integer second (common with m4b files). The player would land just before the chapter boundary and subsequent presses wouldn't move at all.

## Which issue is fixed?

n/a, discovered while testing a separate fix. Happy to file one first if preferred

## Pull Request Type

Android native plugin plus JS frontend. iOS already accepted Double values through the seek path so no Swift changes were needed.

## In-depth Description

The seek plugin truncated to integer seconds: `AbsAudioPlayer.seek({ value: Math.floor(time) })` on the JS side, and `call.getInt("value", 0)` on the Android side. If a chapter started at 100.5s, `Math.floor(100.5) = 100` was sent to native, which seeked to 100000ms.
That's still inside the previous chapter, which ends at 100500ms. Pressing next again produced the same result because `nextChapter` is computed by comparing against `currentTime`, and `currentTime` was still less than `nextChapter.start`.

Traced the Math.floor back to a 2022 commit that switched the plugin contract from a millisecond string to an integer-seconds value. The floor was defensive to match the new Int required value from Android, not a deliberate precision decision. iOS already accepted Double, so it had never suffered the truncation.

The fix drops the Math.floor in both JS callers of `AbsAudioPlayer.seek` and switches the Android plugin to read the value as a Double and convert to ms with full precision. `seekForward` and `seekBackward` are unchanged since their values are always integer-second jump intervals from device settings.

One minor side effect is that drag-to-seek on the timeline now lands exactly where you drop rather than at the floor of the nearest second. That's an improvement IMO, but also a tiny behavior shift, so flagging it here and it could potentially be worked around to stay as it was if that's preferred.

## How have you tested this?
- Tested by toggling on chapters in the player and using next/previous buttons

## Screenshots
- N/A