### PR TITLE
feat: auto-play next episode when playing podcast playlists (rebased #1810, tested)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Audiobookshelf mobile app built with **NuxtJS 2** (SSR disabled, static target) and **Capacitor 7**, sharing one JS codebase across Android and iOS. Requires a running Audiobookshelf server to connect to.
+
+## Development Commands
+
+```bash
+npm install                  # install dependencies
+npm run generate             # build static web app into dist/
+npx cap sync                 # copy dist/ into android/ios native shells
+npm run sync                 # shortcut: generate + cap sync (use after JS changes)
+npm run dev                  # local web dev server at http://0.0.0.0:1337
+npx cap open android         # open Android Studio
+npx cap open ios             # open Xcode
+npm run devlive              # live reload via ionic cap run on connected device
+```
+
+There are no automated tests in this project.
+
+## Architecture
+
+### Two-layer structure
+
+**JS Layer (NuxtJS)** → compiled to `dist/` → synced into native shells via Capacitor.
+
+**Native Layer (Android/Kotlin)** in `android/app/src/main/java/com/audiobookshelf/app/`.
+
+### Custom Capacitor Plugins
+
+The bridge between JS and native is five custom Capacitor plugins. Each has a JS counterpart in `plugins/capacitor/` and a Kotlin implementation in `android/.../plugins/`:
+
+| Plugin | Purpose |
+|---|---|
+| `AbsAudioPlayer` | Audio playback control, cast, sleep timer |
+| `AbsDatabase` | Local SQLite DB, device data, download progress |
+| `AbsDownloader` | File download management |
+| `AbsFileSystem` | File system access, folder scanning |
+| `AbsLogger` | Native log capture |
+
+**JS → Native**: Call plugin methods directly, e.g. `AbsAudioPlayer.prepareLibraryItem({...})`.
+**Native → JS**: Use Capacitor's `notifyListeners()` on the native side and `addListener()` on the JS side.
+
+### Android Native Key Files
+
+- `MainActivity.kt` — `BridgeActivity` subclass; registers all plugins; binds `PlayerNotificationService` on `onPostCreate` and wires it to `AbsAudioPlayer` via `pluginCallback`.
+- `player/PlayerNotificationService.kt` — `MediaBrowserServiceCompat` foreground service; owns ExoPlayer instance; implements `ClientEventEmitter` interface to push events back to `AbsAudioPlayer.kt`.
+- `player/CastManager.kt` / `CastPlayer.kt` — Google Cast support.
+- `media/MediaManager.kt` — Caches library items, authors, series, collections, and podcast data for Android Auto / media browser.
+- `media/MediaProgressSyncer.kt` — Syncs playback progress with the server.
+- `managers/DbManager.kt` — SQLite wrapper for local library items and progress.
+- `managers/SleepTimerManager.kt` — Sleep timer logic.
+- `server/ApiHandler.kt` — All REST API calls to the ABS server.
+
+### JS Layer Key Files
+
+- `plugins/server.js` — `ServerSocket` class (socket.io); injected as `$socket`; handles authentication and real-time events from server.
+- `plugins/db.js` — `DbService`; thin wrapper around `AbsDatabase`; injected as `$db`; also listens for `onTokenRefresh` / `onTokenRefreshFailure` events.
+- `plugins/localStore.js` — `LocalStorage` class backed by Capacitor `Preferences`; injected as `$localStore`; persists user settings, theme, language, last library.
+- `plugins/init.client.js` — Registers global Vue utilities (`$eventBus`, date/time helpers, `$bytesPretty`, `$elapsedPretty`, etc.); handles back-button behavior for Android and iOS swipe navigation.
+- `plugins/capacitor/AbsAudioPlayer.js` — Web fallback implementation of `AbsAudioPlayer` using the HTML5 `<audio>` element; used during browser-based development.
+
+### Vuex Store
+
+- `store/index.js` — Global state: network status, current playback session, player playing/fullscreen state, cast availability, playlist queue.
+- `store/user.js` — Auth token, server connection config, user object (permissions, media progress, bookmarks), user settings.
+- `store/libraries.js` — Library list, current library ID, filter data.
+- `store/globals.js` — Modal open state and other UI globals.
+
+### Playlist Queue
+
+Podcast playlist playback is coordinated entirely in the JS layer. `store/index.js` holds `playlistQueue: { playlistId, items, currentIndex }`. When an episode ends, `AudioPlayer.vue` receives the `ENDED` `onMetadata` event and emits `playback-ended` on `$eventBus`. `AudioPlayerContainer.vue` handles this by advancing `currentIndex` and emitting `play-item` for the next episode.
+
+**Background playback gotcha**: `AbsAudioPlayer.kt` suppresses `onMetadata` events while the app is backgrounded (`isInForeground == false`) to avoid flooding the WebView. The `ENDED` state is explicitly exempted from this suppression so that playlist advancement works when the screen is off or the app is minimized. Do not remove this exemption.
+
+### Communication Patterns
+
+- **Server REST API**: `$axios` (configured in `plugins/axios.js`); base URL is the connected server address.
+- **Real-time updates**: socket.io via `$socket`; socket must be authenticated with `auth` event after connection.
+- **Playback events**: flow from `PlayerNotificationService` → `AbsAudioPlayer.kt` (via `ClientEventEmitter`) → `notifyListeners()` → JS `addListener()` handlers → Vuex mutations.
+
+### i18n
+
+Translation strings live in `strings/<locale>.json`. Applied via `plugins/i18n.js`. Language preference is persisted with `$localStore.setLanguage()`.
+
+### Styling
+
+Tailwind CSS 3 with PostCSS. Global styles in `assets/app.css` and `assets/tailwind.css`. The `tailwind.config.js` controls customization.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
@@ -145,6 +145,7 @@ class PlayerListener(var playerNotificationService:PlayerNotificationService) : 
         playerNotificationService.sendClientMetadata(PlayerState.ENDED)
 
         playerNotificationService.handlePlaybackEnded()
+        playerNotificationService.advancePlaylistQueue()
       }
       if (playerNotificationService.currentPlayer.playbackState == Player.STATE_IDLE) {
         Log.d(tag, "STATE_IDLE")

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
@@ -141,7 +141,7 @@ class PlayerListener(var playerNotificationService:PlayerNotificationService) : 
         playerNotificationService.sendClientMetadata(PlayerState.BUFFERING)
       }
       if (playerNotificationService.currentPlayer.playbackState == Player.STATE_ENDED) {
-        Log.d(tag, "STATE_ENDED")
+        Log.d(tag, "STATE_ENDED | playlistQueueSize=${playerNotificationService.playlistQueue.size} | playlistQueueIndex=${playerNotificationService.playlistQueueIndex}")
         playerNotificationService.sendClientMetadata(PlayerState.ENDED)
 
         playerNotificationService.handlePlaybackEnded()

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationListener.kt
@@ -18,19 +18,26 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
     notification: Notification,
     onGoing: Boolean) {
 
-    // Keep foreground service alive when a playlist queue is active (e.g. between episodes)
+    // Keep foreground service alive when a playlist queue is active AND the player
+    // intends to continue playing (playWhenReady is true).  When the player is
+    // paused — whether by Bluetooth disconnect (ACTION_AUDIO_BECOMING_NOISY),
+    // user pause, or any other reason — playWhenReady is false and we must NOT
+    // re-assert foreground, because doing so can interfere with the pause on
+    // some devices (Samsung One UI, Android 12+) or prevent the system from
+    // properly demoting the service after an audio-route change.
     val hasPlaylistQueue = playerNotificationService.playlistQueue.isNotEmpty()
-    val effectiveOnGoing = onGoing || hasPlaylistQueue
+    val playerWantsToPlay = playerNotificationService.currentPlayer.playWhenReady
+    val effectiveOnGoing = onGoing || (hasPlaylistQueue && playerWantsToPlay)
 
     if (effectiveOnGoing) {
       if (!isForegroundService) {
         // Start foreground service for the first time
-        Log.d(tag, "Notification Posted $notificationId - Start Foreground | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue")
+        Log.d(tag, "Notification Posted $notificationId - Start Foreground | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue playWhenReady=$playerWantsToPlay")
         PlayerNotificationService.isClosed = false
-      } else if (!onGoing && hasPlaylistQueue) {
-        // Player stopped but playlist queue active: re-assert foreground to prevent system from
-        // downgrading the service (Android 12+ may demote non-ongoing foreground services)
-        Log.d(tag, "Notification Posted $notificationId - Re-assert Foreground for playlist queue | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue")
+      } else if (!onGoing && hasPlaylistQueue && playerWantsToPlay) {
+        // Player not actively playing but intends to continue (e.g. between episodes):
+        // re-assert foreground to prevent system from downgrading the service
+        Log.d(tag, "Notification Posted $notificationId - Re-assert Foreground for playlist queue | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue playWhenReady=$playerWantsToPlay")
       } else {
         // Already in foreground and ongoing - just update the notification
         return
@@ -43,7 +50,7 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
       }
       isForegroundService = true
     } else {
-      Log.d(tag, "Notification posted $notificationId, not starting foreground - onGoing=$onGoing | hasPlaylistQueue=$hasPlaylistQueue | isForegroundService=$isForegroundService")
+      Log.d(tag, "Notification posted $notificationId, not starting foreground - onGoing=$onGoing | hasPlaylistQueue=$hasPlaylistQueue | playWhenReady=$playerWantsToPlay | isForegroundService=$isForegroundService")
     }
   }
 
