### PR TITLE
Android TV (2/10): keyboard hygiene + foundational TV DOM markup

### DIFF
--- a/components/app/Appbar.vue
+++ b/components/app/Appbar.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="w-full h-16 bg-primary relative z-20">
     <div id="appbar" class="absolute top-0 left-0 w-full h-full flex items-center px-2">
-      <nuxt-link v-show="!showBack" to="/" class="mr-3">
+      <nuxt-link v-show="!showBack" to="/" class="mr-3" tabindex="-1" aria-hidden="true">
         <img src="/Logo.png" class="h-10 w-10" />
       </nuxt-link>
-      <a v-if="showBack" @click="back" aria-label="Back" class="rounded-full h-10 w-10 flex items-center justify-center mr-2 cursor-pointer">
+      <a v-if="showBack" @click="back" @keydown.enter.prevent="back" aria-label="Back" tabindex="0" class="rounded-full h-10 w-10 flex items-center justify-center mr-2 cursor-pointer">
         <span class="material-symbols text-3xl text-fg">arrow_back</span>
       </a>
       <div v-if="user && currentLibrary">

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -4,13 +4,13 @@
       <div class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: var(--gradient-audio-player)" />
 
       <div class="top-4 left-4 absolute cursor-pointer">
-        <span class="material-symbols text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="collapseFullscreen">keyboard_arrow_down</span>
+        <span tabindex="0" class="material-symbols text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="collapseFullscreen" @keydown.enter.prevent="collapseFullscreen">keyboard_arrow_down</span>
       </div>
       <div v-show="showCastBtn" class="top-6 right-16 absolute cursor-pointer">
         <span class="material-symbols text-3xl" :class="coverBgIsLight && theme !== 'black' ? 'text-black' : ''" @click="castClick">{{ isCasting ? 'cast_connected' : 'cast' }}</span>
       </div>
       <div class="top-6 right-4 absolute cursor-pointer">
-        <span class="material-symbols text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="showMoreMenuDialog = true">more_vert</span>
+        <span tabindex="0" class="material-symbols text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="showMoreMenuDialog = true" @keydown.enter.prevent="showMoreMenuDialog = true">more_vert</span>
       </div>
       <p class="top-4 absolute left-0 right-0 mx-auto text-center uppercase tracking-widest text-opacity-75" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" style="font-size: 10px">{{ isDirectPlayMethod ? $strings.LabelPlaybackDirect : isLocalPlayMethod ? $strings.LabelPlaybackLocal : $strings.LabelPlaybackTranscode }}</p>
     </div>
@@ -50,41 +50,41 @@
     <div id="playerContent" class="playerContainer w-full z-20 absolute bottom-0 left-0 right-0 p-2 pointer-events-auto transition-all" :style="{ backgroundColor: showFullscreen ? '' : coverRgb }" @click="clickContainer">
       <div v-if="showFullscreen" class="absolute bottom-4 left-0 right-0 w-full pb-4 pt-2 mx-auto px-6" style="max-width: 414px">
         <div class="flex items-center justify-between pointer-events-auto">
-          <span v-if="!isPodcast && serverLibraryItemId && socketConnected" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')">bookmark</span>
+          <span v-if="!isPodcast && serverLibraryItemId && socketConnected" tabindex="0" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')" @keydown.enter.prevent="$emit('showBookmarks')">bookmark</span>
           <!-- hidden for podcasts but still using this as a placeholder -->
           <span v-else class="material-symbols text-3xl text-white text-opacity-0">bookmark</span>
 
-          <span class="font-mono text-fg-muted cursor-pointer" style="font-size: 1.35rem" @click="$emit('selectPlaybackSpeed')">{{ currentPlaybackRate }}x</span>
-          <svg v-if="!sleepTimerRunning" xmlns="http://www.w3.org/2000/svg" class="h-7 w-7 text-fg-muted cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor" @click.stop="$emit('showSleepTimer')">
+          <span tabindex="0" class="font-mono text-fg-muted cursor-pointer" style="font-size: 1.35rem" @click="$emit('selectPlaybackSpeed')" @keydown.enter.prevent="$emit('selectPlaybackSpeed')">{{ currentPlaybackRate }}x</span>
+          <svg v-if="!sleepTimerRunning" xmlns="http://www.w3.org/2000/svg" tabindex="0" class="h-7 w-7 text-fg-muted cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor" @click.stop="$emit('showSleepTimer')" @keydown.enter.prevent.stop="$emit('showSleepTimer')">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
           </svg>
-          <div v-else class="h-7 w-7 flex items-center justify-around cursor-pointer" @click.stop="$emit('showSleepTimer')">
+          <div v-else tabindex="0" class="h-7 w-7 flex items-center justify-around cursor-pointer" @click.stop="$emit('showSleepTimer')" @keydown.enter.prevent.stop="$emit('showSleepTimer')">
             <p class="text-xl font-mono text-success">{{ sleepTimeRemainingPretty }}</p>
           </div>
 
-          <span class="material-symbols text-3xl text-fg cursor-pointer" :class="chapters.length ? 'text-opacity-75' : 'text-opacity-10'" @click="clickChaptersBtn">format_list_bulleted</span>
+          <span tabindex="0" class="material-symbols text-3xl text-fg cursor-pointer" :class="chapters.length ? 'text-opacity-75' : 'text-opacity-10'" @click="clickChaptersBtn" @keydown.enter.prevent="clickChaptersBtn">format_list_bulleted</span>
         </div>
       </div>
       <div v-else class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: var(--gradient-minimized-audio-player)" />
 
       <div id="playerControls" class="absolute right-0 bottom-0 mx-auto" style="max-width: 414px">
         <div class="flex items-center max-w-full" :class="playerSettings.lockUi ? 'justify-center' : 'justify-between'">
-          <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart">first_page</span>
-          <div v-show="!playerSettings.lockUi" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards">
+          <span v-show="showFullscreen && !playerSettings.lockUi" :tabindex="showFullscreen && !playerSettings.lockUi ? 0 : -1" class="material-symbols next-icon text-fg cursor-pointer" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart" @keydown.enter.prevent.stop="jumpChapterStart">first_page</span>
+          <div v-show="!playerSettings.lockUi" tabindex="0" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards" @keydown.enter.prevent.stop="jumpBackwards">
             <span class="material-symbols text-3xl leading-none">replay</span>
             <span v-if="showFullscreen" class="jump-label text-[10px] font-semibold leading-tight">{{ jumpBackwardsLabel }}</span>
           </div>
-          <div class="play-btn cursor-pointer shadow-sm flex items-center justify-center rounded-full text-primary mx-4 relative overflow-hidden" :style="{ backgroundColor: coverRgb }" :class="{ 'animate-spin': seekLoading }" @mousedown.prevent @mouseup.prevent @click.stop="playPauseClick">
+          <div tabindex="0" class="play-btn cursor-pointer shadow-sm flex items-center justify-center rounded-full text-primary mx-4 relative overflow-hidden" :style="{ backgroundColor: coverRgb }" :class="{ 'animate-spin': seekLoading }" @mousedown.prevent @mouseup.prevent @click.stop="playPauseClick" @keydown.enter.prevent.stop="playPauseClick">
             <div v-if="!coverBgIsLight" class="absolute top-0 left-0 w-full h-full bg-white bg-opacity-20 pointer-events-none" />
 
             <span v-if="!showLoadingState" class="material-symbols fill" :class="{ 'text-white': coverRgb && !coverBgIsLight }">{{ seekLoading ? 'autorenew' : !isPlaying ? 'play_arrow' : 'pause' }}</span>
             <widgets-spinner-icon v-else class="h-8 w-8" />
           </div>
