### PR TITLE
[Android] Restore download queue on app kill/restore

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -127,6 +127,8 @@ dependencies {
 
   // Jackson for JSON
   implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.12.2'
+
+  testImplementation 'junit:junit:4.13.2'
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -75,6 +75,98 @@ class DownloadItemManager(
     checkUpdateDownloadQueue()
   }
 
+  /**
+   * Re-hydrate the in-memory queue from persisted state and resume any in-flight downloads.
+   * Idempotent: safe to call multiple times. Bails out if no server is connected yet, since any
+   * internal-storage part needs a fresh signed URL to re-enqueue.
+   */
+  fun restoreQueue() {
+    if (!DeviceManager.isConnectedToServer) {
+      Log.i(tag, "restoreQueue skipped: no server connection")
+      return
+    }
+
+    val persistedItems = DeviceManager.dbManager.getDownloadItems()
+    if (persistedItems.isEmpty()) return
+
+    Log.i(tag, "Restoring ${persistedItems.size} persisted download item(s)")
+    for (downloadItem in persistedItems) {
+      try {
+        restorePersistedItem(downloadItem)
+      } catch (e: Exception) {
+        Log.e(tag, "Dropping unrestorable persisted download ${downloadItem.id}", e)
+        DeviceManager.dbManager.removeDownloadItem(downloadItem.id)
+      }
+    }
+    checkUpdateDownloadQueue()
+  }
+
+  private fun restorePersistedItem(downloadItem: DownloadItem) {
+    if (downloadItemQueue.any { it.id == downloadItem.id }) return
+
+    // Records written by older builds may be missing string fields needed for restoration.
+    if (downloadItem.downloadItemParts.any {
+              it.finalDestinationPath.isEmpty() || it.destinationPath.isEmpty()
+            }
+    ) {
+      throw IllegalStateException("Persisted item ${downloadItem.id} has parts with missing paths")
+    }
+
+    // Self-heal: records persisted by app versions before per-part progress was saved
+    // (i.e. anyone upgrading from a prior release) report every part as fresh. For
+    // internal-storage parts the file on disk is the ground truth - if it's there at the
+    // expected size, mark it completed regardless of what the record claims.
+    downloadItem.downloadItemParts.forEach { part ->
+      if (!part.completed && part.isInternalStorage) {
+        val file = File(part.finalDestinationPath)
+        if (file.exists() &&
+                        file.length() > 0 &&
+                        (part.fileSize <= 0 || file.length() == part.fileSize)
+        ) {
+          part.completed = true
+          part.failed = false
+          part.bytesDownloaded = file.length()
+          part.progress = 100
+        }
+      }
+    }
+
+    downloadItem.downloadItemParts.forEach { part ->
+      when (DownloadRestoreLogic.classifyPart(
+                      isInternalStorage = part.isInternalStorage,
+                      downloadId = part.downloadId,
+                      completed = part.completed,
+                      moved = part.moved,
+                      failed = part.failed
+              )
+      ) {
+        DownloadRestoreLogic.PartRestoreAction.AlreadyDone -> {
+          /* keep flagged done */
+        }
+        DownloadRestoreLogic.PartRestoreAction.ResetAndReenqueue -> {
+          part.downloadId = null
+          part.bytesDownloaded = 0
+          part.progress = 0
+          part.completed = false
+          part.failed = false
+          part.isMoving = false
+          File(part.finalDestinationPath).takeIf { it.exists() }?.delete()
+        }
+        DownloadRestoreLogic.PartRestoreAction.ResumeExternal -> {
+          part.isMoving = false // stale flag if app died mid-move; watcher will retry
+          currentDownloadItemParts.add(part)
+        }
+      }
+    }
+
+    downloadItemQueue.add(downloadItem)
+    clientEventEmitter.onDownloadItem(downloadItem)
+
+    // Self-heal may have made the whole item done; run the normal completion path to scan
+    // and clean up the persisted record.
+    if (downloadItem.isDownloadFinished) checkDownloadItemFinished(downloadItem)
+  }
+
   /** Checks and updates the download queue. */
   private fun checkUpdateDownloadQueue() {
     for (downloadItem in downloadItemQueue) {
@@ -135,6 +227,7 @@ class DownloadItemManager(
             .download(downloadItemPart.serverUrl)
     downloadItemPart.downloadId = 1
     currentDownloadItemParts.add(downloadItemPart)
+    persistParentOf(downloadItemPart)
   }
 
   /** Starts an external download. */
@@ -144,6 +237,17 @@ class DownloadItemManager(
     downloadItemPart.downloadId = downloadId
     Log.d(tag, "checkUpdateDownloadQueue: Starting download item part, downloadId=$downloadId")
     currentDownloadItemParts.add(downloadItemPart)
+    persistParentOf(downloadItemPart)
+  }
+
+  /**
+   * Persist the parent DownloadItem so transient flags on its parts (downloadId, completed, moved,
+   * failed) survive process death and can be re-read by [restoreQueue].
+   */
+  private fun persistParentOf(downloadItemPart: DownloadItemPart) {
+    downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }?.let {
+      DeviceManager.dbManager.saveDownloadItem(it)
+    }
   }
 
   /** Starts watching the downloads. */
@@ -181,6 +285,7 @@ class DownloadItemManager(
     clientEventEmitter.onDownloadItemPartUpdate(downloadItemPart)
 
     if (downloadItemPart.completed) {
+      persistParentOf(downloadItemPart)
       val downloadItem = downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }
       downloadItem?.let { checkDownloadItemFinished(it) }
       currentDownloadItemParts.remove(downloadItemPart)
@@ -292,6 +397,7 @@ class DownloadItemManager(
                 downloadItemPart.failed = true
                 downloadItemPart.isMoving = false
                 file?.delete()
+                persistParentOf(downloadItemPart)
                 checkDownloadItemFinished(downloadItem)
                 currentDownloadItemParts.remove(downloadItemPart)
               }
@@ -314,6 +420,7 @@ class DownloadItemManager(
 
                 downloadItemPart.moved = true
                 downloadItemPart.isMoving = false
+                persistParentOf(downloadItemPart)
                 checkDownloadItemFinished(downloadItem)
                 currentDownloadItemParts.remove(downloadItemPart)
               }

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadRestoreLogic.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadRestoreLogic.kt
@@ -1,0 +1,41 @@
+package com.audiobookshelf.app.managers
+
+/**
+ * Pure decision logic for how to handle a persisted DownloadItemPart on app start.
+ * Kept Android-free so it can be unit-tested on the JVM.
+ */
+internal object DownloadRestoreLogic {
+  enum class PartRestoreAction {
+    /** Part already finished and was moved to its final destination — skip. */
+    AlreadyDone,
+
+    /**
+     * External (system DownloadManager) part with a known downloadId. Reattach the watcher;
+     * DLM is a system service so the download likely kept progressing across the app's death.
+     */
+    ResumeExternal,
+
+    /**
+     * Drop any partial bytes and re-enqueue from scratch. Used for internal (in-process OkHttp)
+     * downloads that died with the app, and for external parts that never got an enqueue id.
+     */
+    ResetAndReenqueue
+  }
+
+  fun classifyPart(
+    isInternalStorage: Boolean,
+    downloadId: Long?,
+    completed: Boolean,
+    moved: Boolean,
+    failed: Boolean
+  ): PartRestoreAction {
+    // A failed part is never "done" — always retry from scratch.
+    if (failed) return PartRestoreAction.ResetAndReenqueue
+    // Internal storage writes straight to finalDestinationPath; the SAF-only `moved` flag
+    // never gets set, so completion is signaled by `completed` alone.
+    if (completed && (moved || isInternalStorage)) return PartRestoreAction.AlreadyDone
+    if (isInternalStorage) return PartRestoreAction.ResetAndReenqueue
+    if (downloadId != null) return PartRestoreAction.ResumeExternal
+    return PartRestoreAction.ResetAndReenqueue
+  }
+}

--- a/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
@@ -17,6 +17,9 @@ data class DownloadItemPart(
   val filename: String,
   val fileSize: Long,
   val finalDestinationPath:String,
+  // Path of the (temporary) file the system DownloadManager / OkHttp writes to before the
+  // SAF move. Stored as a String so it survives PaperDB serialization (Uri does not).
+  val destinationPath: String,
   val serverPath: String,
   val localFolderName: String,
   val localFolderUrl: String,
@@ -28,9 +31,6 @@ data class DownloadItemPart(
   var moved:Boolean,
   var isMoving:Boolean,
   var failed:Boolean,
-  @JsonIgnore val uri: Uri,
-  @JsonIgnore val destinationUri: Uri,
-  @JsonIgnore val finalDestinationUri: Uri,
   val finalDestinationSubfolder: String,
   var downloadId: Long?,
   var progress: Long,
@@ -38,22 +38,14 @@ data class DownloadItemPart(
 ) {
   companion object {
     fun make(downloadItemId:String, filename:String, fileSize: Long, destinationFile: File, finalDestinationFile: File, subfolder:String, serverPath:String, localFolder: LocalFolder, ebookFile: EBookFile?, audioTrack: AudioTrack?, episode: PodcastEpisode?) :DownloadItemPart {
-      val destinationUri = Uri.fromFile(destinationFile)
-      val finalDestinationUri = Uri.fromFile(finalDestinationFile)
-
-      var downloadUrl = "${DeviceManager.serverAddress}${serverPath}?token=${DeviceManager.token}"
-      if (serverPath.endsWith("/cover")) {
-        downloadUrl += "&raw=1" // Download raw cover image
-      }
-
-      val downloadUri = Uri.parse(downloadUrl)
-      Log.d("DownloadItemPart", "Audio File Destination Uri: $destinationUri | Final Destination Uri: $finalDestinationUri | Download URI $downloadUri")
+      Log.d("DownloadItemPart", "Audio File Destination: ${destinationFile.absolutePath} | Final Destination: ${finalDestinationFile.absolutePath} | Server Path $serverPath")
       return DownloadItemPart(
         id = DeviceManager.getBase64Id(finalDestinationFile.absolutePath),
         downloadItemId,
         filename = filename,
         fileSize = fileSize,
         finalDestinationPath = finalDestinationFile.absolutePath,
+        destinationPath = destinationFile.absolutePath,
         serverPath = serverPath,
         localFolderName = localFolder.name,
         localFolderUrl = localFolder.contentUrl,
@@ -65,9 +57,6 @@ data class DownloadItemPart(
         moved = false,
         isMoving = false,
         failed = false,
-        uri = downloadUri,
-        destinationUri = destinationUri,
-        finalDestinationUri = finalDestinationUri,
         finalDestinationSubfolder = subfolder,
         downloadId = null,
         progress = 0,
@@ -79,8 +68,23 @@ data class DownloadItemPart(
   @get:JsonIgnore
   val isInternalStorage get() = localFolderId.startsWith("internal-")
 
+  // Re-derive on every access so we always pick up the current server token (if it rotated
+  // while the app was suspended) and so we don't depend on Uri being deserialized.
   @get:JsonIgnore
-  val serverUrl get() = uri.toString()
+  val serverUrl: String get() {
+    var url = "${DeviceManager.serverAddress}${serverPath}?token=${DeviceManager.token}"
+    if (serverPath.endsWith("/cover")) url += "&raw=1"
+    return url
+  }
+
+  @get:JsonIgnore
+  val uri: Uri get() = Uri.parse(serverUrl)
+
+  @get:JsonIgnore
+  val destinationUri: Uri get() = Uri.fromFile(File(destinationPath))
+
+  @get:JsonIgnore
+  val finalDestinationUri: Uri get() = Uri.fromFile(File(finalDestinationPath))
 
   @JsonIgnore
   fun getDownloadRequest(): DownloadManager.Request {

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
@@ -53,6 +53,13 @@ class AbsDownloader : Plugin() {
   }
 
   @PluginMethod
+  fun restoreDownloadQueue(call: PluginCall) {
+    Log.d(tag, "restoreDownloadQueue called")
+    downloadItemManager.restoreQueue()
+    call.resolve()
+  }
+
+  @PluginMethod
   fun downloadLibraryItem(call: PluginCall) {
     val libraryItemId = call.data.getString("libraryItemId").toString()
     var episodeId = call.data.getString("episodeId").toString()

--- a/android/app/src/test/java/com/audiobookshelf/app/managers/DownloadRestoreLogicTest.kt
+++ b/android/app/src/test/java/com/audiobookshelf/app/managers/DownloadRestoreLogicTest.kt
@@ -1,0 +1,85 @@
+package com.audiobookshelf.app.managers
+
+import com.audiobookshelf.app.managers.DownloadRestoreLogic.PartRestoreAction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DownloadRestoreLogicTest {
+  private fun classify(
+    isInternalStorage: Boolean = false,
+    downloadId: Long? = null,
+    completed: Boolean = false,
+    moved: Boolean = false,
+    failed: Boolean = false
+  ) = DownloadRestoreLogic.classifyPart(isInternalStorage, downloadId, completed, moved, failed)
+
+  @Test
+  fun externalPart_completedAndMoved_isAlreadyDone() {
+    assertEquals(
+      PartRestoreAction.AlreadyDone,
+      classify(downloadId = 7L, completed = true, moved = true)
+    )
+  }
+
+  @Test
+  fun internalPart_completed_isAlreadyDone_evenWithoutMovedFlag() {
+    // Internal downloads never set `moved` because they write directly to the final path.
+    // Treating them as ResetAndReenqueue caused completed parts to be re-downloaded after restore.
+    assertEquals(
+      PartRestoreAction.AlreadyDone,
+      classify(isInternalStorage = true, completed = true)
+    )
+  }
+
+  @Test
+  fun internalPart_inFlight_resetsAndReenqueues() {
+    // OkHttp call dies with the process; partial bytes can't be resumed.
+    assertEquals(
+      PartRestoreAction.ResetAndReenqueue,
+      classify(isInternalStorage = true, downloadId = 1L)
+    )
+  }
+
+  @Test
+  fun internalPart_completedButFailed_retries() {
+    // OkHttp marks `completed=true` even on transport failure; the `failed` flag separates them.
+    assertEquals(
+      PartRestoreAction.ResetAndReenqueue,
+      classify(isInternalStorage = true, completed = true, failed = true)
+    )
+  }
+
+  @Test
+  fun externalPart_withDownloadId_resumesFromSystemDownloadManager() {
+    assertEquals(
+      PartRestoreAction.ResumeExternal,
+      classify(downloadId = 42L)
+    )
+  }
+
+  @Test
+  fun externalPart_completedButNotMoved_stillResumes() {
+    // The download finished but the move callback was killed; let the watcher retry the move.
+    assertEquals(
+      PartRestoreAction.ResumeExternal,
+      classify(downloadId = 42L, completed = true)
+    )
+  }
+
+  @Test
+  fun externalPart_failedRequest_retriesEvenWithDownloadId() {
+    assertEquals(
+      PartRestoreAction.ResetAndReenqueue,
+      classify(downloadId = 42L, failed = true)
+    )
+  }
+
+  @Test
+  fun externalPart_neverEnqueued_resetsAndReenqueues() {
+    // Process died between addDownloadItem persisting and processDownloadItemParts running.
+    assertEquals(
+      PartRestoreAction.ResetAndReenqueue,
+      classify()
+    )
+  }
+}

--- a/components/widgets/DownloadProgressIndicator.vue
+++ b/components/widgets/DownloadProgressIndicator.vue
@@ -16,6 +16,9 @@ export default {
     }
   },
   computed: {
+    serverConnectionConfigId() {
+      return this.$store.state.user.serverConnectionConfig?.id || null
+    },
     downloadItems() {
       return this.$store.state.globals.itemDownloads
     },
@@ -42,9 +45,24 @@ export default {
       return this.$platform === 'ios'
     }
   },
+  watch: {
+    serverConnectionConfigId(newId, oldId) {
+      // Server connection just came online — pick up any persisted downloads that we
+      // couldn't restore on cold-mount (token/serverAddress weren't available yet).
+      if (newId && !oldId) this.tryRestoreDownloadQueue()
+    }
+  },
   methods: {
     clickedIt() {
       this.$router.push('/downloading')
+    },
+    async tryRestoreDownloadQueue() {
+      if (this.$platform !== 'android' || !AbsDownloader.restoreDownloadQueue) return
+      try {
+        await AbsDownloader.restoreDownloadQueue()
+      } catch (e) {
+        console.error('Failed to restore download queue', e)
+      }
     },
     onItemDownloadComplete(data) {
       console.log('DownloadProgressIndicator onItemDownloadComplete', JSON.stringify(data))
@@ -82,6 +100,10 @@ export default {
     this.downloadItemListener = await AbsDownloader.addListener('onDownloadItem', (data) => this.onDownloadItem(data))
     this.itemPartUpdateListener = await AbsDownloader.addListener('onDownloadItemPartUpdate', (data) => this.onDownloadItemPartUpdate(data))
     this.completeListener = await AbsDownloader.addListener('onItemDownloadComplete', (data) => this.onItemDownloadComplete(data))
+
+    // If a server connection is already established at mount time, restore now.
+    // Otherwise the watcher above will kick off restoration once the user re-authenticates.
+    if (this.serverConnectionConfigId) await this.tryRestoreDownloadQueue()
   },
   beforeDestroy() {
     this.downloadItemListener?.remove()


### PR DESCRIPTION
 ## Brief summary

  Restore Android download queue across app suspends. Persisted downloads are now read back on launch, per-part progress is saved as parts complete, and resume picks up from the last known state instead of restarting from zero.

##  Which issue is fixed?

Partially addresses #1838 - after the user returns to the app, the queue is restored and in-flight downloads pick up where they left off, so the "close, reopen, reinitiate the download" workaround is no longer needed. Does not prevent the original stall while backgrounded; that requires a foreground service, which is out of scope here.

There are also several other download-queue related issues.

##  Pull Request Type

  Android only - frontend (one Vue component, gated $platform === 'android') + native Kotlin. iOS unaffected.

##  In-depth Description

  The bug had two layers:
  1. DbManager.getDownloadItems() had zero callers, so a killed app forgot every in-flight download.
  2. saveDownloadItem was only called once at queue-add time, so even if the queue had been restored, parts would all look fresh and re-download.

 ### Changes

  - DownloadItemPart - Uri fields don't survive serialization, so they're now computed getters over String paths. Added destinationPath so the SAF temp path survives restart. serverUrl is rebuilt from serverPath + DeviceManager.{serverAddress,token} on each access (also handles token rotation across 
  suspends).
  - DownloadItemManager —-New restoreQueue() re-hydrates the in-memory queue, re-attaches external parts to the system DownloadManager by their saved downloadId, and re-enqueues parts that can't be resumed (in-process OkHttp). Bails out if no server is connected. Self-heals from disk: internal-storage parts whose file already exists at the expected size are adopted as completed regardless of what the persisted record claims -this is what makes the fix work for records written by older builds. New persistParentOf() saves at every state transition: downloadId assigned, completion, move success/failure.                

 ### Out of scope

  - Foreground service / WorkManager migration - proper long-term fix for backgrounded downloads (and the full fix for #1838), but a much larger refactor.

 ## How have you tested this?

  - ./gradlew :app:testDebugUnitTest -8/8 pass.
  - ./gradlew assembleDebug - clean.
  - On emulator and on physical Pixel 9 pro: queue an audiobook, let several parts complete, force-stop, reopen + reconnect. Restore picks up correctly: completed parts skipped, queue count accurate, remaining parts continue.  Tested with internal app storage and sdcard.

##  Screenshots

  No visual changes. 