@@ -54,11 +61,15 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
     val hasPlaylistQueue = playerNotificationService.playlistQueue.isNotEmpty()
 
     if (dismissedByUser) {
-      if (hasPlaylistQueue) {
-        Log.d(tag, "onNotificationCancelled dismissed by user but playlist queue active - keeping service alive")
+      // Only keep the service alive if the player actually intends to continue
+      // playing (e.g. between episodes).  If the user paused and then dismissed,
+      // or if Bluetooth disconnected (playWhenReady == false), allow the stop.
+      val playerWantsToPlay = playerNotificationService.currentPlayer.playWhenReady
+      if (hasPlaylistQueue && playerWantsToPlay) {
+        Log.d(tag, "onNotificationCancelled dismissed by user but playlist queue active and playWhenReady - keeping service alive")
         return
       }
-      Log.d(tag, "onNotificationCancelled dismissed by user")
+      Log.d(tag, "onNotificationCancelled dismissed by user | hasPlaylistQueue=$hasPlaylistQueue | playWhenReady=$playerWantsToPlay")
       playerNotificationService.stopSelf()
     } else {
       Log.d(tag, "onNotificationCancelled not dismissed by user | hasPlaylistQueue=$hasPlaylistQueue")

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -2,8 +2,10 @@ package com.audiobookshelf.app.player
 
 import android.annotation.SuppressLint
 import android.app.*
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.ImageDecoder
@@ -108,6 +110,12 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   lateinit var currentPlayer: Player
   var castPlayer: CastPlayer? = null
 
+  // Defense-in-depth receiver for Bluetooth disconnect / headphone unplug.
+  // ExoPlayer's setHandleAudioBecomingNoisy(true) registers its own receiver,
+  // but on some devices (Samsung One UI, Android 12+) the foreground service
+  // re-assertion can interfere.  This explicit receiver ensures pause sticks.
+  private var audioNoisyReceiver: BroadcastReceiver? = null
+
   lateinit var sleepTimerManager: SleepTimerManager
   lateinit var mediaProgressSyncer: MediaProgressSyncer
 
@@ -195,6 +203,12 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
       Log.e(tag, "Error unregistering network listening callback $error")
     }
 
+    // Unregister the defense-in-depth AUDIO_BECOMING_NOISY receiver
+    audioNoisyReceiver?.let {
+      try { unregisterReceiver(it) } catch (_: Exception) {}
+      audioNoisyReceiver = null
+    }
+
     Log.d(tag, "onDestroy")
     isStarted = false
     isClosed = true
@@ -214,12 +228,17 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     super.onTaskRemoved(rootIntent)
 
     val isPlaying = try { currentPlayer.isPlaying } catch (e: Exception) { false }
-    if (playlistQueue.isNotEmpty() || isPlaying) {
-      Log.d(tag, "onTaskRemoved: keeping service alive (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying)")
+    val playerWantsToPlay = try { currentPlayer.playWhenReady } catch (e: Exception) { false }
+    // Only keep the service alive if the player is actively playing or if it
+    // intends to continue (playWhenReady == true with a playlist queue, i.e.
+    // between episodes).  When paused by Bluetooth disconnect or user action,
+    // playWhenReady is false and the service should be allowed to stop.
+    if (isPlaying || (playlistQueue.isNotEmpty() && playerWantsToPlay)) {
+      Log.d(tag, "onTaskRemoved: keeping service alive (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying, playWhenReady=$playerWantsToPlay)")
       return
     }
 
-    Log.d(tag, "onTaskRemoved: stopping service")
+    Log.d(tag, "onTaskRemoved: stopping service (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying, playWhenReady=$playerWantsToPlay)")
     stopSelf()
   }
 
@@ -409,6 +428,31 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                     .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
                     .build()
     mPlayer.setAudioAttributes(audioAttributes, true)
+
+    // Defense-in-depth: register an explicit receiver for audio route changes
+    // (Bluetooth disconnect, headphone unplug).  ExoPlayer's built-in handler
+    // should pause the player, but on some devices the foreground service
+    // lifecycle can interfere.  This receiver ensures the pause is authoritative.
+    audioNoisyReceiver?.let {
+      try { unregisterReceiver(it) } catch (_: Exception) {}
+    }
+    audioNoisyReceiver = object : BroadcastReceiver() {
+      override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+          Log.d(tag, "ACTION_AUDIO_BECOMING_NOISY received — ensuring player is paused")
+          try {
+            if (mPlayer.playWhenReady) {
+              mPlayer.playWhenReady = false
+              Log.d(tag, "Forced playWhenReady=false on AUDIO_BECOMING_NOISY")
+            }
+          } catch (e: Exception) {
+            Log.e(tag, "Error handling AUDIO_BECOMING_NOISY: $e")
+          }
+        }
+      }
+    }
+    val noisyFilter = IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+    registerReceiver(audioNoisyReceiver, noisyFilter)
 
     // attach player to playerNotificationManager
     playerNotificationManager.setPlayer(mPlayer)

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -63,8 +63,9 @@ class AbsAudioPlayer : Plugin() {
         }
 
         override fun onMetadata(metadata: PlaybackMetadata) {
-          // Skip frequent metadata updates when app is backgrounded to prevent event queue buildup
-          if (!isInForeground) return
+          // Skip frequent metadata updates when app is backgrounded to prevent event queue buildup,
+          // but always forward ENDED state so playlist queue advancement works in background
+          if (!isInForeground && metadata.playerState != PlayerState.ENDED) return
           notifyListeners("onMetadata", JSObject(jacksonMapper.writeValueAsString(metadata)))
         }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -449,6 +449,36 @@ class AbsAudioPlayer : Plugin() {
   }
 
   @PluginMethod
