### PR TITLE
Android TV (4/10): CSS focus-ring foundation

### DIFF
--- a/assets/css/tv-focus.css
+++ b/assets/css/tv-focus.css
@@ -1,0 +1,132 @@
+/* Focus styles only apply on Android TV devices. */
+
+/* Focus ring color — single source of truth. Override at runtime via
+   document.documentElement.style.setProperty('--tv-focus-color', value). */
+:root.android-tv {
+  --tv-focus-color: #1ad691;
+}
+
+/* Default: no focus ring (overridden below for specific elements) */
+.android-tv *:focus {
+  outline: none !important;
+}
+
+
+/* ── Cards: pseudo-element border overlay ── */
+.android-tv [id^="book-card-"]:focus::after,
+.android-tv [id^="series-card-"]:focus::after,
+.android-tv [id^="collection-card-"]:focus::after,
+.android-tv [id^="playlist-card-"]:focus::after,
+.android-tv [id^="author-book-"]:focus::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 3px solid var(--tv-focus-color);
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 200;
+}
+
+/* ── Modal/overlay items: green left accent on focus ── */
+.android-tv .modal li[role="option"]:focus,
+.android-tv .modal li[tabindex="0"]:focus {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  border-left: 3px solid var(--tv-focus-color) !important;
+  outline: none !important;
+}
+
+/* Side drawer items: green left accent on focus */
+.android-tv .bg-bg.transition-transform button:focus,
+.android-tv .bg-bg.transition-transform a:focus {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  border-left: 3px solid var(--tv-focus-color) !important;
+  outline: none !important;
+}
+
+/* Library modal items */
+.android-tv .modal li[role="option"]:focus > div,
+.android-tv .modal li[tabindex="0"]:focus > div {
+  opacity: 1;
+}
+
+/* Author cards: use a permanent transparent border to prevent layout shift on focus */
+.android-tv .author-card-inner {
+  border: 3px solid transparent;
+}
+.android-tv .author-card-wrapper:focus .author-card-inner {
+  border-color: var(--tv-focus-color);
+}
+
+/* ── Item detail cover art: pseudo-element border overlay ── */
+.android-tv #item-cover:focus {
+  outline: none !important;
+}
+.android-tv #item-cover:focus::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border: 3px solid var(--tv-focus-color);
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 200;
+}
+/* Hide cover focus ring when a modal is open (e.g. fullscreen cover overlay) */
+.android-tv.modal-open #item-cover:focus::after {
+  display: none;
+}
+
+/* ── Non-card, non-modal elements: tight green outline ── */
+.android-tv button:focus,
+.android-tv a:focus,
+.android-tv input:focus,
+.android-tv select:focus,
+.android-tv span[tabindex="0"]:focus,
+.android-tv svg[tabindex="0"]:focus,
+.android-tv p[tabindex="0"]:focus,
+.android-tv div[tabindex="0"]:focus:not([id^="book-card-"]):not([id^="series-card-"]):not([id^="collection-card-"]):not([id^="playlist-card-"]):not([id^="author-book-"]):not(.author-card-wrapper) {
+  outline: 2px solid var(--tv-focus-color) !important;
+  outline-offset: -2px;
+  border-radius: 2px;
+}
+
+/* ── Settings dropdown wrappers: green border on the input inside when focused ── */
+.android-tv .settings-dropdown:focus {
+  outline: none !important;
+}
+.android-tv .settings-dropdown:focus input {
+  border: 2px solid var(--tv-focus-color) !important;
+  border-radius: 4px;
+}
+
+/* Override: podcast episode description links should NOT get the green outline */
+.android-tv .episode-subtitle a:focus,
+.android-tv .description-container a:focus {
+  outline: none !important;
+}
+
+/* Override: modal items should NOT get the green outline */
+.android-tv .modal li[role="option"]:focus,
+.android-tv .modal li[tabindex="0"]:focus,
+.android-tv .bg-bg.transition-transform button:focus,
+.android-tv .bg-bg.transition-transform a:focus {
+  outline: none !important;
+}
+
+/* ── Player controls: round focus ring ── */
+.android-tv .play-btn:focus,
+.android-tv .jump-icon:focus {
+  outline: 2px solid var(--tv-focus-color) !important;
+  outline-offset: -2px;
+  border-radius: 50%;
+}
+
+/* ── Loading-overlay dots follow the chosen focus color (TV only, #20) ── */
+.android-tv .tv-focus-dots > div {
+  background-color: var(--tv-focus-color) !important;
+}

--- a/components/ui/LoadingIndicator.vue
+++ b/components/ui/LoadingIndicator.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="w-40">
     <div class="bg-bg border border-border py-2 px-5 rounded-lg flex items-center flex-col box-shadow-md">
-      <div class="loader-dots block relative w-20 h-5 mt-2">
+      <div class="loader-dots tv-focus-dots block relative w-20 h-5 mt-2">
         <div class="absolute top-0 mt-1 w-3 h-3 rounded-full bg-green-500"></div>
         <div class="absolute top-0 mt-1 w-3 h-3 rounded-full bg-green-500"></div>
         <div class="absolute top-0 mt-1 w-3 h-3 rounded-full bg-green-500"></div>

