### PR TITLE
Make AudioTrack.mimeType nullable to prevent Android playback stall (fixes #1905)

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/AudioTrack.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/AudioTrack.kt
@@ -10,7 +10,7 @@ data class AudioTrack(
         var duration: Double,
         var title: String,
         var contentUrl: String,
-        var mimeType: String,
+        var mimeType: String?,
         var metadata: FileMetadata?,
         var isLocal: Boolean,
         var localFileId: String?,

--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -332,7 +332,7 @@ class PlaybackSession(
             MediaInfo.Builder(mediaUri.toString())
                     .apply {
                       setContentUrl(mediaUri.toString())
-                      setContentType(audioTrack.mimeType)
+                      setContentType(audioTrack.mimeType ?: "")
                       setMetadata(castMetadata)
                       setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
                     }


### PR DESCRIPTION
## Brief summary

Make `AudioTrack.mimeType` nullable so the Android app stops stalling on tap-to-play when a podcast contains any episode with a null server-side mimeType.

## Which issue is fixed?

Fixes #1905.

## Pull Request Type

Android only, Kotlin.

## In-depth Description

The play-session response inlines every episode of the podcast with an `audioTrack` per episode. Server-side `audioTrack.mimeType` is `null` whenever the underlying `audioFile` row has no probe data. [`AudioTrack.kt:13`](https://github.com/advplyr/audiobookshelf-app/blob/main/android/app/src/main/java/com/audiobookshelf/app/data/AudioTrack.kt#L13) declared `mimeType: String` (non-null), so Jackson throws `MissingKotlinParameterException` on the first null, the whole response fails to deserialize, and ExoPlayer is never called — silent stall on the play spinner.

- `AudioTrack.kt`: `mimeType: String?`. ExoPlayer's `setMimeType` already accepts nullable.
- `PlaybackSession.kt:335`: coerce `?: ""` for Cast SDK's `setContentType`, which is non-null Java.

## How have you tested this?

Reproduced on a podcast with 603/1015 episodes having null server-side mimeType: tap-to-play stalled on every episode in the Android app, played fine in the web UI. Force-reprobing the bad rows server-side (which backfills `mimeType`) restored playback — confirming the chain. This PR fixes it from the app side.

## Screenshots

No UI change.

---

_Disclaimer: investigated and drafted with the help of an LLM (Claude). All source references, API claims, and the fix verified against repo HEAD and on a live server._