+  fun setPlaylistQueue(call: PluginCall) {
+    val items = call.getArray("items") ?: run { call.resolve(); return }
+    val currentIndex = call.getInt("currentIndex", 0) ?: 0
+    val queue = mutableListOf<PlayerNotificationService.PlaylistQueueItem>()
+    for (i in 0 until items.length()) {
+      val item = items.getJSONObject(i)
+      queue.add(PlayerNotificationService.PlaylistQueueItem(
+        libraryItemId = item.getString("libraryItemId"),
+        episodeId = if (item.has("episodeId") && !item.isNull("episodeId")) item.getString("episodeId") else null
+      ))
+    }
+    Handler(Looper.getMainLooper()).post {
+      playerNotificationService.playlistQueue = queue
+      playerNotificationService.playlistQueueIndex = currentIndex
+      Log.d(tag, "setPlaylistQueue: ${queue.size} items, currentIndex=$currentIndex")
+    }
+    call.resolve()
+  }
+
+  @PluginMethod
+  fun clearPlaylistQueue(call: PluginCall) {
+    Handler(Looper.getMainLooper()).post {
+      playerNotificationService.playlistQueue = emptyList()
+      playerNotificationService.playlistQueueIndex = -1
+      Log.d(tag, "clearPlaylistQueue: cleared")
+    }
+    call.resolve()
+  }
+
+  @PluginMethod
   fun getIsCastAvailable(call: PluginCall) {
     val jsobj = JSObject()
     jsobj.put("value", isCastAvailable)

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -43,7 +43,11 @@ class ApiHandler(var ctx:Context) {
     }
   }
 
