### PR TITLE
Add "Scale Remaining Time by Speed" option in the item screen for audiobooks and podcast episodes

### DIFF
--- a/components/modals/ItemMoreMenuModal.vue
+++ b/components/modals/ItemMoreMenuModal.vue
@@ -50,6 +50,15 @@ export default {
     userIsAdminOrUp() {
       return this.$store.getters['user/getIsAdminOrUp']
     },
+    scaleRemainingTimeBySpeed: {
+      get() {
+        return this.$store.state.globals.scaleRemainingTimeBySpeed
+      },
+      set(val) {
+        this.$localStore.setScaleRemainingTimeBySpeed(val)
+        this.$store.commit('globals/setScaleRemainingTimeBySpeed', val)
+      }
+    },
     moreMenuItems() {
       const items = []
 
@@ -78,6 +87,12 @@ export default {
             icon: 'backspace'
           })
         }
+
+        items.push({
+          text: this.$strings.LabelScaleRemainingTimeBySpeed,
+          value: 'scaleRemainingTimeBySpeed',
+          icon: this.scaleRemainingTimeBySpeed ? 'check_box' : 'check_box_outline_blank'
+        })
       }
 
       if ((!this.isPodcast && this.serverLibraryItemId) || (this.episode && this.serverEpisodeId)) {
@@ -285,6 +300,8 @@ export default {
         this.$router.push(`/media/${this.mediaId}/history?title=${this.title}`)
       } else if (action === 'discardProgress') {
         this.clearProgressClick()
+      } else if (action === 'scaleRemainingTimeBySpeed') {
+        this.scaleRemainingTimeBySpeed = !this.scaleRemainingTimeBySpeed
       } else if (action === 'deleteLocal') {
         this.deleteLocalItem()
       } else if (action === 'deleteLocalEpisode') {
@@ -506,6 +523,8 @@ export default {
         })
     }
   },
-  mounted() {}
+  async mounted() {
+    this.scaleRemainingTimeBySpeed = await this.$localStore.getScaleRemainingTimeBySpeed()
+  }
 }
 </script>

