### PR TITLE
feat: Add car mode modal

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -47,9 +47,10 @@
       <p class="author-text text-fg text-opacity-75 truncate">{{ authorName }}</p>
     </div>
 
-    <div id="playerContent" class="playerContainer w-full z-20 absolute bottom-0 left-0 right-0 p-2 pointer-events-auto transition-all" :style="{ backgroundColor: showFullscreen ? '' : coverRgb }" @click="clickContainer">
+    <div id="playerContent" v-show="!showCarModeModal" class="playerContainer w-full z-20 absolute bottom-0 left-0 right-0 p-2 pointer-events-auto transition-all" :style="{ backgroundColor: showFullscreen ? '' : coverRgb }" @click="clickContainer">
       <div v-if="showFullscreen" class="absolute bottom-4 left-0 right-0 w-full pb-4 pt-2 mx-auto px-6" style="max-width: 414px">
         <div class="flex items-center justify-between pointer-events-auto">
+          <span class="material-symbols text-3xl text-fg-muted cursor-pointer" @click="clickCarModeBtn">directions_car</span>
           <span v-if="!isPodcast && serverLibraryItemId && socketConnected" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')">bookmark</span>
           <!-- hidden for podcasts but still using this as a placeholder -->
           <span v-else class="material-symbols text-3xl text-white text-opacity-0">bookmark</span>
@@ -67,7 +68,7 @@
       </div>
       <div v-else class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: var(--gradient-minimized-audio-player)" />
 
-      <div id="playerControls" class="absolute right-0 bottom-0 mx-auto" style="max-width: 414px">
+      <div id="playerControls" v-show="!showCarModeModal" class="absolute right-0 bottom-0 mx-auto" style="max-width: 414px">
         <div class="flex items-center max-w-full" :class="playerSettings.lockUi ? 'justify-center' : 'justify-between'">
           <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart">first_page</span>
           <div v-show="!playerSettings.lockUi" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards">
@@ -88,7 +89,7 @@
         </div>
       </div>
 
-      <div id="playerTrack" class="absolute left-0 w-full px-6">
+      <div id="playerTrack" v-show="!showCarModeModal" class="absolute left-0 w-full px-6">
         <div class="flex pointer-events-none">
           <p class="font-mono text-fg" style="font-size: 0.8rem" ref="currentTimestamp">0:00</p>
           <div class="flex-grow" />
@@ -105,6 +106,7 @@
       </div>
     </div>
 
+    <modals-car-mode-modal v-model="showCarModeModal" :is-playing="isPlaying" @close="showCarModeModal = false" />
     <modals-chapters-modal v-model="showChapterModal" :current-chapter="currentChapter" :chapters="chapters" :playback-rate="currentPlaybackRate" @select="selectChapter" />
     <modals-dialog v-model="showMoreMenuDialog" :items="menuItems" width="80vw" @action="clickMenuAction" />
   </div>