-  private var defaultClient = OkHttpClient()
+  private var defaultClient = OkHttpClient.Builder()
+    .connectTimeout(15, TimeUnit.SECONDS)
+    .readTimeout(15, TimeUnit.SECONDS)
+    .writeTimeout(15, TimeUnit.SECONDS)
+    .build()
   private var pingClient = OkHttpClient.Builder().callTimeout(3, TimeUnit.SECONDS).build()
   private var jacksonMapper = jacksonObjectMapper().enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
   private var secureStorage = SecureStorage(ctx)

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -845,6 +845,7 @@ export default {
 
       if (data.playerState === 'ENDED') {
         console.log('[AudioPlayer] Playback ended')
+        this.$eventBus.$emit('playback-ended')
       }
       this.isEnded = data.playerState === 'ENDED'
 

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -192,12 +192,56 @@ export default {
           this.$toast.error('Failed to play')
         })
     },
+    onPlaybackEnded() {
+      const playlistQueue = this.$store.state.playlistQueue
+      if (!playlistQueue) return
+
+      const { items, currentIndex } = playlistQueue
+      const nextIndex = currentIndex + 1
+      if (nextIndex >= items.length) {
+        this.$store.commit('clearPlaylistQueue')
+        return
+      }
+
+      const nextItem = items[nextIndex]
+      this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: nextIndex })
+      this.$store.commit('setPlayerIsStartingPlayback', nextItem.episodeId || nextItem.libraryItemId)
+      if (nextItem.localLibraryItem) {
+        this.$eventBus.$emit('play-item', {
+          libraryItemId: nextItem.localLibraryItem.id,
+          episodeId: nextItem.localEpisode?.id,
+          serverLibraryItemId: nextItem.libraryItemId,
+          serverEpisodeId: nextItem.episodeId,
+          fromPlaylistQueue: true
+        })
+      } else {
+        this.$eventBus.$emit('play-item', {
+          libraryItemId: nextItem.libraryItemId,
+          episodeId: nextItem.episodeId,
+          fromPlaylistQueue: true
+        })
+      }
+    },
     async playLibraryItem(payload) {
       await AbsLogger.info({ tag: 'AudioPlayerContainer', message: `playLibraryItem: Received play request for library item ${payload.libraryItemId} ${payload.episodeId ? `episode ${payload.episodeId}` : ''}` })
       const libraryItemId = payload.libraryItemId
       const episodeId = payload.episodeId
       const startTime = payload.startTime
       const startWhenReady = !payload.paused
+
+      if (!payload.fromPlaylistQueue) {
+        const playlistQueue = this.$store.state.playlistQueue
+        if (playlistQueue) {
+          const serverLibraryItemId = payload.serverLibraryItemId || (!libraryItemId?.startsWith('local') ? libraryItemId : null)
+          const serverEpisodeId = payload.serverEpisodeId || (!episodeId?.startsWith('local') ? episodeId : null)
+          const matchIndex = playlistQueue.items.findIndex((i) => i.libraryItemId === serverLibraryItemId && i.episodeId === serverEpisodeId)
+          if (matchIndex >= 0) {
+            this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: matchIndex })
+          } else {
+            this.$store.commit('clearPlaylistQueue')
+          }
+        }
+      }
 
       const isLocal = libraryItemId.startsWith('local')
       if (!isLocal) {
@@ -453,6 +497,7 @@ export default {
     this.$eventBus.$on('playback-time-update', this.playbackTimeUpdate)
     this.$eventBus.$on('device-focus-update', this.deviceFocused)
     this.$eventBus.$on('socket-reconnected', this.socketReconnected)
+    this.$eventBus.$on('playback-ended', this.onPlaybackEnded)
   },
   beforeDestroy() {
     this.onLocalMediaProgressUpdateListener?.remove()
@@ -469,6 +514,7 @@ export default {
     this.$eventBus.$off('playback-time-update', this.playbackTimeUpdate)
     this.$eventBus.$off('device-focus-update', this.deviceFocused)
     this.$eventBus.$off('socket-reconnected', this.socketReconnected)
+    this.$eventBus.$off('playback-ended', this.onPlaybackEnded)
   }
 }
 </script>

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -193,6 +193,9 @@ export default {
         })
     },
     onPlaybackEnded() {
+      // Native layer (PlayerNotificationService.advancePlaylistQueue) handles the actual
+      // playback advancement even when the screen is off or the app is backgrounded.
+      // This handler only keeps the Vuex state in sync for UI purposes.
       const playlistQueue = this.$store.state.playlistQueue
       if (!playlistQueue) return
 
@@ -200,27 +203,12 @@ export default {
       const nextIndex = currentIndex + 1
       if (nextIndex >= items.length) {
         this.$store.commit('clearPlaylistQueue')
+        AbsAudioPlayer.clearPlaylistQueue()
         return
       }
 
-      const nextItem = items[nextIndex]
+      // Advance Vuex index so the UI reflects the currently playing episode
       this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: nextIndex })
