### PR TITLE
fix(android-auto): run server connection check off the main thread to prevent ANR

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/media/MediaManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/media/MediaManager.kt
@@ -9,8 +9,11 @@ import com.audiobookshelf.app.device.DeviceManager
 import com.audiobookshelf.app.server.ApiHandler
 import com.getcapacitor.JSObject
 import java.util.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.json.JSONException
 import org.json.JSONObject
 import kotlin.coroutines.resume
@@ -45,6 +48,16 @@ class MediaManager(private var apiHandler: ApiHandler, var ctx: Context) {
   var serverLibraries = listOf<Library>()
 
   var userSettingsPlaybackRate:Float? = null
+
+  // Android Auto browses on the media browser service main thread, so the server pings
+  // and authorize call must not run there or they block it and trigger an ANR
+  private val androidAutoIOScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+  // Android Auto re-requests the browse root every ~2s and multiple clients do so at once,
+  // so overlapping loads are coalesced into one to avoid racing on the shared server state
+  private var isLoadingAndroidAutoItems = false
+  private val pendingAndroidAutoLoadCallbacks = mutableListOf<() -> Unit>()
+  private val androidAutoLoadLock = Any()
 
   fun getIsLibrary(id:String) : Boolean {
     return serverLibraries.find { it.id == id } != null
@@ -136,7 +149,7 @@ class MediaManager(private var apiHandler: ApiHandler, var ctx: Context) {
     //   and reset any server data already set
     val serverConnConfig = if (DeviceManager.isConnectedToServer) DeviceManager.serverConnectionConfig else DeviceManager.deviceData.getLastServerConnectionConfig()
 
-    if (!DeviceManager.isConnectedToServer || !DeviceManager.checkConnectivity(ctx) || serverConnConfig == null || serverConnConfig.id !== serverConfigIdUsed) {
+    if (!DeviceManager.isConnectedToServer || !DeviceManager.checkConnectivity(ctx) || serverConnConfig == null || serverConnConfig.id != serverConfigIdUsed) {
       podcastEpisodeLibraryItemMap = mutableMapOf()
       serverLibraries = listOf()
       serverLibraryItems = mutableListOf()
@@ -730,7 +743,10 @@ class MediaManager(private var apiHandler: ApiHandler, var ctx: Context) {
     return mediaProgress
   }
 
-  private fun checkSetValidServerConnectionConfig(cb: (Boolean) -> Unit) = runBlocking {
+  // Runs on [androidAutoIOScope] rather than blocking the caller: this is reached from
+  // onLoadChildren on the media browser service main thread, and the pings/authorize below
+  // are network calls, so runBlocking here caused ANRs while browsing in Android Auto
+  private fun checkSetValidServerConnectionConfig(cb: (Boolean) -> Unit) = androidAutoIOScope.launch {
     Log.d(tag, "checkSetValidServerConnectionConfig | serverConfigIdUsed=$serverConfigIdUsed | lastServerConnectionConfigId=${DeviceManager.deviceData.lastServerConnectionConfigId}")
 
     coroutineScope {
@@ -835,6 +851,26 @@ class MediaManager(private var apiHandler: ApiHandler, var ctx: Context) {
   fun loadAndroidAutoItems(cb: () -> Unit) {
     Log.d(tag, "Load android auto items")
 
+    // Coalesce overlapping calls into a single load, every caller still gets its callback
+    synchronized(androidAutoLoadLock) {
+      pendingAndroidAutoLoadCallbacks.add(cb)
+      if (isLoadingAndroidAutoItems) {
+        Log.d(tag, "loadAndroidAutoItems: Load already in progress, queued callback")
+        return
+      }
+      isLoadingAndroidAutoItems = true
+    }
+
+    val onLoadFinished = {
+      val callbacks: List<() -> Unit>
+      synchronized(androidAutoLoadLock) {
+        isLoadingAndroidAutoItems = false
+        callbacks = pendingAndroidAutoLoadCallbacks.toList()
+        pendingAndroidAutoLoadCallbacks.clear()
+      }
+      callbacks.forEach { it() }
+    }
+
     // Check if any valid server connection if not use locally downloaded books
     checkSetValidServerConnectionConfig { isConnected ->
       if (isConnected) {
@@ -844,14 +880,14 @@ class MediaManager(private var apiHandler: ApiHandler, var ctx: Context) {
         loadLibraries { libraries ->
           if (libraries.isEmpty()) {
             Log.w(tag, "No libraries returned from server request")
-            cb()
+            onLoadFinished()
           } else {
-            cb() // Fully loaded
+            onLoadFinished() // Fully loaded
           }
         }
       } else { // Not connected to server
         Log.d(tag, "loadAndroidAutoItems: Not connected to server")
-        cb()
+        onLoadFinished()
       }
     }
   }


### PR DESCRIPTION
## Brief summary

Fixes Android Auto browsing repeatedly crashing the app (phone app "closes", Android Auto shows a generic "failed to connect" error). The server connectivity check ran network I/O on the media browser service main thread via `runBlocking`, causing an ANR that was compounded by the ~2s Android Auto browse-root polling.

## Which issue is fixed?

Fixes #1919

## Pull Request Type

Android only, native (Kotlin) backend of the app. No frontend changes.

## In-depth Description

`PlayerNotificationService.onLoadChildren` runs on the media browser service **main thread**. For the Android Auto root it calls `MediaManager.loadAndroidAutoItems` → `checkSetValidServerConnectionConfig`, which used `runBlocking { ... }` to ping every saved server config (`checkServerConnection`) and run `authorize` — all suspend network calls. Under `runBlocking` on the main thread, this blocks the main thread on network I/O.

It is made re-entrant by a reload storm: Android Auto (`gearhead`) and Assistant (`googlequicksearchbox`) each poll the browse root every ~2s. While the Capacitor webview hasn't established the server connection, `DeviceManager.serverConnectionConfig` is null, so every `onGetRoot` flags `forceReloadingAndroidAuto = true`, forcing another `loadAndroidAutoItems` on the next `onLoadChildren`. Repeated blocking loads → ANR → process killed.

Changes (all in `android/app/src/main/java/com/audiobookshelf/app/media/MediaManager.kt`):

1. **`checkSetValidServerConnectionConfig` now runs on a dedicated `Dispatchers.IO` scope** instead of `runBlocking`, so the pings/authorize never block the caller. The `(Boolean) -> Unit` callback contract is unchanged; downstream Android Auto callbacks already ran off the main thread (delivered on the OkHttp callback thread), so ordering/threading of the result is preserved.

2. **`loadAndroidAutoItems` coalesces overlapping calls** behind a single in-flight guard and fires all queued callbacks when the one load completes. This prevents the browse-root polling storm from spawning concurrent loads that race on the shared server state (`serverLibraries`, `serverUserMediaProgress`, etc.). The existing 5-second ping cache already bounds network cost; this bounds concurrency.

3. **Fix a latent bug in `checkResetServerItems`**: the server config id was compared with `!==` (reference identity) instead of `!=` (value), which could trigger spurious cache resets that fed the reload storm.

No public API or behavior changes outside the Android Auto browse path.

## How have you tested this?

Built from source in Android Studio and installed on a physical device (Pixel 9 Pro, Android 17, app 0.13.0). Before the change, connecting to Android Auto reliably crashed the app within seconds of browsing; after the change the crash is fully resolved and Android Auto browsing works normally, including the previously-failing cold-start case where Auto binds the media browser service before the webview establishes the server connection.

Repro used: force-stop the app (webview not running), then launch Android Auto so it cold-binds the browse service. Pre-fix: ANR/crash. Post-fix: browses normally.

## Screenshots

N/A — no front-end changes.