@@ -135,6 +137,7 @@ export default {
       windowWidth: 0,
       playbackSession: null,
       showChapterModal: false,
+      showCarModeModal: false,
       showFullscreen: false,
       totalDuration: 0,
       currentPlaybackRate: 1,
@@ -409,6 +412,10 @@ export default {
     clickChaptersBtn() {
       if (!this.chapters.length) return
       this.showChapterModal = true
+    },
+    clickCarModeBtn() {
+      console.log('[AudioPlayer] Car mode toggled', !this.showCarModeModal)
+      this.showCarModeModal = true
     },
     async coverImageLoaded(fullCoverUrl) {
       if (!fullCoverUrl) return

--- a/components/modals/CarModeModal.vue
+++ b/components/modals/CarModeModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <modals-modal v-model="show" :width="400" max-width="95%" height="100%">
+    <div class="w-full h-full overflow-hidden absolute top-0 left-0 flex items-center justify-center" @click="show = false">
+      <div class="w-full h-full" @click.stop>
+        <div class="w-full h-full flex flex-col">
+          <div class="h-1/2 mt-20">
+            <button @click.stop="playPauseClick" class="aspect-square w-full flex items-center justify-center">
+              <span class="material-symbols text-7xl text-white">{{ localPlaying ? 'pause' : 'play_arrow' }}</span>
+            </button>
+          </div>
+
+          <div class="h-1/2 flex items-end justify-center px-6 pb-10">
+            <div class="flex items-center justify-center w-full max-w-2xl gap-8">
+              <button @click.stop="jumpBackward" class="aspect-square flex-col w-44 flex items-center justify-center">
+                  <span class="material-symbols text-5xl text-white leading-none">replay</span>
+                  <span class="jump-label font-semibold leading-tight text-4xl text-white"">{{ jumpBackwardsLabel }}</span>
+              </button>
+              <button @click.stop="jumpForward" class="aspect-square flex-col w-44 flex items-center justify-center">
+                  <span class="material-symbols text-5xl text-white leading-none">forward_media</span>
+                  <span class="jump-label font-semibold leading-tight text-4xl text-white"">{{ jumpForwardLabel }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </modals-modal>
+</template>
+
+<script>
+import { AbsAudioPlayer } from '@/plugins/capacitor'
+import jumpLabelMixin from '@/mixins/jumpLabel'
+
+export default {
+  props: {
+    value: Boolean
+  },
+  mixins: [jumpLabelMixin],
+  data() {
+    return {
+      localPlaying: false,
+      playingListener: null
+    }
+  },
+  computed: {
+    show: {
+      get() {
+        return this.value
+      },
+      set(val) {
+        this.$emit('input', val)
+      }
+    },
+    jumpForwardLabel() {
+      return this.getJumpLabel(this.jumpForwardTime)
+    },
+    jumpBackwardsLabel() {
+      return this.getJumpLabel(this.jumpBackwardsTime)
+    },
+    jumpForwardTime() {
+      return this.$store.getters['getJumpForwardTime']
+    },
+    jumpBackwardsTime() {
+      return this.$store.getters['getJumpBackwardsTime']
+    }
+  },
+  methods: {
+    async playPauseClick() {
+      try {
+        const res = await AbsAudioPlayer.playPause()
+        if (res && typeof res.playing !== 'undefined') {
+          this.localPlaying = !!res.playing
+        } else {
+          this.localPlaying = !this.localPlaying
+        }
+      } catch (e) {
+        console.error('[CarModeModal] playToggle failed', e)
+      }
+    },
+    onPlayingUpdate(data) {
+      if (data && typeof data.value !== 'undefined') this.localPlaying = !!data.value
+      else if (data && typeof data.playing !== 'undefined') this.localPlaying = !!data.playing
+    },
+    async jumpForward() {
+      try {
+        await AbsAudioPlayer.seekForward({ value: this.jumpForwardTime })
+      } catch (e) {
+        console.error('[CarModeModal] skipForward failed', e)
+      }
+    },
+    async jumpBackward() {
+      try {
+        await AbsAudioPlayer.seekBackward({ value: this.jumpBackwardsTime })
+      } catch (e) {
+        console.error('[CarModeModal] skipBackward failed', e)
+      }
+    }
+  },
+  mounted() {
+    try {
+      this.playingListener = AbsAudioPlayer.addListener('onPlayingUpdate', this.onPlayingUpdate)
+    } catch (e) {
+      // ignore if unavailable in environment
+    }
+  },
+  beforeDestroy() {
+    try {
+      if (this.playingListener && this.playingListener.remove) {
+        this.playingListener.remove()
+      }
+    } catch (e) {
+      // Ignore
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Brief summary

Adds a basic "Car Mode" toggle to the audio player for a simplified, large-button UI during in-car use.

## Which issue is fixed?

N/A

## Pull Request Type

Frontend (UI) Android and IOS

## In-depth Description

This PR introduces a simplified Car Mode modal to the fullscreen audio player, providing larger touch targets and removing clutter.

### Changes

* **`components/modals/CarModeModal.vue` (New)**
  * Creates a modal with three large, square buttons: Play/Pause, Skip Back, and Skip Forward.
  * Uses Tailwind for consistent, touch-friendly sizing.
  * Calls existing playback methods directly from the audio plugin.
* **`components/app/AudioPlayer.vue` (Modified)**
  * Adds a car icon to the top header to trigger the modal.
  * Uses `v-show` to hide standard bottom playback controls and the seek bar while Car Mode is active.

## How have you tested this?

Manual testing:
1. Started playback and opened the fullscreen player.
2. Tapped the car icon to open Car Mode.
3. Verified the layout (large buttons) and confirmed the standard controls hidden themselves.
4. Tested play, pause, and skip functionality.
5. Closed the modal and confirmed regular player behavior resumed.

## Screenshots

<table>
  <tr>
    <td><strong>Before</strong></td>
    <td><strong>After (Normal UI)</strong></td>
    <td><strong>After (Car Mode)</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/96366502-167f-411f-b21e-f1b5e63c9e0b" width="250" alt="Before" /></td>
    <td><img src="https://github.com/user-attachments/assets/17635b78-6d84-4055-bfdd-a0380fca5b86" width="250" alt="After Normal" /></td>
    <td><img src="https://github.com/user-attachments/assets/822bb67b-78e5-459a-9bde-d9a08281d344" width="250" alt="After Car Mode" /></td>
  </tr>
</table>
