### PR TITLE
[Android] Skip already-downloaded files and resume interrupted downloads on restart

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -75,6 +75,60 @@ class DownloadItemManager(
     checkUpdateDownloadQueue()
   }
 
+  /**
+   * Restores any download items that were persisted to disk and resumes them. Called once on app
+   * startup. Parts whose files already exist at their final destination are skipped by the queue's
+   * existing file-existence check; the rest are re-downloaded.
+   */
+  fun restoreDownloadQueue() {
+    val savedItems = DeviceManager.dbManager.getDownloadItems()
+    if (savedItems.isEmpty()) return
+
+    Log.i(tag, "Restoring ${savedItems.size} persisted download item(s) from disk")
+
+    var restoredCount = 0
+    savedItems.forEach { downloadItem ->
+      // Skip anything already in the in-memory queue
+      if (downloadItemQueue.any { it.id == downloadItem.id }) return@forEach
+
+      // Reset transient per-part state so the queue re-evaluates every part. getNextDownloadItemParts()
+      // only picks parts with a null downloadId, so a part that was mid-download when the app died must
+      // be reset or it would never resume. Already-finished parts are re-detected by the file-existence
+      // check in processDownloadItemParts().
+      downloadItem.downloadItemParts.forEach { part ->
+        part.downloadId = null
+        part.completed = false
+        part.moved = false
+        part.isMoving = false
+        part.failed = false
+        part.progress = 0
+        part.bytesDownloaded = 0
+
+        // Remove any stale partial temp file from an interrupted external download. The normal build
+        // path deletes these before queueing; the restore path bypasses it, and DownloadManager fails
+        // if the destination already exists.
+        if (!part.isInternalStorage) {
+          part.destinationUri.path?.let { tempPath ->
+            val tempFile = File(tempPath)
+            if (tempFile.exists()) {
+              Log.d(tag, "Removing stale temp file on restore: $tempPath")
+              tempFile.delete()
+            }
+          }
+        }
+      }
+
+      downloadItemQueue.add(downloadItem)
+      clientEventEmitter.onDownloadItem(downloadItem)
+      restoredCount++
+    }
+
+    if (restoredCount > 0) {
+      Log.i(tag, "Resuming $restoredCount restored download item(s)")
+      checkUpdateDownloadQueue()
+    }
+  }
+
   /** Checks and updates the download queue. */
   private fun checkUpdateDownloadQueue() {
     for (downloadItem in downloadItemQueue) {
@@ -99,13 +153,41 @@ class DownloadItemManager(
 
   /** Processes the download item parts. */
   private fun processDownloadItemParts(nextDownloadItemParts: List<DownloadItemPart>) {
-    nextDownloadItemParts.forEach {
-      if (it.isInternalStorage) {
-        startInternalDownload(it)
+    val skippedItemIds = mutableSetOf<String>()
+
+    nextDownloadItemParts.forEach { part ->
+      if (isFileAlreadyDownloaded(part)) {
+        Log.i(tag, "Skipping already-downloaded file: ${part.filename}")
+        part.completed = true
+        part.moved = true
+        part.bytesDownloaded = part.fileSize
+        part.progress = 100
+        part.downloadId = -1L
+        clientEventEmitter.onDownloadItemPartUpdate(part)
+        skippedItemIds.add(part.downloadItemId)
+      } else if (part.isInternalStorage) {
+        startInternalDownload(part)
       } else {
-        startExternalDownload(it)
+        startExternalDownload(part)
       }
     }
+
+    skippedItemIds.forEach { id ->
+      downloadItemQueue.find { it.id == id }?.let { checkDownloadItemFinished(it) }
+    }
+
+    // If all parts in this batch were skipped, the watch loop won't start.
+    // Kick off another queue check to process any remaining unscheduled parts.
+    if (skippedItemIds.isNotEmpty() && currentDownloadItemParts.isEmpty()) {
+      GlobalScope.launch(Dispatchers.Main) { checkUpdateDownloadQueue() }
+    }
+  }
+
+  /** Returns true if a file already exists at the final destination with the expected size. */
+  private fun isFileAlreadyDownloaded(part: DownloadItemPart): Boolean {
+    val file = File(part.finalDestinationPath)
+    if (!file.exists()) return false
+    return if (part.fileSize > 0) file.length() == part.fileSize else file.length() > 0
   }
 
   /** Starts an internal download. */

--- a/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
@@ -18,6 +18,10 @@ data class DownloadItemPart(
   val fileSize: Long,
   val finalDestinationPath:String,
   val serverPath: String,
+  // Stored at creation time so serverUrl survives a Kryo round-trip (android.net.Uri does not).
+  // @JsonIgnore so the token is not included in Capacitor events sent to the JS layer.
+  @JsonIgnore val serverAddress: String,
+  @JsonIgnore val serverToken: String,
   val localFolderName: String,
   val localFolderUrl: String,
   val localFolderId: String,
@@ -30,7 +34,6 @@ data class DownloadItemPart(
   var failed:Boolean,
   @JsonIgnore val uri: Uri,
   @JsonIgnore val destinationUri: Uri,
-  @JsonIgnore val finalDestinationUri: Uri,
   val finalDestinationSubfolder: String,
   var downloadId: Long?,
   var progress: Long,
@@ -39,15 +42,16 @@ data class DownloadItemPart(
   companion object {
     fun make(downloadItemId:String, filename:String, fileSize: Long, destinationFile: File, finalDestinationFile: File, subfolder:String, serverPath:String, localFolder: LocalFolder, ebookFile: EBookFile?, audioTrack: AudioTrack?, episode: PodcastEpisode?) :DownloadItemPart {
       val destinationUri = Uri.fromFile(destinationFile)
-      val finalDestinationUri = Uri.fromFile(finalDestinationFile)
 
-      var downloadUrl = "${DeviceManager.serverAddress}${serverPath}?token=${DeviceManager.token}"
+      val address = DeviceManager.serverAddress
+      val token = DeviceManager.token
+      var downloadUrl = "${address}${serverPath}?token=${token}"
       if (serverPath.endsWith("/cover")) {
         downloadUrl += "&raw=1" // Download raw cover image
       }
 
       val downloadUri = Uri.parse(downloadUrl)
-      Log.d("DownloadItemPart", "Audio File Destination Uri: $destinationUri | Final Destination Uri: $finalDestinationUri | Server Path $serverPath")
+      Log.d("DownloadItemPart", "Audio File Destination Uri: $destinationUri | Server Path $serverPath")
       return DownloadItemPart(
         id = DeviceManager.getBase64Id(finalDestinationFile.absolutePath),
         downloadItemId,
@@ -55,6 +59,8 @@ data class DownloadItemPart(
         fileSize = fileSize,
         finalDestinationPath = finalDestinationFile.absolutePath,
         serverPath = serverPath,
+        serverAddress = address,
+        serverToken = token,
         localFolderName = localFolder.name,
         localFolderUrl = localFolder.contentUrl,
         localFolderId = localFolder.id,
@@ -67,7 +73,6 @@ data class DownloadItemPart(
         failed = false,
         uri = downloadUri,
         destinationUri = destinationUri,
-        finalDestinationUri = finalDestinationUri,
         finalDestinationSubfolder = subfolder,
         downloadId = null,
         progress = 0,
@@ -76,11 +81,23 @@ data class DownloadItemPart(
     }
   }
 
+  // Derived from finalDestinationPath rather than stored as a Uri field because android.net.Uri
+  // does not survive a Kryo round-trip (Paper DB), and finalDestinationPath is the authoritative
+  // persisted String.
+  @get:JsonIgnore
+  val finalDestinationUri get() = Uri.fromFile(File(finalDestinationPath))
+
   @get:JsonIgnore
   val isInternalStorage get() = localFolderId.startsWith("internal-")
 
+  // Uses serverAddress/serverToken stored at creation time rather than the uri field because
+  // android.net.Uri does not survive a Kryo round-trip (Paper DB), so uri is null on restore.
   @get:JsonIgnore
-  val serverUrl get() = uri.toString()
+  val serverUrl get(): String {
+    var url = "${serverAddress}${serverPath}?token=${serverToken}"
+    if (serverPath.endsWith("/cover")) url += "&raw=1"
+    return url
+  }
 
   @JsonIgnore
   fun getDownloadRequest(): DownloadManager.Request {

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
@@ -50,6 +50,22 @@ class AbsDownloader : Plugin() {
     folderScanner = FolderScanner(mainActivity)
     apiHandler = ApiHandler(mainActivity)
     downloadItemManager = DownloadItemManager(downloadManager, folderScanner, mainActivity, clientEventEmitter)
+
+    // Resume any downloads that were interrupted by an app restart
+    downloadItemManager.restoreDownloadQueue()
+  }
+
+  // Re-emit any in-progress download items when JS registers its listener. This handles the case
+  // where restoreDownloadQueue() ran before the WebView loaded, so the initial onDownloadItem
+  // events were dropped. The JS store bootstraps from these re-emitted events.
+  @PluginMethod(returnType = PluginMethod.RETURN_NONE)
+  override fun addListener(call: PluginCall) {
+    super.addListener(call)
+    if (call.getString("eventName") == "onDownloadItem" && downloadItemManager.downloadItemQueue.isNotEmpty()) {
+      downloadItemManager.downloadItemQueue.forEach { item ->
+        notifyListeners("onDownloadItem", JSObject(jacksonMapper.writeValueAsString(item)))
+      }
+    }
   }
 
   @PluginMethod


### PR DESCRIPTION
## Problem

When a multi-track audiobook download is interrupted (force-close, crash, or OS kill), the app has no way to resume. On restart the user must tap Download again, which re-downloads every track from scratch — including ones that already completed.

Fixes #215, fixes #1722.

## What this PR does

Two cooperating changes, both Android-only:

**1. Skip already-downloaded files (`DownloadItemManager`)**

`processDownloadItemParts()` now calls `isFileAlreadyDownloaded()` before starting each part. If the file already exists at its final destination with the expected size, the part is marked complete/moved and the queue moves on. This fires on both the restore path and on any normal download batch, so a file that finished before the interruption is never re-fetched.

**2. Restore the download queue on startup (`DownloadItemManager` + `AbsDownloader`)**

`restoreDownloadQueue()` (called once from `AbsDownloader.load()`) reads persisted `DownloadItem`s from Paper DB via the existing-but-previously-uncalled `getDownloadItems()`, resets transient per-part state, and re-queues everything. The skip check then detects already-finished parts automatically.

**3. Fix `android.net.Uri` fields not surviving Kryo round-trips (`DownloadItemPart`)**

Paper DB uses Kryo for serialization. `android.net.Uri` fields deserialize as `null` after a round-trip (Kryo bypasses constructors via `sun.misc.Unsafe`, so `@JsonIgnore` and non-null declarations are not respected). Three Uri fields were affected:

- `finalDestinationUri` — converted to a computed property derived from the persisted `finalDestinationPath` string
- `serverUrl` — was computed from `uri` (null on restore); now computed from new `serverAddress`/`serverToken` String fields stored at creation time
- `uri` / `destinationUri` — still null on restore, but only used in `getDownloadRequest()` for external-storage downloads, which is out of scope for this PR

**4. Re-emit download items when JS listener registers (`AbsDownloader`)**

`restoreDownloadQueue()` runs during `load()`, before the WebView has loaded and JS listeners have registered. The initial `onDownloadItem` events are therefore dropped. The `addListener` override re-emits all in-progress queue items when the JS layer registers for `onDownloadItem`, so the download UI reflects restored downloads correctly.

## Scope

- **In scope:** Android internal-storage downloads (the common case), multi-track books.
- **Out of scope:** iOS — iOS uses `URLSessionConfiguration.background`, which survives app termination at the OS level and does not have the same restart problem. External-storage (SAF) restore is also not addressed; `uri`/`destinationUri` remain null on restore for that path.

## Testing

Tested on a physical Android device against a real ABS server (13-track audiobook):

1. Started download, force-closed after 3 tracks completed.
2. On restart: `Restoring 1 persisted download item(s) from disk` in logcat, then `Skipping already-downloaded file` for each completed track.
3. Remaining 10 tracks resumed and completed.
4. Book appeared as fully downloaded in the library.
5. Tapping Download on an already-downloading item correctly shows "Download already started" rather than re-queuing.

Logcat snippet (restart run):
```
I DownloadItemManager: Restoring 1 persisted download item(s) from disk
I DownloadItemManager: Skipping already-downloaded file: Arkady & Boris Strugatsky - Roadside Picnic 01-13.mp3
I DownloadItemManager: Skipping already-downloaded file: Arkady & Boris Strugatsky - Roadside Picnic 02-13.mp3
I DownloadItemManager: Skipping already-downloaded file: Arkady & Boris Strugatsky - Roadside Picnic 03-13.mp3
I DownloadItemManager: Resuming 1 restored download item(s)
D DownloadItemManager: Start internal download to destination path .../Roadside Picnic 04-13.mp3
D DownloadItemManager: Start internal download to destination path .../Roadside Picnic 05-13.mp3
D DownloadItemManager: Start internal download to destination path .../Roadside Picnic 06-13.mp3
```