-          <div v-show="!playerSettings.lockUi" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpForward">
+          <div v-show="!playerSettings.lockUi" tabindex="0" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpForward" @keydown.enter.prevent.stop="jumpForward">
             <span class="material-symbols text-3xl leading-none">forward_media</span>
             <span v-if="showFullscreen" class="jump-label text-[10px] font-semibold leading-tight">{{ jumpForwardLabel }}</span>
           </div>
-          <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="nextChapter && !showLoadingState ? 'text-opacity-75' : 'text-opacity-10'" @click.stop="jumpNextChapter">last_page</span>
+          <span v-show="showFullscreen && !playerSettings.lockUi" :tabindex="showFullscreen && !playerSettings.lockUi ? 0 : -1" class="material-symbols next-icon text-fg cursor-pointer" :class="nextChapter && !showLoadingState ? 'text-opacity-75' : 'text-opacity-10'" @click.stop="jumpNextChapter" @keydown.enter.prevent.stop="jumpNextChapter">last_page</span>
         </div>
       </div>
 

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -8,7 +8,7 @@
 
       <!-- Collapse button - minimizes player -->
       <div class="top-4 left-4 absolute cursor-pointer">
-        <span class="material-symbols text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="collapseFullscreen">keyboard_arrow_down</span>
+        <span tabindex="0" class="material-symbols text-5xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="collapseFullscreen" @keydown.enter.prevent="collapseFullscreen">keyboard_arrow_down</span>
       </div>
 
       <!-- Cast button - Chromecast toggle -->
@@ -18,7 +18,7 @@
 
       <!-- Player options menu button -->
       <div class="top-6 right-4 absolute cursor-pointer">
-        <span class="material-symbols text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="showMoreMenuDialog = true">more_vert</span>
+        <span tabindex="0" class="material-symbols text-3xl" :class="{ 'text-black text-opacity-75': coverBgIsLight && theme !== 'black' }" @click="showMoreMenuDialog = true" @keydown.enter.prevent="showMoreMenuDialog = true">more_vert</span>
       </div>
 
       <!-- Playback method indicator (Direct/Local/Transcode) -->
@@ -65,19 +65,19 @@
       <!-- Top controls bar - fullscreen only: bookmarks, speed, sleep timer, chapters -->
       <div v-if="showFullscreen" class="absolute bottom-4 left-0 right-0 w-full pb-4 pt-2 mx-auto px-6" style="max-width: 414px">
         <div class="flex items-center justify-between pointer-events-auto">
-          <span v-if="!isPodcast && serverLibraryItemId && socketConnected" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')">bookmark</span>
+          <span v-if="!isPodcast && serverLibraryItemId && socketConnected" tabindex="0" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')" @keydown.enter.prevent="$emit('showBookmarks')">bookmark</span>
           <!-- hidden for podcasts but still using this as a placeholder -->
           <span v-else class="material-symbols text-3xl text-white text-opacity-0">bookmark</span>
 
-          <span class="font-mono text-fg-muted cursor-pointer" style="font-size: 1.35rem" @click="$emit('selectPlaybackSpeed')">{{ currentPlaybackRate }}x</span>
-          <svg v-if="!sleepTimerRunning" xmlns="http://www.w3.org/2000/svg" class="h-7 w-7 text-fg-muted cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor" @click.stop="$emit('showSleepTimer')">
+          <span tabindex="0" class="font-mono text-fg-muted cursor-pointer" style="font-size: 1.35rem" @click="$emit('selectPlaybackSpeed')" @keydown.enter.prevent="$emit('selectPlaybackSpeed')">{{ currentPlaybackRate }}x</span>
+          <svg v-if="!sleepTimerRunning" xmlns="http://www.w3.org/2000/svg" tabindex="0" class="h-7 w-7 text-fg-muted cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor" @click.stop="$emit('showSleepTimer')" @keydown.enter.prevent.stop="$emit('showSleepTimer')">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
           </svg>
-          <div v-else class="h-7 w-7 flex items-center justify-around cursor-pointer" @click.stop="$emit('showSleepTimer')">
+          <div v-else tabindex="0" class="h-7 w-7 flex items-center justify-around cursor-pointer" @click.stop="$emit('showSleepTimer')" @keydown.enter.prevent.stop="$emit('showSleepTimer')">
             <p class="text-xl font-mono text-success">{{ sleepTimeRemainingPretty }}</p>
           </div>
 
-          <span class="material-symbols text-3xl text-fg cursor-pointer" :class="chapters.length ? 'text-opacity-75' : 'text-opacity-10'" @click="clickChaptersBtn">format_list_bulleted</span>
+          <span tabindex="0" class="material-symbols text-3xl text-fg cursor-pointer" :class="chapters.length ? 'text-opacity-75' : 'text-opacity-10'" @click="clickChaptersBtn" @keydown.enter.prevent="clickChaptersBtn">format_list_bulleted</span>
         </div>
       </div>
       <div v-else class="w-full h-full absolute top-0 left-0 pointer-events-none" style="background: var(--gradient-minimized-audio-player)" />
@@ -85,22 +85,22 @@
       <!-- Playback controls - jump buttons, play/pause, chapter navigation -->
       <div id="playerControls" class="absolute right-0 bottom-0 mx-auto" style="max-width: 414px">
         <div class="flex items-center max-w-full" :class="playerSettings.lockUi ? 'justify-center' : 'justify-between'">
-          <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart">first_page</span>
-          <div v-show="!playerSettings.lockUi" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards">
+          <span v-show="showFullscreen && !playerSettings.lockUi" :tabindex="showFullscreen && !playerSettings.lockUi ? 0 : -1" class="material-symbols next-icon text-fg cursor-pointer" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpChapterStart" @keydown.enter.prevent.stop="jumpChapterStart">first_page</span>
+          <div v-show="!playerSettings.lockUi" tabindex="0" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpBackwards" @keydown.enter.prevent.stop="jumpBackwards">
             <span class="material-symbols text-3xl leading-none">replay</span>
             <span v-if="showFullscreen" class="jump-label text-[10px] font-semibold leading-tight">{{ jumpBackwardsLabel }}</span>
           </div>
-          <div class="play-btn cursor-pointer shadow-sm flex items-center justify-center rounded-full text-primary mx-4 relative overflow-hidden" :style="{ backgroundColor: coverRgb }" :class="{ 'animate-spin': seekLoading }" @mousedown.prevent @mouseup.prevent @click.stop="playPauseClick">
+          <div tabindex="0" class="play-btn cursor-pointer shadow-sm flex items-center justify-center rounded-full text-primary mx-4 relative overflow-hidden" :style="{ backgroundColor: coverRgb }" :class="{ 'animate-spin': seekLoading }" @mousedown.prevent @mouseup.prevent @click.stop="playPauseClick" @keydown.enter.prevent.stop="playPauseClick">
             <div v-if="!coverBgIsLight" class="absolute top-0 left-0 w-full h-full bg-white bg-opacity-20 pointer-events-none" />
 
             <span v-if="!showLoadingState" class="material-symbols fill" :class="{ 'text-white': coverRgb && !coverBgIsLight }">{{ seekLoading ? 'autorenew' : !isPlaying ? 'play_arrow' : 'pause' }}</span>
             <widgets-spinner-icon v-else class="h-8 w-8" />
           </div>
-          <div v-show="!playerSettings.lockUi" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpForward">
+          <div v-show="!playerSettings.lockUi" tabindex="0" class="jump-icon text-fg cursor-pointer flex flex-col items-center" :class="showLoadingState ? 'text-opacity-10' : 'text-opacity-75'" @click.stop="jumpForward" @keydown.enter.prevent.stop="jumpForward">
             <span class="material-symbols text-3xl leading-none">forward_media</span>
             <span v-if="showFullscreen" class="jump-label text-[10px] font-semibold leading-tight">{{ jumpForwardLabel }}</span>
           </div>