-      this.$store.commit('setPlayerIsStartingPlayback', nextItem.episodeId || nextItem.libraryItemId)
-      if (nextItem.localLibraryItem) {
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: nextItem.localLibraryItem.id,
-          episodeId: nextItem.localEpisode?.id,
-          serverLibraryItemId: nextItem.libraryItemId,
-          serverEpisodeId: nextItem.episodeId,
-          fromPlaylistQueue: true
-        })
-      } else {
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: nextItem.libraryItemId,
-          episodeId: nextItem.episodeId,
-          fromPlaylistQueue: true
-        })
-      }
     },
     async playLibraryItem(payload) {
       await AbsLogger.info({ tag: 'AudioPlayerContainer', message: `playLibraryItem: Received play request for library item ${payload.libraryItemId} ${payload.episodeId ? `episode ${payload.episodeId}` : ''}` })
@@ -239,6 +227,7 @@ export default {
             this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: matchIndex })
           } else {
             this.$store.commit('clearPlaylistQueue')
+            AbsAudioPlayer.clearPlaylistQueue()
           }
         }
       }

--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -38,6 +38,10 @@ export default {
     item: {
       type: Object,
       default: () => {}
+    },
+    playlistPlayableItems: {
+      type: Array,
+      default: () => []
     }
   },
   data() {
@@ -162,20 +166,32 @@ export default {
       let mediaId = this.episodeId || this.libraryItem.id
       if (this.streamIsPlaying) {
         this.$eventBus.$emit('pause-item')
-      } else if (this.localLibraryItem) {
-        this.$store.commit('setPlayerIsStartingPlayback', mediaId)
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: this.localLibraryItem.id,
-          episodeId: this.localEpisode?.id,
-          serverLibraryItemId: this.libraryItem.id,
-          serverEpisodeId: this.episodeId
-        })
       } else {
-        this.$store.commit('setPlayerIsStartingPlayback', mediaId)
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: this.libraryItem.id,
-          episodeId: this.episodeId
-        })
+        if (this.playlistPlayableItems.length) {
+          const currentIndex = this.playlistPlayableItems.findIndex((i) => i.libraryItemId === this.libraryItem.id && i.episodeId === this.episodeId)
+          if (currentIndex >= 0) {
+            this.$store.commit('setPlaylistQueue', {
+              playlistId: this.playlistId,
+              items: this.playlistPlayableItems,
+              currentIndex
+            })
+          }
+        }
+        if (this.localLibraryItem) {
+          this.$store.commit('setPlayerIsStartingPlayback', mediaId)
+          this.$eventBus.$emit('play-item', {
+            libraryItemId: this.localLibraryItem.id,
+            episodeId: this.localEpisode?.id,
+            serverLibraryItemId: this.libraryItem.id,
+            serverEpisodeId: this.episodeId
+          })
+        } else {
+          this.$store.commit('setPlayerIsStartingPlayback', mediaId)
+          this.$eventBus.$emit('play-item', {
+            libraryItemId: this.libraryItem.id,
+            episodeId: this.episodeId
+          })
+        }
       }
     }
   },

