### PR TITLE
Fix download corrupt network switch

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -5,6 +5,7 @@ import android.graphics.ImageDecoder
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
+import android.util.Log
 import android.support.v4.media.MediaMetadataCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toFile
@@ -224,18 +225,27 @@ class PlaybackSession(
                             coverUri.toString()
                     )
 
-    // Local covers get bitmap
+    // Local covers get bitmap — guarded against corrupt/partial files left by interrupted downloads
     if (localLibraryItem?.coverContentUrl != null) {
-      val bitmap =
-              if (Build.VERSION.SDK_INT < 28) {
-                MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
-              } else {
-                val source: ImageDecoder.Source =
-                        ImageDecoder.createSource(ctx.contentResolver, coverUri)
-                ImageDecoder.decodeBitmap(source)
-              }
-      metadataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, bitmap)
-      metadataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, bitmap)
+      try {
+        val bitmap =
+                if (Build.VERSION.SDK_INT < 28) {
+                  @Suppress("DEPRECATION")
+                  MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
+                } else {
+                  val source: ImageDecoder.Source =
+                          ImageDecoder.createSource(ctx.contentResolver, coverUri)
+                  ImageDecoder.decodeBitmap(source)
+                }
+        metadataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, bitmap)
+        metadataBuilder.putBitmap(MediaMetadataCompat.METADATA_KEY_ART, bitmap)
+      } catch (e: Exception) {
+        Log.e("PlaybackSession", "getMediaMetadataCompat: Failed to decode local cover, clearing coverContentUrl", e)
+        localLibraryItem?.let { lli ->
+          lli.coverContentUrl = null
+          DeviceManager.dbManager.saveLocalLibraryItem(lli)
+        }
+      }
     }
 
     return metadataBuilder.build()

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -1,6 +1,11 @@
 package com.audiobookshelf.app.managers
 
 import android.app.DownloadManager
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import android.net.Uri
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
@@ -65,6 +70,49 @@ class DownloadItemManager(
     var isDownloading: Boolean = false
   }
 