-          <span v-show="showFullscreen && !playerSettings.lockUi" class="material-symbols next-icon text-fg cursor-pointer" :class="nextChapter && !showLoadingState ? 'text-opacity-75' : 'text-opacity-10'" @click.stop="jumpNextChapter">last_page</span>
+          <span v-show="showFullscreen && !playerSettings.lockUi" :tabindex="showFullscreen && !playerSettings.lockUi ? 0 : -1" class="material-symbols next-icon text-fg cursor-pointer" :class="nextChapter && !showLoadingState ? 'text-opacity-75' : 'text-opacity-10'" @click.stop="jumpNextChapter" @keydown.enter.prevent.stop="jumpNextChapter">last_page</span>
         </div>
       </div>
 

--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="fixed top-0 left-0 right-0 layout-wrapper w-full z-50 overflow-hidden pointer-events-none">
     <div class="absolute top-0 left-0 w-full h-full bg-black transition-opacity duration-200" :class="show ? 'bg-opacity-60 pointer-events-auto' : 'bg-opacity-0'" @click="clickBackground" />
-    <div class="absolute top-0 right-0 w-64 h-full bg-bg transform transition-transform py-6 pointer-events-auto" :class="show ? '' : 'translate-x-64'" @click.stop>
+    <div class="absolute top-0 right-0 w-64 h-full bg-bg transform transition-transform py-6 pointer-events-auto" :class="show ? '' : 'translate-x-64'" :data-tv-overlay="show ? 'side-drawer' : null" @click.stop>
       <div class="px-6 mb-4">
         <p v-if="user" class="text-base" v-html="$getString('HeaderWelcome', [username])" />
       </div>
 
       <div class="w-full overflow-y-auto">
         <template v-for="item in navItems">
-          <button v-if="item.action" :key="item.text" :tabindex="show ? 0 : -1" class="w-full hover:bg-bg/60 flex items-center py-3 px-6 text-fg-muted" @click="clickAction(item.action)">
+          <button v-if="item.action" :key="item.text" :tabindex="show ? 0 : -1" class="w-full hover:bg-bg/60 flex items-center py-3 px-6 text-fg-muted" @click="clickAction(item.action)" @keydown.enter.prevent="clickAction(item.action)">
             <span class="material-symbols fill text-lg">{{ item.icon }}</span>
             <p class="pl-4">{{ item.text }}</p>
           </button>
@@ -25,7 +25,7 @@
         <div class="flex items-center">
           <p class="text-xs">{{ $config.version }}</p>
           <div class="flex-grow" />
-          <div v-if="user" class="flex items-center" @click="disconnect">
+          <div v-if="user" :tabindex="show ? 0 : -1" class="flex items-center cursor-pointer" @click="disconnect" @keydown.enter.prevent="disconnect">
             <p class="text-xs pr-2">{{ $strings.ButtonDisconnect }}</p>
             <i class="material-symbols text-sm -mb-0.5">cloud_off</i>
           </div>

--- a/components/cards/LazyBookCard.vue
+++ b/components/cards/LazyBookCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="card" tabindex="0" :id="`book-card-${index}`" :style="{ minWidth: width + 'px', maxWidth: width + 'px', height: height + 'px' }" class="rounded-sm z-10 bg-primary cursor-pointer box-shadow-book" @click="clickCard">
+  <div ref="card" tabindex="0" :id="`book-card-${index}`" :style="{ minWidth: width + 'px', maxWidth: width + 'px', height: height + 'px' }" class="rounded-sm z-10 bg-primary cursor-pointer box-shadow-book" @click="clickCard" @keydown.enter.prevent="clickCard">
     <!-- When cover image does not fill -->
     <div v-show="showCoverBg" class="absolute top-0 left-0 w-full h-full overflow-hidden rounded-sm bg-primary">
       <div class="absolute cover-bg" ref="coverBg" />

--- a/components/cards/LazyCollectionCard.vue
+++ b/components/cards/LazyCollectionCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="card" :id="`collection-card-${index}`" :style="{ width: width + 'px', height: height + 'px' }" class="rounded-sm cursor-pointer z-30" @click="clickCard">
+  <div ref="card" tabindex="0" :id="`collection-card-${index}`" :style="{ width: width + 'px', height: height + 'px' }" class="rounded-sm cursor-pointer z-30" @click="clickCard" @keydown.enter.prevent="clickCard">
     <div class="absolute top-0 left-0 w-full box-shadow-book shadow-height" />
     <div class="w-full h-full bg-primary relative rounded overflow-hidden">
       <covers-collection-cover ref="cover" :book-items="books" :width="width" :height="height" :book-cover-aspect-ratio="bookCoverAspectRatio" />

--- a/components/cards/LazyPlaylistCard.vue
+++ b/components/cards/LazyPlaylistCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="card" :id="`playlist-card-${index}`" :style="{ width: width + 'px', height: height + 'px' }" class="absolute top-0 left-0 rounded-sm z-30 cursor-pointer" @click="clickCard">
+  <div ref="card" tabindex="0" :id="`playlist-card-${index}`" :style="{ width: width + 'px', height: height + 'px' }" class="absolute top-0 left-0 rounded-sm z-30 cursor-pointer" @click="clickCard" @keydown.enter.prevent="clickCard">
     <div class="absolute top-0 left-0 w-full box-shadow-book shadow-height" />
     <div class="w-full h-full bg-primary relative rounded overflow-hidden">
       <covers-playlist-cover ref="cover" :items="items" :width="width" :height="height" />

--- a/components/cards/LazySeriesCard.vue
+++ b/components/cards/LazySeriesCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="card" :id="`series-card-${index}`" :style="{ width: width + 'px', height: height + 'px' }" class="rounded-sm cursor-pointer z-30" @click="clickCard">
+  <div ref="card" tabindex="0" :id="`series-card-${index}`" :style="{ width: width + 'px', height: height + 'px' }" class="rounded-sm cursor-pointer z-30" @click="clickCard" @keydown.enter.prevent="clickCard">
     <div class="absolute top-0 left-0 w-full box-shadow-book shadow-height" />
     <div class="w-full h-full bg-primary relative rounded overflow-hidden">
       <covers-group-cover v-if="series" ref="cover" :id="seriesId" :name="title" :book-items="books" :width="width" :height="height" :book-cover-aspect-ratio="bookCoverAspectRatio" />

--- a/components/home/BookshelfToolbar.vue
+++ b/components/home/BookshelfToolbar.vue
@@ -5,16 +5,16 @@
         <p v-show="!selectedSeriesName" class="pt-1">{{ $formatNumber(totalEntities) }} {{ entityTitle }}</p>
         <p v-show="selectedSeriesName" class="ml-2 pt-1">{{ selectedSeriesName }} ({{ $formatNumber(totalEntities) }})</p>
         <div class="flex-grow" />
-        <span v-if="page == 'library' || seriesBookPage" class="material-symbols text-2xl px-2" @click="changeView">{{ !bookshelfListView ? 'view_list' : 'grid_view' }}</span>
+        <span v-if="page == 'library' || seriesBookPage" tabindex="0" class="material-symbols text-2xl px-2" @click="changeView" @keydown.enter.prevent="changeView">{{ !bookshelfListView ? 'view_list' : 'grid_view' }}</span>
         <template v-if="page === 'library'">
-          <div class="relative flex items-center px-2">
-            <span class="material-symbols text-2xl" @click="showFilterModal = true">filter_alt</span>
+          <div class="relative flex items-center px-2" tabindex="0" @keydown.enter.prevent="showFilterModal = true" @click="showFilterModal = true">
+            <span class="material-symbols text-2xl">filter_alt</span>
             <div v-show="hasFilters" class="absolute top-0 right-2 w-2 h-2 rounded-full bg-success border border-green-300 shadow-sm z-10 pointer-events-none" />
           </div>
