### PR TITLE
Always display title in player

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -311,7 +311,6 @@ export default {
     title() {
       const mediaItemTitle = this.playbackSession?.displayTitle || this.mediaMetadata?.title || 'Title'
       if (this.currentChapterTitle) {
-        if (this.showFullscreen) return this.currentChapterTitle
         return `${mediaItemTitle} | ${this.currentChapterTitle}`
       }
       return mediaItemTitle


### PR DESCRIPTION
In pull request #1861 @hobesman asked to also show the title and not only the chapter in the fullscreen player view. The collapsed player already combines title and chapter.

<img width="200" alt="Screenshot from 2026-05-10 01-17-03" src="https://github.com/user-attachments/assets/d14578ac-7119-4eba-850b-66f249f27c24" />


This patch removes the special handler for the fullscreen player which causes only the chapter to be displayed. Instead, you always get `<title> | <chapter>` if chapters exist. If no chapters exist, the behavior does not change. The book title was displayed already.

<img width="600" alt="Screenshot from 2026-05-10 01-16-42" src="https://github.com/user-attachments/assets/515dbca5-d340-4008-b228-0208b7505c99" />


This affects both Android and iOS.
