### PR TITLE
Remove hardcoded search result limit of 5

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -122,7 +122,7 @@ export default {
         return
       }
       this.isFetching = true
-      const results = await this.$nativeHttp.get(`/api/libraries/${this.currentLibraryId}/search?q=${value}&limit=5`).catch((error) => {
+      const results = await this.$nativeHttp.get(`/api/libraries/${this.currentLibraryId}/search?q=${value}`).catch((error) => {
         console.error('Search error', error)
         return null
       })


### PR DESCRIPTION
## Brief summary

Removed the hardcoded search result limit parameter (`limit=5`) from the library search API request in the app.

## Which issue is fixed?

Fixes #1872

## Pull Request Type

This change affects both Android and iOS apps as it is a shared frontend code modification in `pages/search.vue`.

## In-depth Description

In `pages/search.vue`, the search API call was sent with a hardcoded `limit=5` parameter. This restricted the app's search results to only 5 items per category (books, podcasts, authors, etc.) even when more matches were available on the server. By removing this hardcoded limit, the API request will now allow the server's default pagination or full search results to be returned and rendered in the app.

## How have you tested this?

1. Built and ran the app locally.
2. Performed searches that are known to return more than 5 results (e.g. searching for a common letter or tag).
3. Verified that more than 5 results are now displayed correctly in the search results page.