-          <span class="material-symbols text-2xl px-2" @click="showSortModal = true">sort</span>
+          <span tabindex="0" class="material-symbols text-2xl px-2" @click="showSortModal = true" @keydown.enter.prevent="showSortModal = true">sort</span>
         </template>
-        <span v-if="seriesBookPage" class="material-symbols text-2xl px-2" @click="downloadSeries">download</span>
-        <span v-if="(page == 'library' && isBookLibrary) || seriesBookPage" class="material-symbols text-2xl px-2" @click="showMoreMenuDialog = true">more_vert</span>
+        <span v-if="seriesBookPage" tabindex="0" class="material-symbols text-2xl px-2" @click="downloadSeries" @keydown.enter.prevent="downloadSeries">download</span>
+        <span v-if="(page == 'library' && isBookLibrary) || seriesBookPage" tabindex="0" class="material-symbols text-2xl px-2" @click="showMoreMenuDialog = true" @keydown.enter.prevent="showMoreMenuDialog = true">more_vert</span>
       </div>
     </div>
 

--- a/components/modals/LibrariesModal.vue
+++ b/components/modals/LibrariesModal.vue
@@ -10,7 +10,7 @@
       <div class="w-full overflow-x-hidden overflow-y-auto bg-secondary rounded-lg border border-border" style="max-height: 75%" @click.stop>
         <ul class="h-full w-full" role="listbox" aria-labelledby="listbox-label">
           <template v-for="library in libraries">
-            <li :key="library.id" class="text-fg select-none relative py-3 cursor-pointer" :class="currentLibraryId === library.id ? 'bg-primary bg-opacity-80' : ''" role="option" @click="clickedOption(library)">
+            <li :key="library.id" tabindex="0" class="text-fg select-none relative py-3 cursor-pointer" :class="currentLibraryId === library.id ? 'bg-primary bg-opacity-80' : ''" role="option" @click="clickedOption(library)" @keydown.enter.prevent="clickedOption(library)">
               <div v-show="currentLibraryId === library.id" class="absolute top-0 left-0 w-0.5 bg-warning h-full" />
               <div class="flex items-center px-3">
                 <ui-library-icon :icon="library.icon" />
@@ -47,6 +47,16 @@ export default {
       return this.$store.state.libraries.libraries
     }
   },
+  watch: {
+    show(newVal) {
+      if (newVal) {
+        this.$nextTick(() => {
+          const firstOption = this.$el?.querySelector('li[tabindex="0"]')
+          if (firstOption) firstOption.focus()
+        })
+      }
+    }
+  },
   methods: {
     async clickedOption(lib) {
       await this.$hapticsImpact()
@@ -57,6 +67,7 @@ export default {
       this.$localStore.setLastLibraryId(lib.id)
     }
   },
-  mounted() {}
+  mounted() {},
+  beforeDestroy() {}
 }
 </script>

--- a/components/tables/ChaptersTable.vue
+++ b/components/tables/ChaptersTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full my-4">
-    <div class="w-full bg-primary px-4 py-2 flex items-center" :class="expanded ? 'rounded-t-md' : 'rounded-md'" @click.stop="clickBar">
+    <div class="w-full bg-primary px-4 py-2 flex items-center" :class="expanded ? 'rounded-t-md' : 'rounded-md'" tabindex="0" @click.stop="clickBar" @keydown.enter.prevent.stop="clickBar">
       <p class="pr-2">{{ $strings.HeaderChapters }}</p>
       <div class="h-6 w-6 rounded-full bg-fg/10 flex items-center justify-center">
         <span class="text-xs font-mono">{{ chapters.length }}</span>
@@ -21,8 +21,8 @@
           <td>
             {{ chapter.title }}
           </td>
-          <td class="font-mono text-center underline w-16" @click.stop="goToTimestamp(chapter.start)">
-            {{ $secondsToTimestamp(chapter.start) }}
+          <td class="font-mono text-center w-16">
+            <span tabindex="0" class="underline cursor-pointer" @click.stop="goToTimestamp(chapter.start)" @keydown.enter.prevent.stop="goToTimestamp(chapter.start)">{{ $secondsToTimestamp(chapter.start) }}</span>
           </td>
           <td class="font-mono text-center">
             {{ $secondsToTimestamp(Math.max(0, chapter.end - chapter.start)) }}

--- a/components/tables/TracksTable.vue
+++ b/components/tables/TracksTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full my-4">
-    <div class="w-full bg-primary px-4 py-2 flex items-center" :class="showTracks ? 'rounded-t-md' : 'rounded-md'" @click.stop="clickBar">
+    <div class="w-full bg-primary px-4 py-2 flex items-center" :class="showTracks ? 'rounded-t-md' : 'rounded-md'" tabindex="0" @click.stop="clickBar" @keydown.enter.prevent.stop="clickBar">
       <p class="pr-2">{{ $strings.HeaderAudioTracks }}</p>
       <div class="h-6 w-6 rounded-full bg-fg/10 flex items-center justify-center">
         <span class="text-xs font-mono">{{ tracks.length }}</span>

--- a/components/tables/podcast/EpisodeRow.vue
+++ b/components/tables/podcast/EpisodeRow.vue
@@ -13,7 +13,7 @@
 
       <p v-if="publishedAt" class="text-xs text-fg-muted mb-1">{{ $getString('LabelPublishedDate', [$formatDate(publishedAt, 'MMM do, yyyy')]) }}</p>
 
-      <p class="text-sm font-semibold">{{ title }}</p>
+      <p tabindex="0" :id="`episode-${episode.id}`" class="text-sm font-semibold cursor-pointer" @click.stop="goToEpisodePage" @keydown.enter.prevent.stop="goToEpisodePage">{{ title }}</p>
 
       <p class="text-sm text-fg episode-subtitle mt-1.5 mb-0.5" v-html="subtitle" />
 
@@ -30,7 +30,7 @@
 
       <div class="flex items-center pt-2">
         <!-- Play/Pause Button -->
-        <div class="h-10 px-4 border border-border rounded-full flex items-center justify-center cursor-pointer" :class="userIsFinished ? 'text-white text-opacity-40' : ''" @click.stop="playClick">
+        <div tabindex="0" class="h-10 px-4 border border-border rounded-full flex items-center justify-center cursor-pointer" :class="userIsFinished ? 'text-white text-opacity-40' : ''" @click.stop="playClick" @keydown.enter.prevent.stop="playClick">
           <span v-if="!playerIsStartingForThisMedia" class="material-symbols text-2xl fill leading-none" :class="streamIsPlaying ? '' : 'text-success'">
             {{ streamIsPlaying ? 'pause' : 'play_arrow' }}
           </span>
@@ -44,14 +44,14 @@
         <ui-read-icon-btn :disabled="isProcessingReadUpdate" :is-read="userIsFinished" borderless class="mx-1" @click="toggleFinished" />
 
         <!-- Add to Playlist Button -->
-        <button v-if="!isLocal" class="mx-1.5" @click.stop="addToPlaylist">
+        <button v-if="!isLocal" class="mx-1.5" @click.stop="addToPlaylist" @keydown.enter.prevent.stop="addToPlaylist">
           <span class="material-symbols text-2xl leading-none">playlist_add</span>
         </button>
 
         <!-- Download Section -->
-        <div v-if="userCanDownload" class="flex items-center">
+        <div v-if="userCanDownload" tabindex="0" class="flex items-center cursor-pointer" @keydown.enter.prevent.stop="!isLocal && !localEpisode && downloadClick()" @click.stop="!isLocal && !localEpisode && downloadClick()">
           <span v-if="isLocal" class="material-symbols px-2 text-success text-2xl leading-none">audio_file</span>