--- a/pages/item/_id/_episode/index.vue
+++ b/pages/item/_id/_episode/index.vue
@@ -250,7 +250,12 @@ export default {
     userTimeRemaining() {
       if (!this.userItemProgress) return 0
       const duration = this.userItemProgress.duration || this.episode.duration
-      return duration - this.userItemProgress.currentTime
+      const remaining = duration - this.userItemProgress.currentTime
+      if (this.$store.state.globals.scaleRemainingTimeBySpeed) {
+        const playbackRate = this.$store.getters['user/getUserSetting']('playbackRate') || 1
+        return remaining / playbackRate
+      }
+      return remaining
     },
     timeRemaining() {
       if (this.playerIsPlaying) return 'Playing'

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -383,7 +383,12 @@ export default {
     userTimeRemaining() {
       if (!this.userItemProgress) return 0
       const duration = this.userItemProgress.duration || this.duration
-      return duration - this.userItemProgress.currentTime
+      const remaining = duration - this.userItemProgress.currentTime
+      if (this.$store.state.globals.scaleRemainingTimeBySpeed) {
+        const playbackRate = this.$store.getters['user/getUserSetting']('playbackRate') || 1
+        return remaining / playbackRate
+      }
+      return remaining
     },
     useEBookProgress() {
       if (!this.userItemProgress || this.userItemProgress.progress) return false

--- a/plugins/localStore.js
+++ b/plugins/localStore.js
@@ -144,10 +144,29 @@ class LocalStorage {
     }
   }
 
+
+  async setScaleRemainingTimeBySpeed(useIt) {
+    try {
+      await Preferences.set({ key: 'scaleRemainingTimeBySpeed', value: useIt ? '1' : '0' })
+    } catch (error) {
+      console.error('[LocalStorage] Failed to set scale remaining time by speed', error)
+    }
+  }
+
+  async getScaleRemainingTimeBySpeed() {
+    try {
+      var obj = await Preferences.get({ key: 'scaleRemainingTimeBySpeed' }) || {}
+      return obj.value === '1'
+    } catch (error) {
+      console.error('[LocalStorage] Failed to get scale remaining time by speed', error)
+      return false
+    }
+  }
+
   /**
    * Get preference value by key
-   * 
-   * @param {string} key 
+   *
+   * @param {string} key
    * @returns {Promise<string>}
    */
   async getPreferenceByKey(key) {

--- a/store/globals.js
+++ b/store/globals.js
@@ -2,6 +2,7 @@ export const state = () => ({
   isModalOpen: false,
   itemDownloads: [],
   bookshelfListView: false,
+  scaleRemainingTimeBySpeed: false,
   series: null,
   localMediaProgress: [],
   lastSearch: null,
@@ -137,6 +138,9 @@ export const mutations = {
   },
   setBookshelfListView(state, val) {
     state.bookshelfListView = val
+  },
+  setScaleRemainingTimeBySpeed(state, val) {
+    state.scaleRemainingTimeBySpeed = val
   },
   setSeries(state, val) {
     state.series = val

--- a/strings/en-us.json
+++ b/strings/en-us.json
@@ -240,6 +240,7 @@
   "LabelRecentlyAdded": "Recently Added",
   "LabelRemoveFromPlaylist": "Remove from Playlist",
   "LabelScaleElapsedTimeBySpeed": "Scale Elapsed Time by Speed",
+  "LabelScaleRemainingTimeBySpeed": "Scale Remaining Time by Speed",
   "LabelSeason": "Season",
   "LabelSelectADevice": "Select a device",
   "LabelSelectMediaType": "Select media type",


### PR DESCRIPTION
## Brief summary

This lets the user choose whether the remaining time should account for the listening speed. Without this change, the listening speed is not accounted for in the calculation.

## Which issue is fixed?

Fixes #1921 

## Pull Request Type

Affects both iOS and Android

## In-depth Description

- Adds a checkbox menu item to ItemMoreMenuModal (shared by both the book and podcast episode screens) showing a checked/unchecked box icon based on the current preference  
- Persists the preference via Capacitor Preferences, following the same dedicated getter/setter pattern used for other boolean settings (e.g. bookshelfListView)             
- Syncs the preference through the Vuex globals store so both the menu and the progress display stay reactive        
- When enabled, divides the calculated remaining time by the user's current playback speed setting in both pages/item/_id/index.vue (books) and pages/item/_id/_episode/index.vue (podcast episodes) 

## How have you tested this?

I tested this manually on my Pixel 10 device. I have an audiobook set to 2x speed for which I toggled the new setting on and off. I confirmed that turning the setting on reduces the remaining time by half, and turning the setting off reset it back to normal. I tested this both with a streaming audiobook and a locally downloaded audiobook.

## Screenshots

Fresh book just started at 2x speed:
<img width="1080" height="2424" alt="Screenshot_20260706_011457" src="https://github.com/user-attachments/assets/fb8bbd02-6da1-429a-a49f-b4b4511634aa" />

New "Scale Remaining Time by Speed" checkbox:
<img width="1080" height="2424" alt="Screenshot_20260706_005343" src="https://github.com/user-attachments/assets/1c7da2f7-c3b7-4c8e-b923-1982370c4da2" />

Check the checkbox:
<img width="1080" height="2424" alt="Screenshot_20260706_005332" src="https://github.com/user-attachments/assets/1c130589-9a29-45d9-8c67-0d75e9130080" />

Now see that the time remaining is down by half, since 2x listening speed leads to half the listening time:
<img width="1080" height="2424" alt="Screenshot_20260706_005254" src="https://github.com/user-attachments/assets/48a71fa9-968f-4874-9550-2fe19be08d66" />


