### PR TITLE
fix: prefer freshest local or server progress on detail pages

### DIFF
--- a/mixins/progressHelpers.js
+++ b/mixins/progressHelpers.js
@@ -1,0 +1,16 @@
+export default {
+  computed: {
+    localProgressForServerItem() {
+      if (!this.serverLibraryItemId) return null
+      return this.$store.getters['globals/getLocalMediaProgressByServerItemId'](this.serverLibraryItemId, this.serverEpisodeId)
+    }
+  },
+  methods: {
+    getFreshestProgress(server, local) {
+      if (!server && !local) return null
+      if (!server) return local
+      if (!local) return server
+      return local.lastUpdate > server.lastUpdate ? local : server
+    }
+  }
+}

--- a/pages/item/_id/_episode/index.vue
+++ b/pages/item/_id/_episode/index.vue
@@ -228,7 +228,12 @@ export default {
     },
     userItemProgress() {
       if (this.isLocal) return this.localItemProgress
-      return this.serverItemProgress
+      const server = this.serverItemProgress
+      const local = this.localProgressForServerItem
+      if (!server && !local) return null
+      if (!server) return local
+      if (!local) return server
+      return local.lastUpdate > server.lastUpdate ? local : server
     },
     localItemProgress() {
       if (!this.localLibraryItemId || !this.localEpisodeId) return null
@@ -237,6 +242,10 @@ export default {
     serverItemProgress() {
       if (!this.serverLibraryItemId || !this.serverEpisodeId) return null
       return this.$store.getters['user/getUserMediaProgress'](this.serverLibraryItemId, this.serverEpisodeId)
+    },
+    localProgressForServerItem() {
+      if (!this.serverLibraryItemId) return null
+      return this.$store.getters['globals/getLocalMediaProgressByServerItemId'](this.serverLibraryItemId, this.serverEpisodeId)
     },
     progressPercent() {
       return this.userItemProgress?.progress || 0

--- a/pages/item/_id/_episode/index.vue
+++ b/pages/item/_id/_episode/index.vue
@@ -57,6 +57,7 @@ import { Capacitor } from '@capacitor/core'
 import { Dialog } from '@capacitor/dialog'
 import { AbsFileSystem, AbsDownloader } from '@/plugins/capacitor'
 import cellularPermissionHelpers from '@/mixins/cellularPermissionHelpers'
+import progressHelpers from '@/mixins/progressHelpers'
 
 export default {
   async asyncData({ store, params, redirect, app }) {
@@ -116,7 +117,7 @@ export default {
       startingDownload: false
     }
   },
-  mixins: [cellularPermissionHelpers],
+  mixins: [cellularPermissionHelpers, progressHelpers],
   computed: {
     transformedDescription() {
       return this.parseDescription(this.description)
@@ -228,12 +229,7 @@ export default {
     },
     userItemProgress() {
       if (this.isLocal) return this.localItemProgress
-      const server = this.serverItemProgress
-      const local = this.localProgressForServerItem
-      if (!server && !local) return null
-      if (!server) return local
-      if (!local) return server
-      return local.lastUpdate > server.lastUpdate ? local : server
+      return this.getFreshestProgress(this.serverItemProgress, this.localProgressForServerItem)
     },
     localItemProgress() {
       if (!this.localLibraryItemId || !this.localEpisodeId) return null
@@ -242,10 +238,6 @@ export default {
     serverItemProgress() {
       if (!this.serverLibraryItemId || !this.serverEpisodeId) return null
       return this.$store.getters['user/getUserMediaProgress'](this.serverLibraryItemId, this.serverEpisodeId)
-    },
-    localProgressForServerItem() {
-      if (!this.serverLibraryItemId) return null
-      return this.$store.getters['globals/getLocalMediaProgressByServerItemId'](this.serverLibraryItemId, this.serverEpisodeId)
     },
     progressPercent() {
       return this.userItemProgress?.progress || 0

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -174,6 +174,7 @@ import { Dialog } from '@capacitor/dialog'
 import { AbsFileSystem, AbsDownloader } from '@/plugins/capacitor'
 import { FastAverageColor } from 'fast-average-color'
 import cellularPermissionHelpers from '@/mixins/cellularPermissionHelpers'
+import progressHelpers from '@/mixins/progressHelpers'
 
 export default {
   async asyncData({ store, params, redirect, app, query }) {
@@ -224,7 +225,7 @@ export default {
       startingDownload: false
     }
   },
-  mixins: [cellularPermissionHelpers],
+  mixins: [cellularPermissionHelpers, progressHelpers],
   computed: {
     isIos() {
       return this.$platform === 'ios'
@@ -367,12 +368,7 @@ export default {
     userItemProgress() {
       if (this.isPodcast) return null
       if (this.isLocal) return this.localItemProgress
-      const server = this.serverItemProgress
-      const local = this.localProgressForServerItem
-      if (!server && !local) return null
-      if (!server) return local
-      if (!local) return server
-      return local.lastUpdate > server.lastUpdate ? local : server
+      return this.getFreshestProgress(this.serverItemProgress, this.localProgressForServerItem)
     },
     localItemProgress() {
       if (this.isPodcast) return null
@@ -381,10 +377,6 @@ export default {
     serverItemProgress() {
       if (this.isPodcast) return null
       return this.$store.getters['user/getUserMediaProgress'](this.serverLibraryItemId)
-    },
-    localProgressForServerItem() {
-      if (!this.serverLibraryItemId) return null
-      return this.$store.getters['globals/getLocalMediaProgressByServerItemId'](this.serverLibraryItemId)
     },
     userIsFinished() {
       return !!this.userItemProgress?.isFinished

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -367,7 +367,12 @@ export default {
     userItemProgress() {
       if (this.isPodcast) return null
       if (this.isLocal) return this.localItemProgress
-      return this.serverItemProgress
+      const server = this.serverItemProgress
+      const local = this.localProgressForServerItem
+      if (!server && !local) return null
+      if (!server) return local
+      if (!local) return server
+      return local.lastUpdate > server.lastUpdate ? local : server
     },
     localItemProgress() {
       if (this.isPodcast) return null
@@ -376,6 +381,10 @@ export default {
     serverItemProgress() {
       if (this.isPodcast) return null
       return this.$store.getters['user/getUserMediaProgress'](this.serverLibraryItemId)
+    },
+    localProgressForServerItem() {
+      if (!this.serverLibraryItemId) return null
+      return this.$store.getters['globals/getLocalMediaProgressByServerItemId'](this.serverLibraryItemId)
     },
     userIsFinished() {
       return !!this.userItemProgress?.isFinished


### PR DESCRIPTION
## Brief summary

When a downloaded audiobook is played and the user navigates back to the book detail page, the progress percentage was stale. This is because the pages only read server progress (updated via Socket.IO roundtrip) and ignored locally-available progress (updated instantly via the native `onLocalMediaProgressUpdate` event).

Now each page compares local and server progress timestamps and displays whichever is more recent.

## Which issue is fixed?

Addresses the stale progress display reported in https://github.com/advplyr/audiobookshelf-app/issues/857

## Pull Request Type

Both android and ios, frontend Vue code only

## In-depth Description

The fix adds a `localProgressForServerItem` computed property that looks up local progress by server item ID (using the existing `getLocalMediaProgressByServerItemId` getter), and modifies `userItemProgress` to prefer whichever source has the more recent `lastUpdate` timestamp.

Affected views:
- Book detail page (`pages/item/_id/index.vue`)
- Podcast episode detail page (`pages/item/_id/_episode/index.vue`)
- Item more menu modal (`components/modals/ItemMoreMenuModal.vue`)

This eliminates the display lag because local progress is updated instantly via `onLocalMediaProgressUpdate` events from the native layer, while server progress only updates after a Socket.IO roundtrip.

## How have you tested this?

1. Download an audiobook
2. Play it for a while
3. Pause playback and navigate back to the book detail page
4. Confirm the progress percentage updates immediately (no delay)
5. Tested with both streaming and local playback

## Screenshots

N/A (logic-only change)