-          <span v-else-if="!localEpisode" class="material-symbols mx-1.5 text-2xl leading-none" :class="downloadItem || startingDownload ? 'animate-bounce text-warning text-opacity-75' : ''" @click.stop="downloadClick">
+          <span v-else-if="!localEpisode" class="material-symbols mx-1.5 text-2xl leading-none" :class="downloadItem || startingDownload ? 'animate-bounce text-warning text-opacity-75' : ''">
             {{ downloadItem || startingDownload ? 'downloading' : 'download' }}
           </span>
           <span v-else class="material-symbols px-2 text-success text-2xl leading-none">download_done</span>

--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -32,7 +32,7 @@
         <div v-show="filterKey !== 'all' && episodesAreFiltered" class="absolute top-0 right-0 w-1.5 h-1.5 rounded-full bg-success border border-green-300 shadow-sm z-10 pointer-events-none" />
       </button>
 
-      <div class="flex items-center border border-white border-opacity-25 rounded px-2" @click="clickSort">
+      <div tabindex="0" class="flex items-center border border-white border-opacity-25 rounded px-2 cursor-pointer" @click="clickSort" @keydown.enter.prevent="clickSort">
         <p class="text-sm text-fg">{{ sortText }}</p>
         <span class="material-symbols ml-1 text-fg">{{ sortDesc ? 'arrow_drop_down' : 'arrow_drop_up' }}</span>
       </div>

--- a/components/tables/podcast/LatestEpisodeRow.vue
+++ b/components/tables/podcast/LatestEpisodeRow.vue
@@ -16,7 +16,7 @@
         </div>
       </div>
 
-      <p class="text-sm font-semibold">{{ title }}</p>
+      <p tabindex="0" :id="`episode-${episode.id}`" class="text-sm font-semibold cursor-pointer" @click.stop="goToEpisodePage" @keydown.enter.prevent.stop="goToEpisodePage">{{ title }}</p>
 
       <p class="text-sm text-fg episode-subtitle mt-1.5 mb-0.5" v-html="subtitle" />
 
@@ -28,7 +28,7 @@
 
       <div class="flex items-center pt-2">
         <!-- Play/Pause Button -->
-        <div class="h-9 px-4 border border-border hover:bg-white hover:bg-opacity-10 rounded-full flex items-center justify-center cursor-pointer" :class="userIsFinished ? 'text-fg text-opacity-40' : ''" @click.stop="playClick">
+        <div tabindex="0" class="h-9 px-4 border border-border hover:bg-white hover:bg-opacity-10 rounded-full flex items-center justify-center cursor-pointer" :class="userIsFinished ? 'text-fg text-opacity-40' : ''" @click.stop="playClick" @keydown.enter.prevent.stop="playClick">
           <span v-if="!playerIsStartingForThisMedia" class="material-symbols text-2xl fill leading-none" :class="streamIsPlaying ? '' : 'text-success'">
             {{ streamIsPlaying ? 'pause' : 'play_arrow' }}
           </span>
@@ -42,14 +42,14 @@
         <ui-read-icon-btn :disabled="isProcessingReadUpdate" :is-read="userIsFinished" borderless class="mx-1" @click="toggleFinished" />
 
         <!-- Add to Playlist Button -->
-        <button v-if="!isLocal" class="mx-1.5" @click.stop="addToPlaylist">
+        <button v-if="!isLocal" class="mx-1.5" @click.stop="addToPlaylist" @keydown.enter.prevent.stop="addToPlaylist">
           <span class="material-symbols text-2xl leading-none">playlist_add</span>
         </button>
 
         <!-- Download Section -->
-        <div v-if="userCanDownload" class="flex items-center">
+        <div v-if="userCanDownload" tabindex="0" class="flex items-center cursor-pointer" @keydown.enter.prevent.stop="!isLocal && !localEpisode && downloadClick()" @click.stop="!isLocal && !localEpisode && downloadClick()">
           <span v-if="isLocal" class="material-symbols px-2 text-success text-2xl leading-none">audio_file</span>
-          <span v-else-if="!localEpisode" class="material-symbols mx-1.5 text-2xl leading-none" :class="downloadItem || pendingDownload ? 'animate-bounce text-warning text-opacity-75' : ''" @click.stop="downloadClick">
+          <span v-else-if="!localEpisode" class="material-symbols mx-1.5 text-2xl leading-none" :class="downloadItem || pendingDownload ? 'animate-bounce text-warning text-opacity-75' : ''">
             {{ downloadItem || pendingDownload ? 'downloading' : 'download' }}
           </span>
           <span v-else class="material-symbols px-2 text-success text-2xl leading-none">download_done</span>

--- a/components/ui/TextInput.vue
+++ b/components/ui/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <input v-model="input" ref="input" :autofocus="autofocus" :type="type" :disabled="disabled" :readonly="readonly" autocorrect="off" autocapitalize="none" autocomplete="off" :placeholder="placeholder" class="py-2 w-full outline-none bg-primary disabled:text-fg-muted" :class="inputClass" @keyup="keyup" />
+    <input v-model="input" ref="input" :autofocus="autofocus" :type="type" :disabled="disabled" :readonly="readonly" :tabindex="readonly ? -1 : undefined" autocorrect="off" autocapitalize="none" autocomplete="off" :placeholder="placeholder" class="py-2 w-full outline-none bg-primary disabled:text-fg-muted" :class="inputClass" @keyup="keyup" />
     <div v-if="prependIcon" class="absolute top-0 left-0 h-full px-2 flex items-center justify-center">
       <span class="material-symbols text-lg">{{ prependIcon }}</span>
     </div>

--- a/components/ui/ToggleSwitch.vue
+++ b/components/ui/ToggleSwitch.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="border rounded-full border-gray-400 flex items-center cursor-pointer w-10 justify-start" :class="className" @click.stop="clickToggle">
+    <div tabindex="0" class="border rounded-full border-gray-400 flex items-center cursor-pointer w-10 justify-start" :class="className" @click.stop="clickToggle" @keydown.enter.prevent.stop="clickToggle">
       <span class="rounded-full border w-5 h-5 border-gray-100 shadow transform transition-transform duration-100" :class="switchClassName"></span>
     </div>
   </div>

--- a/docs/pr-02-keyboard-hygiene.md
+++ b/docs/pr-02-keyboard-hygiene.md
@@ -1,0 +1,47 @@
+# PR 02 — Keyboard hygiene + foundational TV DOM markup
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+Additive, behavior-neutral DOM changes across ~25 shared components and pages so
+the existing UI is keyboard/D-pad navigable. **Every change is inert on
+touch/pointer devices** — `tabindex` and `@keydown.enter.prevent` only affect
+keyboard focus, and the data-attribute / `id` hooks are read by nothing until
+the navigation engine (later PRs) is present. Phone/tablet behavior is byte-identical.
+
+Two kinds of change, both safe to land before anything that consumes them:
+
+- **Keyboard hygiene** — `tabindex` (focusability) plus `@keydown.enter.prevent`
+  (Enter fires the same handler as click) on cards, tables, toolbars, modal
+  options, UI inputs/toggles, side-drawer items, the audio-player controls, and
+  detail-page actions.
+- **Inert TV DOM hooks** — stable `data-tv-target="play-button"` /
+  `data-tv-overlay="side-drawer"` attributes and scroll-container `id`s
+  (`#settings-page`, `#stats-page`, `#logs-container`, `#account-page`,
+  `#episode-page`, `#item-cover`, `#manage-files-page`). These are a stable
+  contract the navigation engine reads later — in place of fragile CSS-class
+  selectors — and have no effect on their own.
+
+## Architecture context (fork-hosted)
+
+- [TV_FOCUS_SYSTEM.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_FOCUS_SYSTEM.md) — the focus/navigation architecture and the `data-*` contract these hooks satisfy.
+
+## Testing
+
+Verified on an Android phone that every modified element behaves exactly as
+before via tap, and on a Google TV Streamer 4K that Enter activates focusable
+elements without double-firing.
+
+## Relationship to the series
+
+- **Depends on:** nothing
+- **Blocks:** PR9 (connect-form D-pad nav builds on this hygiene), PR10 (author
+  cards); the inert hooks are later consumed by PR5/PR6 (the engine).
+- **Wave:** 1 of 3

