### PR TITLE
Treat KEYCODE_MEDIA_STOP as pause instead of closing the playback session

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
@@ -234,7 +234,7 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
             playerNotificationService.jumpBackward()
           }
           KeyEvent.KEYCODE_MEDIA_STOP -> {
-            playerNotificationService.closePlayback()
+            playerNotificationService.pause()
           }
           else -> {
             Log.d(tag, "KeyCode:${keyEvent.keyCode}")


### PR DESCRIPTION
## Summary

- When a car head unit powers off, it sends `KEYCODE_MEDIA_STOP` to the Android media session. The current handler calls `closePlayback()`, which tears down the session entirely, removing the media notification from the shade and requiring the user to manually reopen the app and restart the book.
- Standard media apps (YouTube, Plex, Jellyfin) treat `KEYCODE_MEDIA_STOP` as a pause, keeping the session and notification alive so playback can resume from the notification shade or when the car reconnects.
- This fix changes the handler in `MediaSessionCallback.kt` to call `pause()` instead of `closePlayback()`.

## Testing

- Tested on Toyota Entune (legacy Bluetooth audio system, not Android Auto).
- Toyota Entune sends `KEYCODE_MEDIA_STOP` on power-off and `KEYCODE_MEDIA_PLAY` on power-on. With this fix, powering off pauses and leaves the book in the notification shade; powering the car back on resumes automatically.
- Not tested with Android Auto. Android Auto should not be negatively affected by this change. If the same issue exists on Android Auto, this fix would likely address it there as well, though we have no way to confirm at this time.

## Related Issues

This fix addresses a root cause reported across several open issues:

- #204 (open since 2022) -- Playback closes when connecting to car Bluetooth (Jabra + Samsung Note 20 Ultra)
- #612 (open since 2022) -- Pause on Bluetooth disconnect from car (Pixel 7 Pro + Pixel Watch)
- #801 (open since 2023) -- Open audiobook player session doesn't stay open after disconnecting from car Bluetooth (Pixel 6 + Toyota Corolla 2016)
- #1476 (closed as duplicate, 2024) -- Player closes on disconnect from car (Galaxy S25 Ultra + BMW)
- #1849 (open since 2024) -- ABS Android app stops playing after Bluetooth disconnect (Samsung + Android Auto)