### PR TITLE
fix(android): optimize internal download speeds and prevent silent stalling

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -18,7 +18,10 @@ class InternalDownloadManager(
 
   private val tag = "InternalDownloadManager"
   private val client: OkHttpClient =
-          OkHttpClient.Builder().connectTimeout(30, TimeUnit.SECONDS).build()
+          OkHttpClient.Builder()
+                  .connectTimeout(15, TimeUnit.SECONDS)
+                  .readTimeout(15, TimeUnit.SECONDS)
+                  .build()
   private val writer = BinaryFileWriter(outputStream, progressCallback)
 
   /**
@@ -39,14 +42,21 @@ class InternalDownloadManager(
                       }
 
                       override fun onResponse(call: Call, response: Response) {
-                        response.body?.let { responseBody ->
-                          val length: Long = response.header("Content-Length")?.toLongOrNull() ?: 0L
-                          writer.write(responseBody.byteStream(), length)
+                        try {
+                          response.body?.let { responseBody ->
+                            val length: Long = response.header("Content-Length")?.toLongOrNull() ?: 0L
+                            writer.write(responseBody.byteStream(), length)
+                          }
+                                  ?: run {
+                                    Log.e(tag, "Response doesn't contain a file")
+                                    progressCallback.onComplete(true)
+                                  }
+                        } catch (e: Exception) {
+                          Log.e(tag, "Exception during internal download write for URL $url", e)
+                          progressCallback.onComplete(true)
+                        } finally {
+                          response.close()
                         }
-                                ?: run {
-                                  Log.e(tag, "Response doesn't contain a file")
-                                  progressCallback.onComplete(true)
-                                }
                       }
                     }
             )
@@ -84,14 +94,22 @@ class BinaryFileWriter(
    */
   @Throws(IOException::class)
   fun write(inputStream: InputStream, length: Long): Long {
-    BufferedInputStream(inputStream).use { input ->
+    inputStream.use { input ->
       val dataBuffer = ByteArray(CHUNK_SIZE)
       var totalBytes: Long = 0
       var readBytes: Int
+      var lastProgressTime: Long = 0
+
       while (input.read(dataBuffer).also { readBytes = it } != -1) {
         totalBytes += readBytes
         outputStream.write(dataBuffer, 0, readBytes)
-        progressCallback.onProgress(totalBytes, (totalBytes * 100L) / length)
+
+        val currentTime = System.currentTimeMillis()
+        // Only report progress at most every 250ms to avoid flooding the JS bridge
+        if (currentTime - lastProgressTime > 250) {
+          lastProgressTime = currentTime
+          progressCallback.onProgress(totalBytes, if (length > 0) (totalBytes * 100L) / length else 0)
+        }
       }
       progressCallback.onComplete(false)
       return totalBytes
@@ -109,6 +127,6 @@ class BinaryFileWriter(
   }
 
   companion object {
-    private const val CHUNK_SIZE = 8192 // Increased chunk size for better performance
+    private const val CHUNK_SIZE = 65536 // Increased to 64KB for much faster I/O
   }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -127,6 +127,6 @@ class BinaryFileWriter(
   }
 
   companion object {
-    private const val CHUNK_SIZE = 65536 // Increased to 64KB for much faster I/O
+    private const val CHUNK_SIZE = 65536 // Increased chunk size for better performance
   }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -19,7 +19,7 @@ class InternalDownloadManager(
   private val tag = "InternalDownloadManager"
   private val client: OkHttpClient =
           OkHttpClient.Builder()
-                  .connectTimeout(15, TimeUnit.SECONDS)
+                  .connectTimeout(30, TimeUnit.SECONDS)
                   .readTimeout(15, TimeUnit.SECONDS)
                   .build()
   private val writer = BinaryFileWriter(outputStream, progressCallback)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5102,6 +5102,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "license": "MIT"
@@ -7582,6 +7592,13 @@
       "version": "2.0.5",
       "license": "MIT"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "license": "MIT",
@@ -7812,6 +7829,20 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -9991,6 +10022,13 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -15857,6 +15895,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/watchpack-chokidar2/node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {


### PR DESCRIPTION
## Description
Fixes an issue where Android internal storage downloads could stall indefinitely without throwing an error. This is done by adding proper OkHttp timeouts and try/catch exception handling to the async callback. 

Also improves download speeds on Android by:

1. Increasing the internal `FileOutputStream` write chunk size from 8KB to 64KB for optimal flash storage I/O.
2. Throttling the progress update events fired to the JavaScript UI layer to a maximum of once every 250ms, preventing the Capacitor bridge and UI thread from being flooded by thousands of updates per second.