--- a/docs/pr-04-css-foundation.md
+++ b/docs/pr-04-css-foundation.md
@@ -1,0 +1,42 @@
+# PR 04 — CSS foundation (focus-ring system)
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+The visual focus-ring system for TV — all scoped under `:root.android-tv` / `.android-tv`,
+so it is **completely inert on phone/tablet** (the `android-tv` class is only
+present on TV, added in PR1):
+
+- **`assets/css/tv-focus.css`** — focus-ring styles plus the `--tv-focus-color`
+  CSS custom property (default `#1ad691`), defined on `:root.android-tv`.
+- **`nuxt.config.js`** — register `tv-focus.css` in the `css` array.
+- **`store/user.js`** — a `tvFocusColor` user setting (default `#1ad691`) that
+  drives the CSS variable (the picker UI to change it lands in a later PR).
+- **`components/ui/LoadingIndicator.vue`** — a `tv-focus-dots` class hook so the
+  loading-overlay dots adopt the chosen focus color on TV (the rule lives in
+  tv-focus.css; inert elsewhere).
+
+Nothing drives the focus rings yet — no JS attaches focus changes until the
+engine PRs — so there is no visible change until then.
+
+## Architecture context (fork-hosted)
+
+- [TV_FOCUS_SYSTEM.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_FOCUS_SYSTEM.md) — focus-system architecture.
+
+## Testing
+
+Phone smoke: no visual change (rules are `.android-tv`-scoped). On a Google TV
+Streamer 4K: the `--tv-focus-color` variable is present on `:root.android-tv`.
+
+## Relationship to the series
+
+- **Depends on:** nothing (inert until PR1's `android-tv` class and the engine).
+- **Blocks:** PR8 (the settings color picker reads/writes `tvFocusColor` and the CSS variable).
+- **Wave:** 1 of 3

--- a/docs/pr-04-css-foundation.md
+++ b/docs/pr-04-css-foundation.md
@@ -1,0 +1,42 @@
+# PR 04 — CSS foundation (focus-ring system)
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+The visual focus-ring system for TV — all scoped under `:root.android-tv` / `.android-tv`,
+so it is **completely inert on phone/tablet** (the `android-tv` class is only
+present on TV, added in PR1):
+
+- **`assets/css/tv-focus.css`** — focus-ring styles plus the `--tv-focus-color`
+  CSS custom property (default `#1ad691`), defined on `:root.android-tv`.
+- **`nuxt.config.js`** — register `tv-focus.css` in the `css` array.
+- **`store/user.js`** — a `tvFocusColor` user setting (default `#1ad691`) that
+  drives the CSS variable (the picker UI to change it lands in a later PR).
+- **`components/ui/LoadingIndicator.vue`** — a `tv-focus-dots` class hook so the
+  loading-overlay dots adopt the chosen focus color on TV (the rule lives in
+  tv-focus.css; inert elsewhere).
+
+Nothing drives the focus rings yet — no JS attaches focus changes until the
+engine PRs — so there is no visible change until then.
+
+## Architecture context (fork-hosted)
+
+- [TV_FOCUS_SYSTEM.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_FOCUS_SYSTEM.md) — focus-system architecture.
+
+## Testing
+
+Phone smoke: no visual change (rules are `.android-tv`-scoped). On a Google TV
+Streamer 4K: the `--tv-focus-color` variable is present on `:root.android-tv`.
+
+## Relationship to the series
+
+- **Depends on:** nothing (inert until PR1's `android-tv` class and the engine).
+- **Blocks:** PR8 (the settings color picker reads/writes `tvFocusColor` and the CSS variable).
+- **Layer:** 1 of 3

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -28,7 +28,7 @@ export default {
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
   },
 
-  css: ['@/assets/tailwind.css', '@/assets/app.css'],
+  css: ['@/assets/tailwind.css', '@/assets/app.css', '@/assets/css/tv-focus.css'],
 
   plugins: ['@/plugins/server.js', '@/plugins/db.js', '@/plugins/localStore.js', '@/plugins/init.client.js', '@/plugins/axios.js', '@/plugins/capacitor/index.js', '@/plugins/capacitor/AbsAudioPlayer.js', '@/plugins/nativeHttp.js', '@/plugins/toast.js', '@/plugins/constants.js', '@/plugins/haptics.js', '@/plugins/i18n.js'],
 

--- a/store/user.js
+++ b/store/user.js
@@ -12,7 +12,8 @@ export const state = () => ({
     mobileFilterBy: 'all',
     playbackRate: 1,
     collapseSeries: false,
-    collapseBookSeries: false
+    collapseBookSeries: false,
+    tvFocusColor: '#1ad691'
   }
 })
 

--- a/store/user.js
+++ b/store/user.js
@@ -15,7 +15,8 @@ export const state = () => ({
     collapseBookSeries: false,
     podcastEpisodesOrderBy: 'publishedAt',
     podcastEpisodesOrderDesc: null,
-    podcastEpisodesFilterBy: 'incomplete'
+    podcastEpisodesFilterBy: 'incomplete',
+    tvFocusColor: '#1ad691'
   }
 })
 


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

### Scope
The TV focus-ring CSS foundation: `assets/css/tv-focus.css` + the `--tv-focus-color` custom property, a `tvFocusColor` user setting (default `#1ad691`), nuxt.config registration, and a `tv-focus-dots` hook on the loading indicator. All scoped under `.android-tv`.

### Safety
`.android-tv`-scoped → completely inert on phone/tablet. Nothing drives the focus rings yet, so there's no visible change.

### Testing
Phone: no visual change. GTV Streamer 4K: `--tv-focus-color` present on `:root.android-tv`.

Independent and reviewable on its own. A later settings PR adds a color picker that writes `--tv-focus-color`.