--- a/docs/pr-02-keyboard-hygiene.md
+++ b/docs/pr-02-keyboard-hygiene.md
@@ -1,0 +1,47 @@
+# PR 02 — Keyboard hygiene + foundational TV DOM markup
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+Additive, behavior-neutral DOM changes across ~25 shared components and pages so
+the existing UI is keyboard/D-pad navigable. **Every change is inert on
+touch/pointer devices** — `tabindex` and `@keydown.enter.prevent` only affect
+keyboard focus, and the data-attribute / `id` hooks are read by nothing until
+the navigation engine (later PRs) is present. Phone/tablet behavior is byte-identical.
+
+Two kinds of change, both safe to land before anything that consumes them:
+
+- **Keyboard hygiene** — `tabindex` (focusability) plus `@keydown.enter.prevent`
+  (Enter fires the same handler as click) on cards, tables, toolbars, modal
+  options, UI inputs/toggles, side-drawer items, the audio-player controls, and
+  detail-page actions.
+- **Inert TV DOM hooks** — stable `data-tv-target="play-button"` /
+  `data-tv-overlay="side-drawer"` attributes and scroll-container `id`s
+  (`#settings-page`, `#stats-page`, `#logs-container`, `#account-page`,
+  `#episode-page`, `#item-cover`, `#manage-files-page`). These are a stable
+  contract the navigation engine reads later — in place of fragile CSS-class
+  selectors — and have no effect on their own.
+
+## Architecture context (fork-hosted)
+
+- [TV_FOCUS_SYSTEM.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_FOCUS_SYSTEM.md) — the focus/navigation architecture and the `data-*` contract these hooks satisfy.
+
+## Testing
+
+Verified on an Android phone that every modified element behaves exactly as
+before via tap, and on a Google TV Streamer 4K that Enter activates focusable
+elements without double-firing.
+
+## Relationship to the series
+
+- **Depends on:** nothing
+- **Blocks:** PR9 (connect-form D-pad nav builds on this hygiene), PR10 (author
+  cards); the inert hooks are later consumed by PR5/PR6 (the engine).
+- **Layer:** 1 of 3

--- a/pages/account.vue
+++ b/pages/account.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full p-4">
+  <div id="account-page" class="w-full h-full p-4 overflow-y-auto">
     <ui-text-input-with-label :value="serverAddress" :label="$strings.LabelHost" disabled class="my-2" />
 
     <ui-text-input-with-label :value="username" :label="$strings.LabelUsername" disabled class="my-2" />

--- a/pages/collection/_id.vue
+++ b/pages/collection/_id.vue
@@ -12,7 +12,7 @@
             {{ collectionName }}
           </h1>
           <div class="flex-grow" />
-          <ui-btn v-if="showPlayButton" color="success" :padding-x="4" :loading="playerIsStartingForThisMedia" small class="flex items-center justify-center mx-1 w-24" @click="playClick">
+          <ui-btn v-if="showPlayButton" color="success" data-tv-target="play-button" :padding-x="4" :loading="playerIsStartingForThisMedia" small class="flex items-center justify-center mx-1 w-24" @click="playClick">
             <span class="material-symbols text-2xl fill">{{ playerIsPlaying ? 'pause' : 'play_arrow' }}</span>
             <span class="px-1 text-sm">{{ playerIsPlaying ? $strings.ButtonPause : $strings.ButtonPlay }}</span>
           </ui-btn>

--- a/pages/item/_id/_episode/index.vue
+++ b/pages/item/_id/_episode/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full px-3 py-4 overflow-y-auto overflow-x-hidden relative bg-bg">
+  <div id="episode-page" class="w-full h-full px-3 py-4 overflow-y-auto overflow-x-hidden relative bg-bg">
     <div class="flex mb-2">
       <div class="w-10 min-w-10">
         <covers-preview-cover :src="coverUrl" :width="40" :book-cover-aspect-ratio="bookCoverAspectRatio" :show-resolution="false" class="md:hidden" />
@@ -29,7 +29,7 @@
 
     <!-- action buttons -->
     <div class="flex mt-4 -mx-1">
-      <ui-btn color="success" class="flex items-center justify-center flex-grow mx-1" :loading="playerIsStartingForThisMedia" :padding-x="4" @click="playClick">
+      <ui-btn color="success" data-tv-target="play-button" class="flex items-center justify-center flex-grow mx-1" :loading="playerIsStartingForThisMedia" :padding-x="4" @click="playClick">
         <span class="material-symbols text-2xl fill">{{ playerIsPlaying ? 'pause' : 'play_arrow' }}</span>
         <span class="px-1 text-sm">{{ playerIsPlaying ? $strings.ButtonPause : localEpisodeId ? $strings.ButtonPlay : $strings.ButtonStream }}</span>
       </ui-btn>

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -12,7 +12,7 @@
           </div>
         </div>
       </div>
-      <div class="relative" @click="showFullscreenCover = true">
+      <div id="item-cover" class="relative" tabindex="0" @click="showFullscreenCover = true" @keydown.enter="showFullscreenCover = true">
         <covers-book-cover :library-item="libraryItem" :width="coverWidth" :book-cover-aspect-ratio="bookCoverAspectRatio" no-bg raw />
         <div v-if="!isPodcast" class="absolute bottom-0 left-0 h-1 z-10 box-shadow-progressbar" :class="userIsFinished ? 'bg-success' : 'bg-yellow-400'" :style="{ width: coverWidth * progressPercent + 'px' }"></div>
       </div>
@@ -51,7 +51,7 @@
         <!-- action buttons -->
         <div class="col-span-full">
           <div v-if="showPlay || showRead" class="flex mt-4 -mx-1">
-            <ui-btn v-if="showPlay" color="success" class="flex items-center justify-center flex-grow mx-1" :loading="playerIsStartingForThisMedia" :padding-x="4" @click="playClick">
+            <ui-btn v-if="showPlay" color="success" data-tv-target="play-button" class="flex items-center justify-center flex-grow mx-1" :loading="playerIsStartingForThisMedia" :padding-x="4" @click="playClick">
               <span class="material-symbols text-2xl fill">{{ playerIsPlaying ? 'pause' : 'play_arrow' }}</span>
               <span class="px-1 text-sm">{{ playerIsPlaying ? $strings.ButtonPause : isPodcast ? $strings.ButtonNextEpisode : hasLocal ? $strings.ButtonPlay : $strings.ButtonStream }}</span>
             </ui-btn>
@@ -139,7 +139,7 @@
         <div v-if="description" class="w-full py-2">
           <div ref="description" class="default-style less-spacing text-sm text-justify whitespace-pre-line font-light" :class="{ 'line-clamp-4': !showFullDescription }" style="hyphens: auto" v-html="description" />
 
-          <div v-if="descriptionClamped" class="text-fg text-sm py-2" @click="showFullDescription = !showFullDescription">
+          <div v-if="descriptionClamped" class="text-fg text-sm py-2" tabindex="0" @click="showFullDescription = !showFullDescription" @keydown.enter.prevent="showFullDescription = !showFullDescription">
             {{ showFullDescription ? $strings.ButtonReadLess : $strings.ButtonReadMore }}
             <span class="material-symbols !align-middle text-base -mt-px">{{ showFullDescription ? 'arrow_drop_up' : 'arrow_drop_down' }}</span>
           </div>

--- a/pages/localMedia/item/_id.vue
+++ b/pages/localMedia/item/_id.vue
@@ -5,17 +5,17 @@
         <p class="text-base font-semibold truncate">{{ mediaMetadata.title }}</p>
         <div class="flex-grow" />
 