+  /** Parts interrupted by a network loss; restored to the queue when connectivity returns. */
+  private val pausedDownloadItemParts: MutableList<DownloadItemPart> = mutableListOf()
+
+  private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+    override fun onLost(network: Network) {
+      val inFlight = currentDownloadItemParts.filter { !it.completed && !it.failed }
+      if (inFlight.isNotEmpty()) {
+        Log.i(tag, "networkCallback: Network lost — pausing ${inFlight.size} in-flight part(s)")
+        inFlight.forEach { it.paused = true }
+        pausedDownloadItemParts.addAll(inFlight)
+      }
+    }
+
+    override fun onAvailable(network: Network) {
+      if (pausedDownloadItemParts.isNotEmpty()) {
+        Log.i(tag, "networkCallback: Network available — restoring ${pausedDownloadItemParts.size} paused part(s)")
+        pausedDownloadItemParts.forEach { part ->
+          part.paused = false
+          part.completed = false
+          part.failed = false
+          part.downloadId = null
+        }
+        pausedDownloadItemParts.clear()
+        checkUpdateDownloadQueue()
+      }
+    }
+  }
+
+  init {
+    val networkRequest = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            .build()
+    (mainActivity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
+            .registerNetworkCallback(networkRequest, networkCallback)
+  }
+
+  /** Unregisters the network callback. Call when the owning component is destroyed. */
+  fun destroy() {
+    (mainActivity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)
+            .unregisterNetworkCallback(networkCallback)
+  }
+
   /** Adds a download item to the queue and starts processing the queue. */
   fun addDownloadItem(downloadItem: DownloadItem) {
     DeviceManager.dbManager.saveDownloadItem(downloadItem)
@@ -108,12 +156,16 @@ class DownloadItemManager(
     }
   }
 
-  /** Starts an internal download. */
+  /** Starts an internal download, writing to a .tmp file and renaming on success. */
   private fun startInternalDownload(downloadItemPart: DownloadItemPart) {
-    val file = File(downloadItemPart.finalDestinationPath)
-    file.parentFile?.mkdirs()
+    val finalFile = File(downloadItemPart.finalDestinationPath)
+    val tempFile = File(downloadItemPart.finalDestinationPath + ".tmp")
+    finalFile.parentFile?.mkdirs()
 
-    val fileOutputStream = FileOutputStream(downloadItemPart.finalDestinationPath)
+    // Resume from however many bytes are already in the temp file, if any.
+    val resumeFrom = if (tempFile.exists()) tempFile.length() else 0L
+    val fileOutputStream = FileOutputStream(tempFile, resumeFrom > 0L)
+
     val internalProgressCallback =
             object : InternalProgressCallback {
               override fun onProgress(totalBytesWritten: Long, progress: Long) {
@@ -124,15 +176,23 @@ class DownloadItemManager(
               override fun onComplete(failed: Boolean) {
                 downloadItemPart.failed = failed
                 downloadItemPart.completed = true
+                if (!failed) {
+                  // Atomic rename: only expose the file once it is fully written.
+                  if (!tempFile.renameTo(finalFile)) {
+                    Log.e(tag, "Failed to rename ${tempFile.absolutePath} → ${finalFile.absolutePath}")
+                    downloadItemPart.failed = true
+                    tempFile.delete()
+                  }
+                }
               }
             }
 
     Log.d(
             tag,
-            "Start internal download to destination path ${downloadItemPart.finalDestinationPath} from ${downloadItemPart.serverUrl}"
+            "Start internal download to ${downloadItemPart.finalDestinationPath} from ${downloadItemPart.serverUrl} (resumeFrom=$resumeFrom)"
     )
     InternalDownloadManager(fileOutputStream, internalProgressCallback)
-            .download(downloadItemPart.serverUrl)
+            .download(downloadItemPart.serverUrl, resumeFrom)
     downloadItemPart.downloadId = 1
     currentDownloadItemParts.add(downloadItemPart)
   }
@@ -155,7 +215,7 @@ class DownloadItemManager(
       isDownloading = true
 
       while (currentDownloadItemParts.isNotEmpty()) {
-        val itemParts = currentDownloadItemParts.filter { !it.isMoving }
+        val itemParts = currentDownloadItemParts.filter { !it.isMoving && !it.paused }
         for (downloadItemPart in itemParts) {
           if (downloadItemPart.isInternalStorage) {
             handleInternalDownloadPart(downloadItemPart)
@@ -181,6 +241,18 @@ class DownloadItemManager(
     clientEventEmitter.onDownloadItemPartUpdate(downloadItemPart)
 
     if (downloadItemPart.completed) {
+      if (downloadItemPart.failed) {
+        if (downloadItemPart.paused) {
+          // Network interruption: keep .tmp so the download can resume from its byte offset.
+          // The NetworkCallback will reset and re-queue this part when connectivity returns.
+          Log.d(tag, "handleInternalDownloadPart: Keeping .tmp for paused part ${downloadItemPart.filename}")
+        } else {
+          // Permanent failure: remove any partial files so the folder scanner never
+          // registers a corrupt file as a completed download.
+          File(downloadItemPart.finalDestinationPath).delete()
+          File(downloadItemPart.finalDestinationPath + ".tmp").delete()
+        }
+      }
       val downloadItem = downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }
       downloadItem?.let { checkDownloadItemFinished(it) }
       currentDownloadItemParts.remove(downloadItemPart)

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -75,11 +75,14 @@ class DownloadItemManager(
 
   private val networkCallback = object : ConnectivityManager.NetworkCallback() {
     override fun onLost(network: Network) {
-      val inFlight = currentDownloadItemParts.filter { !it.completed && !it.failed }
+      // Include parts that OkHttp already marked failed due to the drop — the watcher loop
+      // will catch them via isNetworkAvailable(), but marking them paused here ensures
+      // the .tmp file is kept and they are re-queued when connectivity returns.
+      val inFlight = currentDownloadItemParts.filter { !it.completed || it.failed }
       if (inFlight.isNotEmpty()) {
         Log.i(tag, "networkCallback: Network lost — pausing ${inFlight.size} in-flight part(s)")
         inFlight.forEach { it.paused = true }
-        pausedDownloadItemParts.addAll(inFlight)
+        pausedDownloadItemParts.addAll(inFlight.filter { !pausedDownloadItemParts.contains(it) })
       }
     }
 
@@ -242,10 +245,20 @@ class DownloadItemManager(
 
     if (downloadItemPart.completed) {
       if (downloadItemPart.failed) {
-        if (downloadItemPart.paused) {
-          // Network interruption: keep .tmp so the download can resume from its byte offset.
-          // The NetworkCallback will reset and re-queue this part when connectivity returns.
-          Log.d(tag, "handleInternalDownloadPart: Keeping .tmp for paused part ${downloadItemPart.filename}")
+        // OkHttp's onFailure fires before networkCallback.onLost, so a part can be marked
+        // completed+failed due to a network drop before paused=true is ever set. Treat any
+        // failure while offline the same as an explicit pause so files aren't lost.
+        if (downloadItemPart.paused || !isNetworkAvailable()) {
+          Log.d(tag, "handleInternalDownloadPart: Network unavailable — deferring retry for ${downloadItemPart.filename}")
+          downloadItemPart.completed = false
+          downloadItemPart.failed = false
+          downloadItemPart.paused = true
+          downloadItemPart.downloadId = null
+          if (!pausedDownloadItemParts.contains(downloadItemPart)) {
+            pausedDownloadItemParts.add(downloadItemPart)
+          }
+          currentDownloadItemParts.remove(downloadItemPart)
+          return
         } else {
           // Permanent failure: remove any partial files so the folder scanner never
           // registers a corrupt file as a completed download.
@@ -257,6 +270,15 @@ class DownloadItemManager(
       downloadItem?.let { checkDownloadItemFinished(it) }
       currentDownloadItemParts.remove(downloadItemPart)
     }
+  }
+
+  /** Returns true if the device currently has a validated internet connection. */
+  private fun isNetworkAvailable(): Boolean {
+    val cm = mainActivity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    val network = cm.activeNetwork ?: return false
+    val caps = cm.getNetworkCapabilities(network) ?: return false
+    return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+            caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
   }
 
   /** Handles an external download part. */

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -18,19 +18,27 @@ class InternalDownloadManager(
 
   private val tag = "InternalDownloadManager"
   private val client: OkHttpClient =
-          OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS).build()
+          OkHttpClient.Builder()
+                  .connectTimeout(30, TimeUnit.SECONDS)
+                  .readTimeout(60, TimeUnit.SECONDS)
+                  .build()
   private val writer = BinaryFileWriter(outputStream, progressCallback)
 
   /**
-   * Downloads a file from the given URL.
+   * Downloads a file from the given URL, optionally resuming from [resumeFrom] bytes.
    *
-   * @param url The URL to download the file from.
-   * @throws IOException If an I/O error occurs.
+   * When [resumeFrom] > 0 the request includes a Range header. A 206 response appends to
+   * the existing partial file; a 200 response means the server does not support ranges and
+   * the caller is responsible for having opened the stream in truncate mode.
    */
-  @Throws(IOException::class)
-  fun download(url: String) {
-    val request: Request = Request.Builder().url(url).addHeader("Accept-Encoding", "identity").build()
-    client.newCall(request)
+  fun download(url: String, resumeFrom: Long = 0L) {
+    val requestBuilder = Request.Builder()
+            .url(url)
+            .addHeader("Accept-Encoding", "identity")
+    if (resumeFrom > 0L) {
+      requestBuilder.addHeader("Range", "bytes=$resumeFrom-")
+    }
+    client.newCall(requestBuilder.build())
             .enqueue(
                     object : Callback {
                       override fun onFailure(call: Call, e: IOException) {
@@ -39,9 +47,22 @@ class InternalDownloadManager(
                       }
 
                       override fun onResponse(call: Call, response: Response) {
+                        if (!response.isSuccessful && response.code != 206) {
+                          Log.e(tag, "Download URL $url returned HTTP ${response.code}")
+                          progressCallback.onComplete(true)
+                          return
+                        }
                         response.body?.let { responseBody ->
-                          val length: Long = response.header("Content-Length")?.toLongOrNull() ?: 0L
-                          writer.write(responseBody.byteStream(), length)
+                          // Content-Length on a 206 is the remaining bytes; add the already-written
+                          // offset so progress percentage is computed against the full file size.
+                          val remaining: Long = response.header("Content-Length")?.toLongOrNull() ?: 0L
+                          val totalLength = if (response.code == 206) resumeFrom + remaining else remaining
+                          try {
+                            writer.write(responseBody.byteStream(), totalLength, resumeFrom)
+                          } catch (e: IOException) {
+                            Log.e(tag, "Stream interrupted during download of $url", e)
+                            progressCallback.onComplete(true)
+                          }
                         }
                                 ?: run {
                                   Log.e(tag, "Response doesn't contain a file")
@@ -75,26 +96,27 @@ class BinaryFileWriter(
 ) : AutoCloseable {
 
   /**
-   * Writes data from the input stream to the output stream.
+   * Writes data from [inputStream] to the output stream.
    *
-   * @param inputStream The input stream to read the data from.
-   * @param length The total length of the data to be written.
-   * @return The total number of bytes written.
-   * @throws IOException If an I/O error occurs.
+   * @param inputStream Source stream.
+   * @param totalFileLength Full expected file size (used for progress percentage).
+   * @param bytesAlreadyWritten Bytes already on disk from a previous partial download;
+   *   progress callbacks include this offset so the percentage reflects the whole file.
    */
-  @Throws(IOException::class)
-  fun write(inputStream: InputStream, length: Long): Long {
+  fun write(inputStream: InputStream, totalFileLength: Long, bytesAlreadyWritten: Long = 0L): Long {
     BufferedInputStream(inputStream).use { input ->
       val dataBuffer = ByteArray(CHUNK_SIZE)
-      var totalBytes: Long = 0
+      var newBytes: Long = 0
       var readBytes: Int
       while (input.read(dataBuffer).also { readBytes = it } != -1) {
-        totalBytes += readBytes
+        newBytes += readBytes
         outputStream.write(dataBuffer, 0, readBytes)
-        progressCallback.onProgress(totalBytes, (totalBytes * 100L) / length)
+        val written = bytesAlreadyWritten + newBytes
+        val progress = if (totalFileLength > 0) (written * 100L) / totalFileLength else 0L
+        progressCallback.onProgress(written, progress)
       }
       progressCallback.onComplete(false)
-      return totalBytes
+      return newBytes
     }
   }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
@@ -34,7 +34,9 @@ data class DownloadItemPart(
   val finalDestinationSubfolder: String,
   var downloadId: Long?,
   var progress: Long,
-  var bytesDownloaded: Long
+  var bytesDownloaded: Long,
+  /** True while waiting for network to return; the watcher loop skips paused parts. */
+  @JsonIgnore var paused: Boolean = false
 ) {
   companion object {
     fun make(downloadItemId:String, filename:String, fileSize: Long, destinationFile: File, finalDestinationFile: File, subfolder:String, serverPath:String, localFolder: LocalFolder, ebookFile: EBookFile?, audioTrack: AudioTrack?, episode: PodcastEpisode?) :DownloadItemPart {


### PR DESCRIPTION
## Brief summary

Fixes downloads getting silently marked as complete when switching networks mid-download, resulting in missing files with no error shown.

## Which issue is fixed?

No issue number, noticed this myself while commuting.

## Pull Request Type

Android only. Backend of the app, no frontend changes.

## In-depth Description

When you switch networks — say, disabling WiFi and falling back to mobile — any files currently downloading would get quietly marked as complete even though they were never actually written to disk. The download would "finish" and show as done, but the files just weren't there.

The cause is a race condition between OkHttp and Android's ConnectivityManager. OkHttp fires its `onFailure` callback the moment the socket dies, which sets `completed=true` and `failed=true` on the download part immediately. Android's `NetworkCallback.onLost` fires later, and the old filter `!it.completed && !it.failed` meant those already-failed parts were completely ignored — never paused, never retried, just abandoned. Since all parts ended up with `completed=true`, `isDownloadFinished` returned true and the whole item got processed as a finished download with missing files.

Three things changed to fix this:

- `handleInternalDownloadPart` now checks `isNetworkAvailable()` when it sees a failed part. If there's no network, instead of treating it as a permanent failure it resets the part and puts it in `pausedDownloadItemParts`. When connectivity returns, `onAvailable` re-queues it and the download resumes from the `.tmp` byte offset as normal.
- The `onLost` filter was changed from `!it.completed && !it.failed` to `!it.completed || it.failed` so parts that OkHttp already failed during the drop also get caught and marked paused.
- Added `isNetworkAvailable()` helper that checks `NET_CAPABILITY_INTERNET` and `NET_CAPABILITY_VALIDATED`, consistent with what the `NetworkRequest` was already registering for.

The existing resume-from-offset logic and `.tmp` file handling was already there and works fine, this just makes sure parts don't get discarded before they get a chance to use it.

## How have you tested this?

Tested on my own device via the local-build branch during daily audiobook listening. Reproduced by starting a download over WiFi, disabling WiFi mid-download to force a switch to mobile, and verifying the download pauses and then resumes and completes correctly once the new network is established. Previously this would silently complete with missing files. Which could crash the App

https://github.com/ckbaker10/audiobookshelf-app/tree/local-build

## Screenshots

N/A, no UI changes.