--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+import { AbsAudioPlayer } from '@/plugins/capacitor'
+
 export default {
   props: {
     playlistId: String,
@@ -173,6 +175,14 @@ export default {
             this.$store.commit('setPlaylistQueue', {
               playlistId: this.playlistId,
               items: this.playlistPlayableItems,
+              currentIndex
+            })
+            // Sync queue to native layer so it can advance independently of the WebView
+            AbsAudioPlayer.setPlaylistQueue({
+              items: this.playlistPlayableItems.map((item) => ({
+                libraryItemId: item.localLibraryItem ? item.localLibraryItem.id : item.libraryItemId,
+                episodeId: item.localLibraryItem ? (item.localEpisode?.id || null) : (item.episodeId || null)
+              })),
               currentIndex
             })
           }

--- a/components/tables/playlist/PlaylistItemsTable.vue
+++ b/components/tables/playlist/PlaylistItemsTable.vue
@@ -11,7 +11,7 @@
       <p v-if="totalDuration" class="text-sm text-fg">{{ totalDurationPretty }}</p>
     </div>
     <template v-for="item in items">
-      <tables-playlist-item-table-row :key="item.id" :item="item" :playlist-id="playlistId" @showMore="showMore" />
+      <tables-playlist-item-table-row :key="item.id" :item="item" :playlist-id="playlistId" :playlist-playable-items="playableItems" @showMore="showMore" />
     </template>
   </div>
 </template>
@@ -29,6 +29,14 @@ export default {
     return {}
   },
   computed: {
+    playableItems() {
+      return this.items.filter((item) => {
+        const libraryItem = item.libraryItem
+        if (!libraryItem || libraryItem.isMissing || libraryItem.isInvalid) return false
+        if (item.episode) return !!item.episode.audioFile
+        return libraryItem.media?.tracks?.length > 0
+      })
+    },
     totalDuration() {
       var _total = 0
       this.items.forEach((item) => {

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -140,11 +140,17 @@ export default {
       }
     },
     playNextItem() {
-      const nextItem = this.playableItems.find((i) => {
+      const nextIndex = this.playableItems.findIndex((i) => {
         const prog = this.$store.getters['user/getUserMediaProgress'](i.libraryItemId, i.episodeId)
         return !prog?.isFinished
       })
-      if (nextItem) {
+      if (nextIndex >= 0) {
+        const nextItem = this.playableItems[nextIndex]
+        this.$store.commit('setPlaylistQueue', {
+          playlistId: this.playlist.id,
+          items: this.playableItems,
+          currentIndex: nextIndex
+        })
         this.mediaIdStartingPlayback = nextItem.episodeId || nextItem.libraryItemId
         this.$store.commit('setPlayerIsStartingPlayback', this.mediaIdStartingPlayback)
         if (nextItem.localLibraryItem) {

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+import { AbsAudioPlayer } from '@/plugins/capacitor'
+
 export default {
   async asyncData({ store, params, app, redirect, route }) {
     if (!store.state.user.user) {
@@ -149,6 +151,14 @@ export default {
         this.$store.commit('setPlaylistQueue', {
           playlistId: this.playlist.id,
           items: this.playableItems,
+          currentIndex: nextIndex
+        })
+        // Pass queue to native layer so it can advance independently of the WebView
+        AbsAudioPlayer.setPlaylistQueue({
+          items: this.playableItems.map((item) => ({
+            libraryItemId: item.localLibraryItem ? item.localLibraryItem.id : item.libraryItemId,
+            episodeId: item.localLibraryItem ? (item.localEpisode?.id || null) : (item.episodeId || null)
+          })),
           currentIndex: nextIndex
         })
         this.mediaIdStartingPlayback = nextItem.episodeId || nextItem.libraryItemId

--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -171,6 +171,16 @@ class AbsAudioPlayerWeb extends WebPlugin {
     return false
   }
 
+  // PluginMethod
+  setPlaylistQueue() {
+    // Web: queue advancement handled in JS layer
+  }
+
+  // PluginMethod
+  clearPlaylistQueue() {
+    // Web: queue advancement handled in JS layer
+  }
+
   initializePlayer() {
     if (document.getElementById('audio-player')) {
       document.getElementById('audio-player').remove()

--- a/store/index.js
+++ b/store/index.js
@@ -9,6 +9,7 @@ export const state = () => ({
   playerIsFullscreen: false,
   playerIsStartingPlayback: false, // When pressing play before native play response
   playerStartingPlaybackMediaId: null,
+  playlistQueue: null, // { playlistId: String, items: Array, currentIndex: Number }
   isCasting: false,
   isCastAvailable: false,
   attemptingConnection: false,
@@ -210,5 +211,11 @@ export const mutations = {
   setServerSettings(state, val) {
     state.serverSettings = val
     this.$localStore.setServerSettings(state.serverSettings)
+  },
+  setPlaylistQueue(state, queue) {
+    state.playlistQueue = queue
+  },
+  clearPlaylistQueue(state) {
+    state.playlistQueue = null
   }
 }


### PR DESCRIPTION
This PR is a rebased, cleaned-up version of #1810 by @Pittermaennchen, which implements auto-play for podcast playlists (the feature requested in #416).

## Changes from #1810

- **Rebased onto current master** (`185cba1`) — no conflicts
- **Dropped the debug icon commit** (`e243477`) — the upside-down app icon in debug builds is an intentional visual distinction between debug and release builds, not a bug to fix
- **All other commits preserved** with original authorship intact

## What it does

When playing a podcast episode that's part of a playlist, the app now automatically advances to the next episode when the current one finishes. This works even when the app is backgrounded or the device enters Doze mode, using Kotlin-native WakeLock and network wake handling.

## Commits (5 of the original 6)

1. `feat: auto-play next episode when playing podcast playlists` — core JS-side playlist advancement
2. `fix: forward ENDED metadata event to JS when app is backgrounded` — ensures the event reaches the webview
3. `fix: advance podcast playlist natively to survive Android Doze mode` — Kotlin-side advancement for background/Doze
4. `fix: keep CPU/network awake during podcast playlist advancement` — WakeLock handling
5. `fix: robust background playlist advancement for podcast playlists` — edge-case hardening

## Testing

Built a debug APK from this branch and tested on a physical Android device — podcast playlists advance correctly through episodes, including when the app is backgrounded.

Closes #416