-        <button v-if="audioTracks.length && !isPodcast" class="shadow-sm text-success flex items-center justify-center rounded-full mx-2" @click.stop="play">
+        <button v-if="audioTracks.length && !isPodcast" class="shadow-sm text-success flex items-center justify-center rounded-full mx-2" @click.stop="play" @keydown.enter.prevent.stop="play">
           <span class="material-symbols fill" style="font-size: 2rem">play_arrow</span>
         </button>
-        <span class="material-symbols text-2xl" @click="showItemDialog">more_vert</span>
+        <span tabindex="0" class="material-symbols text-2xl cursor-pointer" @click="showItemDialog" @keydown.enter.prevent="showItemDialog">more_vert</span>
       </div>
 
       <p v-if="!isIos" class="px-2 text-sm mb-0.5 text-fg-muted">{{ $strings.LabelFolder }}: {{ folderName }}</p>
 
       <p class="px-2 mb-4 text-xs text-fg-muted">{{ libraryItemId ? 'Linked to item on server ' + liServerAddress : 'Not linked to server item' }}</p>
 
-      <div class="w-full max-w-full media-item-container overflow-y-auto overflow-x-hidden relative pb-4" :class="{ 'media-order-changed': orderChanged }">
+      <div id="manage-files-page" class="w-full max-w-full media-item-container overflow-y-auto overflow-x-hidden relative pb-4" :class="{ 'media-order-changed': orderChanged }">
         <div v-if="!isPodcast && audioTracksCopy.length" class="w-full py-2">
           <div class="flex justify-between items-center mb-2">
             <p class="text-base">Audio Tracks ({{ audioTracks.length }})</p>
@@ -40,7 +40,7 @@
                     <p class="text-sm">{{ $elapsedPretty(track.duration) }}</p>
                   </div>
                   <div v-if="!isIos" class="w-12 h-12 flex items-center justify-center" style="min-width: 48px">
-                    <span class="material-symbols text-2xl" @click="showTrackDialog(track)">more_vert</span>
+                    <span tabindex="0" class="material-symbols text-2xl cursor-pointer" @click="showTrackDialog(track)" @keydown.enter.prevent="showTrackDialog(track)">more_vert</span>
                   </div>
                 </div>
               </template>
@@ -66,7 +66,7 @@
                 <p class="text-sm">{{ $elapsedPretty(episode.audioTrack.duration) }}</p>
               </div>
               <div class="w-12 h-12 flex items-center justify-center" style="min-width: 48px">
-                <span class="material-symbols text-2xl" @click="showTrackDialog(episode)">more_vert</span>
+                <span tabindex="0" class="material-symbols text-2xl cursor-pointer" @click="showTrackDialog(episode)" @keydown.enter.prevent="showTrackDialog(episode)">more_vert</span>
               </div>
             </div>
           </template>

--- a/pages/logs.vue
+++ b/pages/logs.vue
@@ -8,7 +8,7 @@
       <ui-icon-btn outlined borderless icon="more_vert" @click="showDialog = true" />
     </div>
 
-    <div class="w-full h-[calc(100%-40px)] overflow-y-auto relative" ref="logContainer">
+    <div id="logs-container" class="w-full h-[calc(100%-40px)] overflow-y-auto relative" ref="logContainer">
       <div v-if="!logs.length && !isLoading" class="flex items-center justify-center h-32 p-4">
         <p class="text-gray-400">{{ $strings.MessageNoLogs }}</p>
       </div>

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -10,7 +10,7 @@
             {{ playlistName }}
           </h1>
           <div class="flex-grow" />
-          <ui-btn v-if="showPlayButton" color="success" :padding-x="4" :loading="playerIsStartingForThisMedia" small class="flex items-center justify-center mx-1 w-24" @click="playClick">
+          <ui-btn v-if="showPlayButton" color="success" data-tv-target="play-button" :padding-x="4" :loading="playerIsStartingForThisMedia" small class="flex items-center justify-center mx-1 w-24" @click="playClick">
             <span class="material-symbols text-2xl fill">{{ playerIsPlaying ? 'pause' : 'play_arrow' }}</span>
             <span class="px-1 text-sm">{{ playerIsPlaying ? $strings.ButtonPause : $strings.ButtonPlay }}</span>
           </ui-btn>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full px-4 py-8 overflow-y-auto">
+  <div id="settings-page" class="w-full h-full px-4 py-8 overflow-y-auto">
     <!-- Display settings -->
     <p class="uppercase text-xs font-semibold text-fg-muted mb-2">{{ $strings.HeaderUserInterfaceSettings }}</p>
     <div class="flex items-center py-3">
@@ -17,19 +17,19 @@
     </div>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelHapticFeedback }}</p>
-      <div @click.stop="showHapticFeedbackOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showHapticFeedbackOptions" @keydown.enter.prevent.stop="showHapticFeedbackOptions">
         <ui-text-input :value="hapticFeedbackOption" readonly append-icon="expand_more" style="max-width: 200px" />
       </div>
     </div>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelLanguage }}</p>
-      <div @click.stop="showLanguageOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showLanguageOptions" @keydown.enter.prevent.stop="showLanguageOptions">
         <ui-text-input :value="languageOption" readonly append-icon="expand_more" style="max-width: 200px" />
       </div>
     </div>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelTheme }}</p>
-      <div @click.stop="showThemeOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showThemeOptions" @keydown.enter.prevent.stop="showThemeOptions">
         <ui-text-input :value="themeOption" readonly append-icon="expand_more" style="max-width: 200px" />
       </div>
     </div>
@@ -38,13 +38,13 @@
     <p class="uppercase text-xs font-semibold text-fg-muted mb-2 mt-10">{{ $strings.HeaderPlaybackSettings }}</p>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelJumpBackwardsTime }}</p>
-      <div @click.stop="showJumpBackwardsOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showJumpBackwardsOptions" @keydown.enter.prevent.stop="showJumpBackwardsOptions">
         <ui-text-input :value="jumpBackwardsOption" readonly append-icon="expand_more" style="width: 145px; max-width: 145px" />
       </div>
     </div>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelJumpForwardsTime }}</p>
-      <div @click.stop="showJumpForwardOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showJumpForwardOptions" @keydown.enter.prevent.stop="showJumpForwardOptions">
         <ui-text-input :value="jumpForwardOption" readonly append-icon="expand_more" style="width: 145px; max-width: 145px" />
       </div>
     </div>
@@ -59,7 +59,7 @@
         <ui-toggle-switch v-model="settings.enableMp3IndexSeeking" @input="saveSettings" />
       </div>
       <p class="pl-4">{{ $strings.LabelEnableMp3IndexSeeking }}</p>
-      <span class="material-symbols text-xl ml-2" @click.stop="showConfirmMp3IndexSeeking">info</span>
+      <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showConfirmMp3IndexSeeking" @keydown.enter.prevent.stop="showConfirmMp3IndexSeeking">info</span>
     </div>
     <div class="flex items-center py-3">
       <div class="w-10 flex justify-center" @click="toggleAllowSeekingOnMediaControls">
@@ -76,11 +76,11 @@
           <ui-toggle-switch v-model="settings.disableShakeToResetSleepTimer" @input="saveSettings" />
         </div>
         <p class="pl-4">{{ $strings.LabelDisableShakeToReset }}</p>
-        <span class="material-symbols text-xl ml-2" @click.stop="showInfo('disableShakeToResetSleepTimer')">info</span>
+        <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('disableShakeToResetSleepTimer')" @keydown.enter.prevent.stop="showInfo('disableShakeToResetSleepTimer')">info</span>
       </div>
       <div v-if="!settings.disableShakeToResetSleepTimer" class="py-3 flex items-center">
         <p class="pr-4 w-36">{{ $strings.LabelShakeSensitivity }}</p>
