### PR TITLE
Fix bookshelf tabs reloading on navigation and log viewer hanging on large logs

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import com.audiobookshelf.app.data.*
 import com.audiobookshelf.app.models.DownloadItem
 import com.audiobookshelf.app.plugins.AbsLog
-import com.audiobookshelf.app.plugins.AbsLogger
 import io.paperdb.Paper
 import java.io.File
 
@@ -14,6 +13,9 @@ class DbManager {
 
   companion object {
     private var isDbInitialized = false
+    // Bound the log viewer read and the total stored log count (mirrors iOS Database).
+    private const val MAX_LOGS_RETURNED = 500
+    private const val MAX_LOGS_STORED = 1000
 
     fun initialize(ctx: Context) {
       if (isDbInitialized) return
@@ -293,14 +295,21 @@ class DbManager {
   fun saveLog(log:AbsLog) {
     Paper.book("log").write(log.id, log)
   }
-  fun getAllLogs() : List<AbsLog> {
+  private fun readAllLogs() : List<AbsLog> {
+    val book = Paper.book("log")
     val logs:MutableList<AbsLog> = mutableListOf()
-    Paper.book("log").allKeys.forEach { logId ->
-      Paper.book("log").read<AbsLog>(logId)?.let {
+    book.allKeys.forEach { logId ->
+      book.read<AbsLog>(logId)?.let {
         logs.add(it)
       }
     }
     return logs.sortedBy { it.timestamp }
+  }
+  fun getAllLogs() : List<AbsLog> {
+    // Bounded read for the log viewer. Loading/serializing/rendering the entire log book hangs the
+    // viewer on devices with a large accumulated history, so return only the most recent entries
+    // (chronological order). See iOS Database.getAllLogs.
+    return readAllLogs().takeLast(MAX_LOGS_RETURNED)
   }
   fun removeAllLogs() {
     Paper.book("log").destroy()
@@ -308,16 +317,28 @@ class DbManager {
   fun cleanLogs() {
     val numberOfHoursToKeep = 48
     val keepLogCutoff = System.currentTimeMillis() - (3600000 * numberOfHoursToKeep)
-    val allLogs = getAllLogs()
+    // Read the full book directly (getAllLogs is intentionally bounded and can't be used here).
+    val allLogs = readAllLogs()
+    val book = Paper.book("log")
     var logsRemoved = 0
+
+    // Remove logs older than the retention window
     allLogs.forEach {
       if (it.timestamp < keepLogCutoff) {
-        Paper.book("log").delete(it.id)
+        book.delete(it.id)
         logsRemoved++
       }
     }
+
+    // Also cap the total stored logs by count. Within the retention window, frequent logging can still
+    // accumulate far more entries than the viewer can load, so trim the oldest overflow (list is ascending).
+    allLogs.filter { it.timestamp >= keepLogCutoff }.dropLast(MAX_LOGS_STORED).forEach {
+      book.delete(it.id)
+      logsRemoved++
+    }
+
     if (logsRemoved > 0) {
-      AbsLogger.info("DbManager", "cleanLogs: Removed $logsRemoved logs older than $numberOfHoursToKeep hours")
+      Log.i("DbManager", "cleanLogs: Removed $logsRemoved expired/overflow logs")
     }
   }
 }

--- a/components/bookshelf/LazyBookshelf.vue
+++ b/components/bookshelf/LazyBookshelf.vue
@@ -79,6 +79,9 @@ export default {
     entityName() {
       return this.page
     },
+    cacheKey() {
+      return `lazy:${this.page}${this.seriesId ? ':' + this.seriesId : ''}`
+    },
     hasFilter() {
       if (this.page === 'series' || this.page === 'collections' || this.page === 'playlists') return false
       return this.filterBy !== 'all'
@@ -344,6 +347,20 @@ export default {
       }
       return entitiesPerShelfBefore < this.entitiesPerShelf // Books per shelf has changed
     },
+    restoreFromCache() {
+      const cache = this.$store.state.bookshelfTabCache[this.cacheKey]
+      if (!cache || !cache.totalEntities) return false
+      // Only reuse if the library and query (filter/sort) are unchanged
+      if (cache.libraryId !== this.currentLibraryId || cache.queryString !== this.buildSearchParams()) return false
+      this.currentSFQueryString = cache.queryString
+      this.entities = cache.entities
+      this.totalEntities = cache.totalEntities
+      this.totalShelves = Math.ceil(this.totalEntities / this.entitiesPerShelf)
+      this.pagesLoaded = { ...cache.pagesLoaded }
+      this.initialized = true
+      this.$eventBus.$emit('bookshelf-total-entities', this.totalEntities)
+      return true
+    },
     async init() {
       if (this.isFirstInit) return
       if (!this.user) {
@@ -358,7 +375,15 @@ export default {
 
       this.isFirstInit = true
       this.initSizeData()
-      await this.loadPage(0)
+      // Restore cached entities to avoid a blank refetch when returning to this tab (e.g. after Logs).
+      const restoredFromCache = this.restoreFromCache()
+      if (!restoredFromCache) {
+        await this.loadPage(0)
+      } else {
+        // Let the template render the restored shelf spacer (totalShelves) before imperatively mounting
+        // cards, otherwise they mount into an unsized container and don't appear.
+        await this.$nextTick()
+      }
       var lastBookIndex = Math.min(this.totalEntities, this.shelvesPerPage * this.entitiesPerShelf)
       this.mountEntites(0, lastBookIndex)
 
@@ -369,6 +394,11 @@ export default {
           // Exact path match with query so use scroll position
           window['bookshelf-wrapper'].scrollTop = scrollTop
         }
+      }
+
+      // If restored from cache, refresh page 0 in the background so content updates in place (no blank flash).
+      if (restoredFromCache) {
+        this.loadPage(0)
       }
     },
     scroll(e) {
@@ -556,6 +586,21 @@ export default {
     // Set bookshelf scroll position for specific bookshelf page and query
     if (window['bookshelf-wrapper']) {
       this.$store.commit('setLastBookshelfScrollData', { scrollTop: window['bookshelf-wrapper'].scrollTop || 0, path: this.routeFullPath, name: this.page })
+    }
+
+    // Cache loaded entities so returning to this tab restores instantly instead of remounting blank + refetching.
+    if (this.initialized && this.totalEntities > 0) {
+      this.$store.commit('setBookshelfTabCache', {
+        key: this.cacheKey,
+        data: {
+          libraryId: this.currentLibraryId,
+          queryString: this.currentSFQueryString,
+          entities: this.entities,
+          totalEntities: this.totalEntities,
+          totalShelves: this.totalShelves,
+          pagesLoaded: this.pagesLoaded
+        }
+      })
     }
   }
 }

--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -219,7 +219,7 @@ class Database {
             return nil
         }
     }
-    
+
     public func saveDownloadItem(_ downloadItem: DownloadItem) throws {
         let realm = try Realm()
         return try realm.write { realm.add(downloadItem, update: .modified) }
@@ -285,10 +285,22 @@ class Database {
         return try realm.write { realm.add(log) }
     }
     
+    // Bounded read for the log viewer. The log table can hold a large number of very frequent entries;
+    // loading, JSON-encoding and rendering all of them hangs the viewer (and blocks the plugin queue so
+    // even Clear Logs can't run). Return only the most recent entries, in chronological order.
+    static let maxLogsReturned = 500
+
     public func getAllLogs() -> [LogEntry] {
         do {
             let realm = try Realm()
-            return realm.objects(LogEntry.self).toArray()
+            // Take the most recent N and detach them from Realm (thread-independent copies), matching
+            // Results.toArray(). Live Realm objects can't be JSON-encoded off their realm/thread, which
+            // is what asDictionaryArray() does. Reverse to chronological (oldest -> newest) for the viewer.
+            let recent: [LogEntry] = realm.objects(LogEntry.self)
+                .sorted(byKeyPath: "timestamp", ascending: false)
+                .prefix(Database.maxLogsReturned)
+                .map { $0.detached() }
+            return Array(recent.reversed())
         } catch {
             debugPrint(error)
             return []
@@ -312,21 +324,31 @@ class Database {
     private func cleanExpiredLogs() throws {
         let realm = try Realm()
         let numberOfHoursToKeep = 48
-        let keepLogCutoff = Date().addingTimeInterval(TimeInterval(-1 * numberOfHoursToKeep * 3600))
-        
-        let allLogs = getAllLogs()
+        let maxLogsToKeep = 1000
+        let keepLogCutoff = Int(Date().addingTimeInterval(TimeInterval(-1 * numberOfHoursToKeep * 3600)).timeIntervalSince1970)
+
         var logsRemoved = 0
+        // Query the full table directly (getAllLogs is intentionally bounded and can't be used here).
         try? realm.write {
-            allLogs.forEach { log in
-                if log.timestamp < Int(keepLogCutoff.timeIntervalSince1970) {
-                    realm.delete(log)
-                    logsRemoved += 1
-                }
+            // Remove logs older than the retention window (batch delete via query, not one-by-one).
+            let expired = realm.objects(LogEntry.self).filter("timestamp < %@", NSNumber(value: keepLogCutoff))
+            logsRemoved += expired.count
+            realm.delete(expired)
+
+            // Also cap the total stored logs by count. Within the retention window, frequent logging can
+            // still accumulate far more entries than the viewer can load, so trim the oldest overflow.
+            let remaining = realm.objects(LogEntry.self).sorted(byKeyPath: "timestamp", ascending: false)
+            if remaining.count > maxLogsToKeep {
+                let overflow = Array(remaining[maxLogsToKeep...])
+                logsRemoved += overflow.count
+                realm.delete(overflow)
             }
         }
-        
+
+        // Note: use debugPrint here, not AbsLogger.info — this runs inside Database.init, and logging
+        // would re-enter Database.shared before it finishes initializing.
         if logsRemoved > 0 {
-            AbsLogger.info(message: "cleanLogs: Removed \(logsRemoved) logs older than \(numberOfHoursToKeep) hours")
+            debugPrint("cleanLogs: Removed \(logsRemoved) expired/overflow logs")
         }
     }
 }

--- a/pages/bookshelf/authors.vue
+++ b/pages/bookshelf/authors.vue
@@ -13,10 +13,14 @@
 <script>
 export default {
   data() {
+    // Restore previously loaded authors so returning to this tab (e.g. after viewing Logs) paints
+    // instantly instead of remounting to a blank list and refetching. Only reuse if same library.
+    const cached = this.$store.state.bookshelfTabCache.authors
+    const cache = cached?.loadedLibraryId === this.$store.state.libraries.currentLibraryId ? cached : {}
     return {
       loading: true,
-      authors: [],
-      loadedLibraryId: null,
+      authors: cache.authors || [],
+      loadedLibraryId: cache.loadedLibraryId || null,
       cardWidth: 200
     }
   },
@@ -35,13 +39,15 @@ export default {
         return
       }
       this.loadedLibraryId = this.currentLibraryId
-      this.authors = await this.$nativeHttp
+      const authors = await this.$nativeHttp
         .get(`/api/libraries/${this.currentLibraryId}/authors`)
         .then((response) => response.authors)
         .catch((error) => {
           console.error('Failed to load authors', error)
-          return []
+          return null
         })
+      // Keep any existing (cached) authors if the fetch failed, so a transient error doesn't blank the list
+      if (authors) this.authors = authors
       console.log('Loaded authors', this.authors)
       this.$eventBus.$emit('bookshelf-total-entities', this.authors.length)
       this.loading = false
@@ -82,6 +88,11 @@ export default {
     this.$eventBus.$on('library-changed', this.libraryChanged)
   },
   beforeDestroy() {
+    // Cache authors so returning to this tab restores instantly instead of remounting blank + refetching.
+    this.$store.commit('setBookshelfTabCache', {
+      key: 'authors',
+      data: { authors: this.authors, loadedLibraryId: this.loadedLibraryId }
+    })
     this.$socket.$off('author_added', this.authorAdded)
     this.$socket.$off('author_updated', this.authorUpdated)
     this.$socket.$off('author_removed', this.authorRemoved)

--- a/pages/bookshelf/index.vue
+++ b/pages/bookshelf/index.vue
@@ -41,12 +41,16 @@
 export default {
   props: {},
   data() {
+    // Restore the previously loaded home shelves (and fetch timestamps) so returning to the home
+    // screen paints instantly instead of refetching from scratch. On slow connections a refetch
+    // shows a "Please Wait" overlay and, if it times out, wipes the bookshelf. See setBookshelfTabCache.
+    const homeCache = this.$store.state.bookshelfTabCache.home
     return {
-      shelves: [],
+      shelves: homeCache?.shelves || [],
       isFirstNetworkConnection: true,
-      lastServerFetch: 0,
-      lastServerFetchLibraryId: null,
-      lastLocalFetch: 0,
+      lastServerFetch: homeCache?.lastServerFetch || 0,
+      lastServerFetchLibraryId: homeCache?.lastServerFetchLibraryId || null,
+      lastLocalFetch: homeCache?.lastLocalFetch || 0,
       localLibraryItems: [],
       isLoading: false
     }
@@ -238,25 +242,28 @@ export default {
       // Set local library items first
       this.localLibraryItems = await this.$db.getLocalLibraryItems()
       const localCategories = this.getLocalMediaItemCategories()
-      this.shelves = localCategories
-      console.log('[categories] Local shelves set', this.shelves.length, this.lastLocalFetch)
 
       if (isConnectedToServerWithInternet) {
+        // Note: don't clear the current shelves before the server responds. On slow connections this
+        // fetch can take several seconds (or time out at connectTimeout), and clearing first flashes an
+        // empty/local-only bookshelf. Keep whatever is already shown until fresh data arrives.
         const categories = await this.$nativeHttp.get(`/api/libraries/${this.currentLibraryId}/personalized?minified=1&include=rssfeed,numEpisodesIncomplete`, { connectTimeout: 10000 }).catch((error) => {
           console.error('[categories] Failed to fetch categories', error)
           return []
         })
         if (!categories.length) {
-          // Failed to load categories so use local shelves
-          console.warn(`[categories] Failed to get server categories so using local categories`)
+          // Failed to load (or timed out). Keep the shelves we already have; only fall back to local if
+          // we have nothing to show. This prevents a transient failure from wiping the home screen.
+          console.warn(`[categories] Failed to get server categories, keeping existing shelves`)
+          if (!this.shelves.length) this.shelves = localCategories
           this.lastServerFetch = 0
           this.lastLocalFetch = Date.now()
           this.isLoading = false
-          console.log('[categories] Local shelves set from failure', this.shelves.length, this.lastLocalFetch)
+          console.log('[categories] Shelves after server failure', this.shelves.length, this.lastLocalFetch)
           return
         }
 
-        this.shelves = categories.map((cat) => {
+        const serverShelves = categories.map((cat) => {
           if (cat.type == 'book' || cat.type == 'podcast' || cat.type == 'episode') {
             // Map localLibraryItem to entities
             cat.entities = cat.entities.map((entity) => {
@@ -274,8 +281,11 @@ export default {
 
         // Only add the local shelf with the same media type
         const localShelves = localCategories.filter((cat) => cat.type === this.currentLibraryMediaType && !cat.localOnly)
-        this.shelves.push(...localShelves)
+        this.shelves = [...serverShelves, ...localShelves]
         console.log('[categories] Server shelves set', this.shelves.length, this.lastServerFetch)
+      } else {
+        this.shelves = localCategories
+        console.log('[categories] Local shelves set', this.shelves.length, this.lastLocalFetch)
       }
 
       this.isLoading = false
@@ -345,6 +355,17 @@ export default {
   },
   beforeDestroy() {
     this.removeListeners()
+    // Cache the loaded shelves + fetch timestamps so returning to the home screen restores instantly
+    // instead of refetching (which flashes a loading/empty state on slow connections).
+    this.$store.commit('setBookshelfTabCache', {
+      key: 'home',
+      data: {
+        shelves: this.shelves,
+        lastServerFetch: this.lastServerFetch,
+        lastServerFetchLibraryId: this.lastServerFetchLibraryId,
+        lastLocalFetch: this.lastLocalFetch
+      }
+    })
   }
 }
 </script>

--- a/pages/bookshelf/latest.vue
+++ b/pages/bookshelf/latest.vue
@@ -11,13 +11,17 @@
 <script>
 export default {
   data() {
+    // Restore previously loaded episodes so returning to this tab (e.g. after viewing Logs) paints
+    // instantly instead of remounting blank and refetching. Only reuse if same library.
+    const cached = this.$store.state.bookshelfTabCache.latest
+    const cache = cached?.loadedLibraryId === this.$store.state.libraries.currentLibraryId ? cached : {}
     return {
       processing: false,
-      recentEpisodes: [],
-      totalEpisodes: 0,
-      currentPage: 0,
+      recentEpisodes: cache.recentEpisodes || [],
+      totalEpisodes: cache.totalEpisodes || 0,
+      currentPage: cache.currentPage || 0,
       localLibraryItems: [],
-      loadedLibraryId: null
+      loadedLibraryId: cache.loadedLibraryId || null
     }
   },
   watch: {},
@@ -69,9 +73,12 @@ export default {
       })
       this.processing = false
       console.log('Episodes', episodePayload)
-      this.recentEpisodes = episodePayload.episodes || []
-      this.totalEpisodes = episodePayload.total
-      this.currentPage = page
+      // Keep any existing (cached) episodes if the fetch failed (also avoids a null dereference)
+      if (episodePayload) {
+        this.recentEpisodes = episodePayload.episodes || []
+        this.totalEpisodes = episodePayload.total
+        this.currentPage = page
+      }
     },
     libraryChanged(libraryId) {
       if (libraryId !== this.loadedLibraryId) {
@@ -104,6 +111,11 @@ export default {
     this.$eventBus.$on('new-local-library-item', this.newLocalLibraryItem)
   },
   beforeDestroy() {
+    // Cache episodes so returning to this tab restores instantly instead of remounting blank + refetching.
+    this.$store.commit('setBookshelfTabCache', {
+      key: 'latest',
+      data: { recentEpisodes: this.recentEpisodes, totalEpisodes: this.totalEpisodes, currentPage: this.currentPage, loadedLibraryId: this.loadedLibraryId }
+    })
     this.$eventBus.$off('library-changed', this.libraryChanged)
     this.$eventBus.$off('new-local-library-item', this.newLocalLibraryItem)
   }

--- a/store/index.js
+++ b/store/index.js
@@ -27,7 +27,8 @@ export const state = () => ({
   isNetworkListenerInit: false,
   serverSettings: null,
   lastBookshelfScrollData: {},
-  lastItemScrollData: {}
+  lastItemScrollData: {},
+  bookshelfTabCache: {}
 })
 
 export const getters = {
@@ -134,6 +135,11 @@ export const mutations = {
   },
   setLastItemScrollData(state, data) {
     state.lastItemScrollData = data
+  },
+  setBookshelfTabCache(state, { key, data }) {
+    // Cache per bookshelf sub-tab (home/authors/latest/...) so returning to a tab after visiting another
+    // top-level page (Logs, Settings...) restores instantly instead of remounting and refetching.
+    state.bookshelfTabCache = { ...state.bookshelfTabCache, [key]: data }
   },
   setPlaybackSession(state, playbackSession) {
     state.currentPlaybackSession = playbackSession


### PR DESCRIPTION
## Brief summary

Two independent reliability fixes for offline / large-library use, one per commit:
- The in-app **Log viewer** no longer hangs the app when the stored log history is large.
- **Bookshelf tabs** no longer reload from scratch (or go blank) when you leave for another page and return.

## Which issue is fixed?

Fixes #1789 (log viewer hangs / blank on iOS)
Fixes #1926 (bookshelf tabs reload and can go blank when returning from Logs/Settings)

## Pull Request Type

Affects **both Android and iOS**. Touches the **frontend** (Vue) and the **native** layer (iOS Swift / Android Kotlin). No server/backend changes.

## In-depth Description

**Log viewer (#1789).** The Logs screen loaded the *entire* persisted log table. On installs that have run a while, that table grows large enough that serializing and rendering all of it never finishes — and on iOS the read runs on the Capacitor plugin's serial queue, so while it churns every other plugin call is blocked too. That is why the reporter in #1789 sees the whole app freeze (main screen empty, Settings modal never closes, playback can't be paused) until force-close.
Fix: keep retention bounded by count (most recent 1000) in addition to the existing 48h window, and return only the most recent 500 entries to the viewer, so the read is fast regardless of how much history is stored. iOS also detaches Realm objects before JSON-encoding them (live Realm objects can't be encoded off their realm/thread, which otherwise surfaced as "Failed to get logs"), batch-deletes expired rows instead of one-by-one, and avoids re-entering `Database.shared` from `cleanExpiredLogs` during init.

**Bookshelf tabs (#1926).** Each bookshelf sub-tab (Home, Authors, Latest, and the lazy Books/Series/Collections/Playlists bookshelf) is a separate page that is destroyed when you navigate to another top-level route and refetches on remount, flashing a loading/empty state and losing scroll — and a timed-out refetch can leave the tab blank ("Bookshelf empty") despite being connected.
Fix: cache each tab's loaded data in a per-tab Vuex slice and restore it on remount, refreshing in the background (stale-while-revalidate). Returning is instant, and a failed refresh no longer wipes the view. The virtualized lazy bookshelf restores its entities/pages and re-mounts cards after a `nextTick` (so the shelf spacer has rendered); restore is guarded by library + query so filter/sort/library changes still refetch. Also fixes a null dereference in Latest when the recent-episodes fetch fails.

This is the least invasive fix given the current architecture: it adds a cache keyed per tab rather than changing how each page fetches, and the native log change is a bounded-read plus a count cap layered on the existing time-based retention.

## How have you tested this?

- **iOS** — built to an iPhone via an **Xcode debug build**, and run on the iOS Simulator, both signed into a live server:
  - Logs open and load quickly; the app stays responsive and "Clear Logs" works.
  - Home / Authors / Library / Series preserve their contents and stay on the same tab across a Logs round-trip; no reload flash, no "Bookshelf empty".
- **Android** — run on an emulator against a live server: Library (700+ books) and Series restore correctly, both scrolled and not; Logs load fast.
- Builds clean on web (`nuxt generate`), Android (`./gradlew :app:compileDebugKotlin`), and iOS (`build_sim`).

Repro steps for each are in #1789 and #1926.

## Screenshots

_Log viewer "before" (blank + app hang) is captured in the screen recording on #1789._

https://github.com/user-attachments/assets/3894090e-595c-4956-a681-cc1b4276719e


https://github.com/user-attachments/assets/03a27b6a-98fb-4093-ac64-aff66c584f85




Bookshelf "before": returning to a tab from Logs shows a "Please Wait" spinner and, on a slow connection, ends on "Bookshelf empty". "After": the tab reappears immediately with its content intact. I can attach before/after screen recordings here on request.

Happy to split this into two PRs if you'd prefer one issue per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

