### PR TITLE
Fix podcast episode sort for pre-1970 broadcast dates

### DIFF
--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -197,10 +197,15 @@ export default {
           bValue = b[this.sortKey]
         }
 
-        // Sort episodes with no pub date as the oldest
+        // publishedAt is a numeric ms epoch (negative for pre-1970 broadcasts).
+        // Compare numerically so the leading "-" of negative epochs doesn't
+        // break Intl.Collator{numeric:true}, which only handles unsigned digit
+        // runs. Missing dates count as oldest (sink in DESC).
         if (this.sortKey === 'publishedAt') {
-          if (!aValue) aValue = Number.MAX_VALUE
-          if (!bValue) bValue = Number.MAX_VALUE
+          const av = aValue == null ? Number.NEGATIVE_INFINITY : Number(aValue)
+          const bv = bValue == null ? Number.NEGATIVE_INFINITY : Number(bValue)
+          const cmp = av < bv ? -1 : av > bv ? 1 : 0
+          return this.sortDesc ? -cmp : cmp
         }
 
         if (this.sortDesc) {

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -534,12 +534,14 @@ export default {
       if (this.playerIsStartingPlayback) return
 
       if (this.isPodcast) {
+        // Sort by numeric publishedAt; serial podcasts play oldest-first,
+        // others newest-first. Numeric comparison is required so pre-1970
+        // negative ms epochs aren't misordered as ASCII strings.
+        const factor = this.podcastType === 'serial' ? 1 : -1
         this.episodes.sort((a, b) => {
-          if (this.podcastType === 'serial') {
-            return String(a.publishedAt).localeCompare(String(b.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
-          } else {
-            return String(b.publishedAt).localeCompare(String(a.publishedAt), undefined, { numeric: true, sensitivity: 'base' })
-          }
+          const av = a.publishedAt == null ? Number.NEGATIVE_INFINITY : Number(a.publishedAt)
+          const bv = b.publishedAt == null ? Number.NEGATIVE_INFINITY : Number(b.publishedAt)
+          return factor * (av < bv ? -1 : av > bv ? 1 : 0)
         })
 
         let episode = this.episodes.find((ep) => {


### PR DESCRIPTION
## Brief summary

Fix podcast episode sort for episodes whose `publishedAt` is a negative ms epoch (broadcasts before 1970-01-01). Two sites in the app were sorting `publishedAt` via `String(value).localeCompare(..., { numeric: true })`, which treats the leading `-` of a negative number as a non-numeric character — so pre-1970 episodes interleave incorrectly with later ones.

## Which issue is fixed?

No existing issue. I considered filing one but the bug is small enough that a single PR with an in-line repro felt cleaner; happy to open an issue first if maintainers prefer that workflow.

## Pull Request Type

Frontend, both Android and iOS (Vue/Nuxt code only — no native changes).

## In-depth Description

`Intl.Collator` with `numeric: true` only treats unsigned digit runs as numbers. The `-` sign of negative ms epochs is plain ASCII, so for those values the comparator is purely lexical. The user-visible effect on a long-running archive podcast (BBC *Just a Minute*, 1967 → present, 1015 episodes) is that pre-1970 episodes cluster together, with a 1967 episode appearing **before** 1968 episodes when "Pub Date — newest first" is selected.

Two sites changed:

- `components/tables/podcast/EpisodesTable.vue` — `episodesSorted` (the visible list)
- `pages/item/_id/index.vue` — the `play()` next-episode picker

Both switch the `publishedAt` branch to numeric subtraction. Other sort keys (`title`, `season`, `episode`, `audioFile.metadata.filename`) are string-typed and continue to use `localeCompare(numeric: true)` so natural sort ("Episode 2" < "Episode 10") is preserved.

A small intent-fix is bundled: the long-standing comment says *"sort episodes with no pub date as the oldest"*, but `Number.MAX_VALUE` made them sort newest. Switched to `Number.NEGATIVE_INFINITY` to match the comment (missing dates sink in DESC, float in ASC).

Same root cause as advplyr/audiobookshelf#3620 (years <1000 in the books library); companion PR for the server's web client: advplyr/audiobookshelf#5233.

## How have you tested this?

The repo has no test infrastructure today, so I can't add a unit test here without scope creep. Verified via:

1. **Paste-into-console reproducer** — confirms the bug and the fix at the comparator level:
   ```js
   const eps = [
     { id: 'bedrooms_1967',  publishedAt: -63417600000 },
     { id: 'brownies_1968',  publishedAt: -61603200000 },
     { id: 'honeymoon_1968', publishedAt: -60393600000 },
     { id: 'bacchus_1970',   publishedAt:    345600000 }
   ]
   // Buggy (current):
   [...eps].sort((a, b) =>
     String(b.publishedAt).localeCompare(String(a.publishedAt),
       undefined, { numeric: true, sensitivity: 'base' })
   ).map(e => e.id)
   // → ['bacchus_1970','bedrooms_1967','brownies_1968','honeymoon_1968']  ← 1967 ahead of 1968 in DESC
   
   // Fixed:
   [...eps].sort((a, b) => b.publishedAt - a.publishedAt).map(e => e.id)
   // → ['bacchus_1970','honeymoon_1968','brownies_1968','bedrooms_1967']  ← chronological
   ```
2. **Real data** — my own ABS server has a 1015-episode *Just a Minute* podcast spanning 1967–2026 that exhibits the bug. After the fix, episodes sort chronologically end-to-end.

Happy to add a follow-up PR introducing Vitest + a unit test for `episodesSorted` if interest.

## Screenshots

Before (sort by Pub Date, descending) — note 1967 "Bedrooms" appears between the 1970 episode and the 1968 episodes:

> User-supplied screenshot from a real install. Will attach in a comment after PR opens (it sits on a private device).

---
*Developed with the help of [Claude](https://claude.ai/) (Anthropic). Bug, fix, and reproducer reviewed and verified by me.*