-        <div @click.stop="showShakeSensitivityOptions">
+        <div tabindex="0" class="settings-dropdown" @click.stop="showShakeSensitivityOptions" @keydown.enter.prevent.stop="showShakeSensitivityOptions">
           <ui-text-input :value="shakeSensitivityOption" readonly append-icon="expand_more" style="width: 145px; max-width: 145px" />
         </div>
       </div>
@@ -90,7 +90,7 @@
         <ui-toggle-switch v-model="settings.disableSleepTimerFadeOut" @input="saveSettings" />
       </div>
       <p class="pl-4">{{ $strings.LabelDisableAudioFadeOut }}</p>
-      <span class="material-symbols text-xl ml-2" @click.stop="showInfo('disableSleepTimerFadeOut')">info</span>
+      <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('disableSleepTimerFadeOut')" @keydown.enter.prevent.stop="showInfo('disableSleepTimerFadeOut')">info</span>
     </div>
     <template v-if="!isiOS">
       <div class="flex items-center py-3">
@@ -98,21 +98,21 @@
           <ui-toggle-switch v-model="settings.disableSleepTimerResetFeedback" @input="saveSettings" />
         </div>
         <p class="pl-4">{{ $strings.LabelDisableVibrateOnReset }}</p>
-        <span class="material-symbols text-xl ml-2" @click.stop="showInfo('disableSleepTimerResetFeedback')">info</span>
+        <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('disableSleepTimerResetFeedback')" @keydown.enter.prevent.stop="showInfo('disableSleepTimerResetFeedback')">info</span>
       </div>
       <div class="flex items-center py-3">
         <div class="w-10 flex justify-center" @click="toggleSleepTimerAlmostDoneChime">
           <ui-toggle-switch v-model="settings.enableSleepTimerAlmostDoneChime" @input="saveSettings" />
         </div>
         <p class="pl-4">{{ $strings.LabelSleepTimerAlmostDoneChime }}</p>
-        <span class="material-symbols text-xl ml-2" @click.stop="showInfo('enableSleepTimerAlmostDoneChime')">info</span>
+        <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('enableSleepTimerAlmostDoneChime')" @keydown.enter.prevent.stop="showInfo('enableSleepTimerAlmostDoneChime')">info</span>
       </div>
       <div class="flex items-center py-3">
         <div class="w-10 flex justify-center" @click="toggleAutoSleepTimer">
           <ui-toggle-switch v-model="settings.autoSleepTimer" @input="saveSettings" />
         </div>
         <p class="pl-4">{{ $strings.LabelAutoSleepTimer }}</p>
-        <span class="material-symbols text-xl ml-2" @click.stop="showInfo('autoSleepTimer')">info</span>
+        <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('autoSleepTimer')" @keydown.enter.prevent.stop="showInfo('autoSleepTimer')">info</span>
       </div>
     </template>
     <!-- Auto Sleep timer settings -->
@@ -126,7 +126,7 @@
     </div>
     <div v-if="settings.autoSleepTimer" class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelSleepTimer }}</p>
-      <div @click.stop="showSleepTimerOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showSleepTimerOptions" @keydown.enter.prevent.stop="showSleepTimerOptions">
         <ui-text-input :value="sleepTimerLengthOption" readonly append-icon="expand_more" style="width: 145px; max-width: 145px" />
       </div>
     </div>
@@ -135,11 +135,11 @@
         <ui-toggle-switch v-model="settings.autoSleepTimerAutoRewind" @input="saveSettings" />
       </div>
       <p class="pl-4">{{ $strings.LabelAutoSleepTimerAutoRewind }}</p>
-      <span class="material-symbols text-xl ml-2" @click.stop="showInfo('autoSleepTimerAutoRewind')">info</span>
+      <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('autoSleepTimerAutoRewind')" @keydown.enter.prevent.stop="showInfo('autoSleepTimerAutoRewind')">info</span>
     </div>
     <div v-if="settings.autoSleepTimerAutoRewind" class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelAutoRewindTime }}</p>
-      <div @click.stop="showAutoSleepTimerRewindOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showAutoSleepTimerRewindOptions" @keydown.enter.prevent.stop="showAutoSleepTimerRewindOptions">
         <ui-text-input :value="autoSleepTimerRewindLengthOption" readonly append-icon="expand_more" style="width: 145px; max-width: 145px" />
       </div>
     </div>
@@ -148,13 +148,13 @@
     <p class="uppercase text-xs font-semibold text-fg-muted mb-2 mt-10">{{ $strings.HeaderDataSettings }}</p>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelDownloadUsingCellular }}</p>
-      <div @click.stop="showDownloadUsingCellularOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showDownloadUsingCellularOptions" @keydown.enter.prevent.stop="showDownloadUsingCellularOptions">
         <ui-text-input :value="downloadUsingCellularOption" readonly append-icon="expand_more" style="max-width: 200px" />
       </div>
     </div>
     <div class="py-3 flex items-center">
       <p class="pr-4 w-36">{{ $strings.LabelStreamingUsingCellular }}</p>
-      <div @click.stop="showStreamingUsingCellularOptions">
+      <div tabindex="0" class="settings-dropdown" @click.stop="showStreamingUsingCellularOptions" @keydown.enter.prevent.stop="showStreamingUsingCellularOptions">
         <ui-text-input :value="streamingUsingCellularOption" readonly append-icon="expand_more" style="max-width: 200px" />
       </div>
     </div>
@@ -165,11 +165,11 @@
       <div class="py-3 flex items-center">
         <p class="pr-4 w-36">{{ $strings.LabelAndroidAutoBrowseLimitForGrouping }}</p>
         <ui-text-input type="number" v-model="settings.androidAutoBrowseLimitForGrouping" style="width: 145px; max-width: 145px" @input="androidAutoBrowseLimitForGroupingUpdated" />
-        <span class="material-symbols text-xl ml-2" @click.stop="showInfo('androidAutoBrowseLimitForGrouping')">info</span>
+        <span tabindex="0" class="material-symbols text-xl ml-2 cursor-pointer" @click.stop="showInfo('androidAutoBrowseLimitForGrouping')" @keydown.enter.prevent.stop="showInfo('androidAutoBrowseLimitForGrouping')">info</span>
       </div>
       <div class="py-3 flex items-center">
         <p class="pr-4 w-36">{{ $strings.LabelAndroidAutoBrowseSeriesSequenceOrder }}</p>
-        <div @click.stop="showAndroidAutoBrowseSeriesSequenceOrderOptions">
+        <div tabindex="0" class="settings-dropdown" @click.stop="showAndroidAutoBrowseSeriesSequenceOrderOptions" @keydown.enter.prevent.stop="showAndroidAutoBrowseSeriesSequenceOrderOptions">
           <ui-text-input :value="androidAutoBrowseSeriesSequenceOrderOption" readonly append-icon="expand_more" style="max-width: 200px" />
         </div>
       </div>

--- a/pages/stats.vue
+++ b/pages/stats.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full px-0 py-4 overflow-y-auto">
+  <div id="stats-page" class="w-full h-full px-0 py-4 overflow-y-auto">
     <!-- Year in review banner shown at the top in December and January -->
     <stats-year-in-review-banner v-if="showYearInReviewBanner" />
 


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

### Scope
`tabindex` + `@keydown.enter.prevent` across ~25 shared components/pages so the existing UI is keyboard/D-pad navigable, plus inert TV DOM hooks (`data-tv-target` / `data-tv-overlay` + scroll-container `id`s) that the navigation engine reads in a later PR.

### Safety
Every change is inert on touch/pointer devices; phone/tablet behavior is byte-identical.

### Testing
Phone: tap regression across modified elements (unchanged). TV: Enter activates without double-firing.

Independent and reviewable on its own. The inert DOM hooks here are what the later navigation-engine PR consumes; nothing reads them yet.
