### PR TITLE
Add offline bookmark sync

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -50,7 +50,7 @@
     <div id="playerContent" class="playerContainer w-full z-20 absolute bottom-0 left-0 right-0 p-2 pointer-events-auto transition-all" :style="{ backgroundColor: showFullscreen ? '' : coverRgb }" @click="clickContainer">
       <div v-if="showFullscreen" class="absolute bottom-4 left-0 right-0 w-full pb-4 pt-2 mx-auto px-6" style="max-width: 414px">
         <div class="flex items-center justify-between pointer-events-auto">
-          <span v-if="!isPodcast && serverLibraryItemId && socketConnected" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')">bookmark</span>
+          <span v-if="!isPodcast && serverLibraryItemId && bookmarksAvailable" class="material-symbols text-3xl text-fg-muted cursor-pointer" :class="{ fill: bookmarks.length }" @click="$emit('showBookmarks')">bookmark</span>
           <!-- hidden for podcasts but still using this as a placeholder -->
           <span v-else class="material-symbols text-3xl text-white text-opacity-0">bookmark</span>
 
@@ -124,6 +124,7 @@ export default {
       type: Array,
       default: () => []
     },
+    bookmarksAvailable: Boolean,
     sleepTimerRunning: Boolean,
     sleepTimeRemaining: Number,
     serverLibraryItemId: String

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -1,16 +1,17 @@
 <template>
   <div>
-    <app-audio-player ref="audioPlayer" :bookmarks="bookmarks" :sleep-timer-running="isSleepTimerRunning" :sleep-time-remaining="sleepTimeRemaining" :serverLibraryItemId="serverLibraryItemId" @selectPlaybackSpeed="showPlaybackSpeedModal = true" @updateTime="(t) => (currentTime = t)" @showSleepTimer="showSleepTimer" @showBookmarks="showBookmarks" />
+    <app-audio-player ref="audioPlayer" :bookmarks="bookmarks" :sleep-timer-running="isSleepTimerRunning" :sleep-time-remaining="sleepTimeRemaining" :serverLibraryItemId="serverLibraryItemId" :bookmarks-available="!!bookmarkIdentity && canUseBookmarkIdentity" @selectPlaybackSpeed="showPlaybackSpeedModal = true" @updateTime="(t) => (currentTime = t)" @showSleepTimer="showSleepTimer" @showBookmarks="showBookmarks" />
 
     <modals-playback-speed-modal v-model="showPlaybackSpeedModal" :playback-rate.sync="playbackSpeed" @update:playbackRate="updatePlaybackSpeed" @change="changePlaybackSpeed" />
     <modals-sleep-timer-modal v-model="showSleepTimerModal" :current-time="sleepTimeRemaining" :sleep-timer-running="isSleepTimerRunning" :current-end-of-chapter-time="currentEndOfChapterTime" :is-auto="isAutoSleepTimer" @change="selectSleepTimeout" @cancel="cancelSleepTimer" @increase="increaseSleepTimer" @decrease="decreaseSleepTimer" />
-    <modals-bookmarks-modal v-model="showBookmarksModal" :bookmarks="bookmarks" :current-time="currentTime" :library-item-id="serverLibraryItemId" :playback-rate="playbackSpeed" @select="selectBookmark" />
+    <modals-bookmarks-modal v-model="showBookmarksModal" :bookmarks="bookmarks" :current-time="currentTime" :library-item-id="serverLibraryItemId" :bookmark-identity="bookmarkIdentity" :playback-rate="playbackSpeed" @select="selectBookmark" />
   </div>
 </template>
 
 <script>
 import { AbsAudioPlayer, AbsLogger } from '@/plugins/capacitor'
 import { Dialog } from '@capacitor/dialog'
+import { identityForItem, isIdentityForActiveAccount } from '@/plugins/bookmarks'
 import CellularPermissionHelpers from '@/mixins/cellularPermissionHelpers'
 
 export default {
@@ -41,10 +42,32 @@ export default {
     }
   },
   mixins: [CellularPermissionHelpers],
+  watch: {
+    currentPlaybackSession: {
+      immediate: true,
+      handler() {
+        this.loadBookmarksForCurrentItem()
+      }
+    },
+    serverLibraryItemId() {
+      this.loadBookmarksForCurrentItem()
+    }
+  },
   computed: {
     bookmarks() {
-      if (!this.serverLibraryItemId) return []
-      return this.$store.getters['user/getUserBookmarksForItem'](this.serverLibraryItemId)
+      if (!this.bookmarkIdentity || !this.canUseBookmarkIdentity) return []
+      return this.$store.getters['bookmarks/getBookmarksForIdentity'](this.bookmarkIdentity)
+    },
+    bookmarkIdentity() {
+      const session = this.currentPlaybackSession
+      const libraryItemId = this.serverLibraryItemId || session?.libraryItemId || session?.localLibraryItem?.libraryItemId
+      return identityForItem(libraryItemId, session, this.$store)
+    },
+    canUseBookmarkIdentity() {
+      const activeUser = this.$store.state.user.user
+      const activeConfig = this.$store.state.user.serverConnectionConfig
+      if (!activeUser || !activeConfig) return true
+      return isIdentityForActiveAccount(this.bookmarkIdentity, this.$store)
     },
     isIos() {
       return this.$platform === 'ios'
@@ -54,6 +77,24 @@ export default {
     }
   },
   methods: {
+    async loadBookmarksForCurrentItem() {
+      const session = this.currentPlaybackSession
+      const sessionItemId = session?.libraryItemId || session?.localLibraryItem?.libraryItemId
+      const libraryItemId = this.serverLibraryItemId || sessionItemId
+      if (!libraryItemId) return
+      if (!this.serverLibraryItemId && sessionItemId) this.serverLibraryItemId = sessionItemId
+
+      const identity = identityForItem(libraryItemId, session, this.$store)
+      if (!identity) return
+      if (!this.canUseBookmarkIdentity) return
+      const canSync = this.$store.state.networkConnected && isIdentityForActiveAccount(identity, this.$store)
+      const serverBookmarks = canSync ? this.$store.state.user.user?.bookmarks || null : null
+      try {
+        await this.$store.dispatch('bookmarks/loadForItem', { identity, serverBookmarks, sync: canSync })
+      } catch (error) {
+        console.error('[AudioPlayerContainer] Failed to load bookmarks', error)
+      }
+    },
     showBookmarks() {
       this.showBookmarksModal = true
     },

--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -900,6 +900,7 @@ export default {
       this.$store.commit('user/setUser', user)
       this.$store.commit('user/setAccessToken', serverConnectionConfig.token)
       this.$store.commit('user/setServerConnectionConfig', serverConnectionConfig)
+      await this.$store.dispatch('bookmarks/syncActiveAccount')
 
       this.$socket.connect(this.serverConfig.address, this.serverConfig.token)
       this.$router.replace('/bookshelf')

--- a/components/modals/BookmarksModal.vue
+++ b/components/modals/BookmarksModal.vue
@@ -24,7 +24,7 @@
         </div>
         <div class="w-full h-full" v-else>
           <template v-for="bookmark in bookmarks">
-            <modals-bookmarks-bookmark-item :key="bookmark.id" :highlight="currentTime === bookmark.time" :bookmark="bookmark" :playback-rate="_playbackRate" @click="clickBookmark" @edit="editBookmark" @delete="deleteBookmark" />
+            <modals-bookmarks-bookmark-item :key="bookmark.libraryItemId + '-' + bookmark.time" :highlight="Math.floor(currentTime) === bookmark.time" :bookmark="bookmark" :playback-rate="_playbackRate" @click="clickBookmark" @edit="editBookmark" @delete="deleteBookmark" />
           </template>
           <div v-if="!bookmarks.length" class="flex h-32 items-center justify-center">
             <p class="text-xl">{{ $strings.MessageNoBookmarks }}</p>
@@ -58,6 +58,7 @@ export default {
       type: Number,
       default: 1
     },
+    bookmarkIdentity: Object,
     libraryItemId: String
   },
   data() {
@@ -85,7 +86,7 @@ export default {
       }
     },
     canCreateBookmark() {
-      return !this.bookmarks.find((bm) => bm.time === this.currentTime)
+      return !this.bookmarks.find((bm) => bm.time === Math.floor(this.currentTime))
     },
     _playbackRate() {
       if (!this.playbackRate || isNaN(this.playbackRate)) return 1
@@ -110,25 +111,21 @@ export default {
       })
       if (!value) return
 
-      this.$nativeHttp
-        .delete(`/api/me/item/${this.libraryItemId}/bookmark/${bm.time}`)
-        .then(() => {
-          this.$store.commit('user/deleteBookmark', { libraryItemId: this.libraryItemId, time: bm.time })
-        })
-        .catch((error) => {
-          this.$toast.error(this.$strings.ToastBookmarkRemoveFailed)
-          console.error(error)
-        })
+      try {
+        await this.$store.dispatch('bookmarks/deleteBookmark', { identity: this.bookmarkIdentity, libraryItemId: this.libraryItemId, time: bm.time })
+      } catch (error) {
+        this.$toast.error(this.$strings.ToastBookmarkRemoveFailed)
+        console.error(error)
+      }
     },
     async clickBookmark(bm) {
       await this.$hapticsImpact()
       this.$emit('select', bm)
     },
     submitUpdateBookmark(updatedBookmark) {
-      this.$nativeHttp
-        .patch(`/api/me/item/${this.libraryItemId}/bookmark`, updatedBookmark)
-        .then((bookmark) => {
-          this.$store.commit('user/updateBookmark', bookmark)
+      this.$store
+        .dispatch('bookmarks/updateBookmark', { identity: this.bookmarkIdentity, bookmark: updatedBookmark })
+        .then(() => {
           this.showBookmarkTitleInput = false
         })
         .catch((error) => {
@@ -142,16 +139,12 @@ export default {
       }
       const bookmark = {
         title: this.newBookmarkTitle,
+        libraryItemId: this.libraryItemId,
         time: Math.floor(this.currentTime)
       }
-      this.$nativeHttp
-        .post(`/api/me/item/${this.libraryItemId}/bookmark`, bookmark)
-        .then(() => {
-          this.$toast.success('Bookmark added')
-        })
-        .catch((error) => {
-          this.$toast.error(this.$strings.ToastBookmarkCreateFailed)
-          console.error(error)
+      this.$store.dispatch('bookmarks/createBookmark', { identity: this.bookmarkIdentity, bookmark }).catch((error) => {
+        this.$toast.error(this.$strings.ToastBookmarkCreateFailed)
+        console.error(error)
         })
 
       this.newBookmarkTitle = ''
@@ -169,7 +162,8 @@ export default {
       if (this.selectedBookmark) {
         var updatePayload = {
           ...this.selectedBookmark,
-          title: this.newBookmarkTitle
+          title: this.newBookmarkTitle,
+          libraryItemId: this.libraryItemId,
         }
         this.submitUpdateBookmark(updatePayload)
       } else {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -32,6 +32,7 @@ export default {
   watch: {
     networkConnected: {
       handler(newVal, oldVal) {
+        this.syncActiveBookmarks()
         if (!this.hasMounted) {
           // watcher runs before mount, handling libraries/connection should be handled in mount
           return
@@ -206,6 +207,7 @@ export default {
       this.$store.commit('user/setUser', user)
       this.$store.commit('user/setAccessToken', serverConnectionConfig.token)
       this.$store.commit('user/setServerConnectionConfig', serverConnectionConfig)
+      await this.syncActiveBookmarks()
 
       this.$socket.connect(serverConnectionConfig.address, serverConnectionConfig.token)
 
@@ -235,6 +237,15 @@ export default {
       this.$eventBus.$emit('library-changed')
       this.inittingLibraries = false
     },
+    async syncActiveBookmarks() {
+      if (!this.networkConnected || !this.user) return
+      try {
+        await this.$store.dispatch('bookmarks/syncActiveAccount')
+      } catch (error) {
+        console.error('[default] Failed to sync bookmarks', error)
+      }
+    },
+
     async syncLocalSessions(isFirstSync) {
       if (!this.user) {
         console.log('[default] No need to sync local sessions - not connected to server')
@@ -249,12 +260,14 @@ export default {
         console.log('[default] Successfully synced local sessions')
         // Reload local media progresses
         await this.$store.dispatch('globals/loadLocalMediaProgress')
+        await this.syncActiveBookmarks()
       }
     },
     userUpdated(user) {
       if (this.user?.id == user.id) {
         this.$store.commit('user/setUser', user)
       }
+      this.syncActiveBookmarks()
     },
     async userMediaProgressUpdated(payload) {
       const prog = payload.data // MediaProgress
@@ -323,6 +336,7 @@ export default {
     },
     async visibilityChanged() {
       if (document.visibilityState === 'visible') {
+        await this.syncActiveBookmarks()
         const elapsedTimeOutOfFocus = Date.now() - this.timeLostFocus
         console.log(`✅ [default] device visibility: has focus (${elapsedTimeOutOfFocus}ms out of focus)`)
         // If device out of focus for more than 30s then reload local media progress

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,7 +30,7 @@ export default {
 
   css: ['@/assets/tailwind.css', '@/assets/app.css'],
 
-  plugins: ['@/plugins/server.js', '@/plugins/db.js', '@/plugins/localStore.js', '@/plugins/init.client.js', '@/plugins/axios.js', '@/plugins/capacitor/index.js', '@/plugins/capacitor/AbsAudioPlayer.js', '@/plugins/nativeHttp.js', '@/plugins/toast.js', '@/plugins/constants.js', '@/plugins/haptics.js', '@/plugins/i18n.js'],
+  plugins: ['@/plugins/server.js', '@/plugins/db.js', '@/plugins/localStore.js', '@/plugins/init.client.js', '@/plugins/axios.js', '@/plugins/capacitor/index.js', '@/plugins/capacitor/AbsAudioPlayer.js', '@/plugins/nativeHttp.js', '@/plugins/bookmarks.js', '@/plugins/toast.js', '@/plugins/constants.js', '@/plugins/haptics.js', '@/plugins/i18n.js'],
 
   components: true,
 

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -129,7 +129,7 @@ export class BookmarkService {
     this.localStore = localStore
     this.nativeHttp = nativeHttp
     this.store = store
-    this.syncLocks = new Map()
+    this.operationLocks = new Map()
   }
 
   _identity(identity) {
@@ -157,7 +157,7 @@ export class BookmarkService {
     return cache
   }
 
-  async apply(identity, type, bookmarkOrTime) {
+  async _applyUnlocked(identity, type, bookmarkOrTime) {
     const normalizedIdentity = this._identity(identity)
     const now = Date.now()
     let cache = await this.getCache(normalizedIdentity)
@@ -216,6 +216,11 @@ export class BookmarkService {
     }
 
     return this.localStore.setBookmarkCache(normalizedIdentity, cache)
+  }
+
+  apply(identity, type, bookmarkOrTime) {
+    const normalizedIdentity = this._identity(identity)
+    return this._enqueue(normalizedIdentity, () => this._applyUnlocked(normalizedIdentity, type, bookmarkOrTime))
   }
 
   async fetchServerBookmarks(identity) {
@@ -314,13 +319,27 @@ export class BookmarkService {
     const key = getIdentityKey(normalizedIdentity)
     if (!key) return Promise.resolve({ cache: createEmptyBookmarkCache(normalizedIdentity), error: new Error('Incomplete bookmark identity') })
 
-    const previous = this.syncLocks.get(key) || Promise.resolve()
+    const previous = this.operationLocks.get(key) || Promise.resolve()
     const current = previous.catch(() => {}).then(() => this._syncUnlocked(normalizedIdentity, options))
-    this.syncLocks.set(key, current)
+    this.operationLocks.set(key, current)
     current.then(() => {
-      if (this.syncLocks.get(key) === current) this.syncLocks.delete(key)
+      if (this.operationLocks.get(key) === current) this.operationLocks.delete(key)
     }, () => {
-      if (this.syncLocks.get(key) === current) this.syncLocks.delete(key)
+      if (this.operationLocks.get(key) === current) this.operationLocks.delete(key)
+    })
+    return current
+  }
+
+  _enqueue(identity, operation) {
+    const key = getIdentityKey(identity)
+    if (!key) return operation()
+    const previous = this.operationLocks.get(key) || Promise.resolve()
+    const current = previous.catch(() => {}).then(operation)
+    this.operationLocks.set(key, current)
+    current.then(() => {
+      if (this.operationLocks.get(key) === current) this.operationLocks.delete(key)
+    }, () => {
+      if (this.operationLocks.get(key) === current) this.operationLocks.delete(key)
     })
     return current
   }

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1,0 +1,335 @@
+import { createEmptyBookmarkCache, normalizeBookmarkCache } from '@/plugins/localStore'
+
+export function normalizeTime(time) {
+  const number = Number(time)
+  return Number.isFinite(number) ? Math.floor(number) : null
+}
+
+export function bookmarkKey(time) {
+  const normalizedTime = normalizeTime(time)
+  return normalizedTime === null ? null : String(normalizedTime)
+}
+
+export function normalizeIdentity(identity = {}) {
+  const localItem = identity.localLibraryItem || identity.localItem || {}
+  const serverConfig = identity.serverConnectionConfig || {}
+  return {
+    serverConnectionConfigId: identity.serverConnectionConfigId || identity.serverConfigId || localItem.serverConnectionConfigId || serverConfig.id || null,
+    serverUserId: identity.serverUserId || identity.userId || localItem.serverUserId || identity.user?.id || null,
+    libraryItemId: identity.libraryItemId || identity.serverLibraryItemId || localItem.libraryItemId || null,
+    serverConnectionConfig: identity.serverConnectionConfig || null
+  }
+}
+
+export function getIdentityKey(identity) {
+  const normalized = normalizeIdentity(identity)
+  if (!normalized.serverConnectionConfigId || !normalized.serverUserId || !normalized.libraryItemId) return null
+  return [normalized.serverConnectionConfigId, normalized.serverUserId, normalized.libraryItemId].join(':')
+}
+
+export function identityForItem(libraryItemId, playbackSession, store) {
+  const session = playbackSession || {}
+  const localItem = session.localLibraryItem || {}
+  const storeUser = store?.state?.user?.user
+  const storeConfig = store?.state?.user?.serverConnectionConfig
+  const identity = normalizeIdentity({
+    libraryItemId: libraryItemId || session.libraryItemId || localItem.libraryItemId,
+    serverConnectionConfigId: session.serverConnectionConfigId || localItem.serverConnectionConfigId || storeConfig?.id,
+    serverUserId: session.userId || session.serverUserId || localItem.serverUserId || storeUser?.id,
+    serverConnectionConfig: storeConfig
+  })
+  if (!identity.libraryItemId || !identity.serverConnectionConfigId || !identity.serverUserId) return null
+  return identity
+}
+
+export function isIdentityForActiveAccount(identity, store) {
+  const normalized = normalizeIdentity(identity)
+  const activeConfig = store?.state?.user?.serverConnectionConfig
+  const activeUser = store?.state?.user?.user
+  return !!activeConfig?.id && !!activeUser?.id && normalized.serverConnectionConfigId === activeConfig.id && normalized.serverUserId === activeUser.id
+}
+
+export function normalizeBookmark(bookmark, libraryItemId, localUpdatedAt = 0) {
+  const time = normalizeTime(bookmark?.time)
+  if (time === null) return null
+  return {
+    ...bookmark,
+    libraryItemId: bookmark.libraryItemId || libraryItemId,
+    time,
+    title: bookmark.title == null ? '' : String(bookmark.title),
+    ...(localUpdatedAt ? { localUpdatedAt } : {})
+  }
+}
+
+export function normalizeServerBookmarks(bookmarks, libraryItemId) {
+  const byKey = new Map()
+  for (const bookmark of Array.isArray(bookmarks) ? bookmarks : []) {
+    if (bookmark?.libraryItemId && bookmark.libraryItemId !== libraryItemId) continue
+    const normalized = normalizeBookmark(bookmark, libraryItemId)
+    if (normalized) byKey.set(bookmarkKey(normalized.time), normalized)
+  }
+  return Array.from(byKey.values()).sort((a, b) => a.time - b.time)
+}
+
+function operationPriority(operation) {
+  return { delete: 0, create: 1, update: 2 }[operation.type] ?? 3
+}
+
+export function mergeServerBookmarks(cache, serverBookmarks, identity) {
+  const normalizedIdentity = normalizeIdentity(identity)
+  const normalizedCache = normalizeBookmarkCache(cache, normalizedIdentity)
+  const byKey = new Map(normalizeServerBookmarks(serverBookmarks, normalizedIdentity.libraryItemId).map((bookmark) => [bookmarkKey(bookmark.time), bookmark]))
+  const operations = [...normalizedCache.pendingOperations].sort((a, b) => operationPriority(a) - operationPriority(b))
+
+  for (const operation of operations) {
+    const key = String(operation.bookmarkKey)
+    if (operation.type === 'delete') {
+      byKey.delete(key)
+    } else if (operation.bookmark) {
+      const bookmark = normalizeBookmark(operation.bookmark, normalizedIdentity.libraryItemId, operation.updatedAt || operation.createdAt || 0)
+      if (bookmark) byKey.set(key, bookmark)
+    }
+  }
+
+  for (const key of Object.keys(normalizedCache.tombstones)) {
+    byKey.delete(key)
+  }
+
+  return {
+    ...normalizedCache,
+    serverConnectionConfigId: normalizedIdentity.serverConnectionConfigId,
+    serverUserId: normalizedIdentity.serverUserId,
+    libraryItemId: normalizedIdentity.libraryItemId,
+    bookmarks: Array.from(byKey.values()).sort((a, b) => a.time - b.time)
+  }
+}
+
+function createOperation(type, bookmarkKeyValue, bookmark, now) {
+  const id = 'bookmark-' + now + '-' + Math.random().toString(36).slice(2, 10)
+  return {
+    id,
+    type,
+    bookmarkKey: String(bookmarkKeyValue),
+    ...(bookmark ? { bookmark } : {}),
+    createdAt: now,
+    updatedAt: now,
+    attempts: 0,
+    lastError: null
+  }
+}
+
+function replaceOperation(cache, operation) {
+  const pendingOperations = cache.pendingOperations.filter((candidate) => candidate.bookmarkKey !== operation.bookmarkKey)
+  pendingOperations.push(operation)
+  return { ...cache, pendingOperations }
+}
+
+export class BookmarkService {
+  constructor({ localStore, nativeHttp, store }) {
+    this.localStore = localStore
+    this.nativeHttp = nativeHttp
+    this.store = store
+    this.syncLocks = new Map()
+  }
+
+  _identity(identity) {
+    return normalizeIdentity(identity)
+  }
+
+  _options(identity) {
+    const options = { connectTimeout: 7000, readTimeout: 7000 }
+    if (identity.serverConnectionConfig) options.serverConnectionConfig = identity.serverConnectionConfig
+    return options
+  }
+
+  async getCache(identity) {
+    const normalizedIdentity = this._identity(identity)
+    return this.localStore.getBookmarkCache(normalizedIdentity)
+  }
+
+  async load(identity, serverBookmarks = null) {
+    const normalizedIdentity = this._identity(identity)
+    let cache = await this.getCache(normalizedIdentity)
+    if (Array.isArray(serverBookmarks)) {
+      cache = mergeServerBookmarks(cache, serverBookmarks, normalizedIdentity)
+      await this.localStore.setBookmarkCache(normalizedIdentity, cache)
+    }
+    return cache
+  }
+
+  async apply(identity, type, bookmarkOrTime) {
+    const normalizedIdentity = this._identity(identity)
+    const now = Date.now()
+    let cache = await this.getCache(normalizedIdentity)
+
+    if (type === 'create') {
+      const bookmark = normalizeBookmark(bookmarkOrTime, normalizedIdentity.libraryItemId, now)
+      if (!bookmark) throw new Error('Cannot create a bookmark without a valid time')
+      const key = bookmarkKey(bookmark.time)
+      cache = {
+        ...cache,
+        bookmarks: [...cache.bookmarks.filter((candidate) => bookmarkKey(candidate.time) !== key), bookmark],
+        tombstones: { ...cache.tombstones }
+      }
+      delete cache.tombstones[key]
+      const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
+      if (existing?.type === 'create' || existing?.type === 'update') {
+        cache = replaceOperation(cache, { ...existing, type: 'create', bookmark, updatedAt: now, lastError: null })
+      } else {
+        cache = replaceOperation(cache, createOperation('create', key, bookmark, now))
+      }
+    } else if (type === 'update') {
+      const bookmark = normalizeBookmark(bookmarkOrTime, normalizedIdentity.libraryItemId, now)
+      if (!bookmark) throw new Error('Cannot update a bookmark without a valid time')
+      const key = bookmarkKey(bookmark.time)
+      cache = {
+        ...cache,
+        bookmarks: [...cache.bookmarks.filter((candidate) => bookmarkKey(candidate.time) !== key), bookmark],
+        tombstones: { ...cache.tombstones }
+      }
+      delete cache.tombstones[key]
+      const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
+      if (existing?.type === 'create') {
+        cache = replaceOperation(cache, { ...existing, bookmark: { ...existing.bookmark, ...bookmark }, updatedAt: now, lastError: null })
+      } else {
+        cache = replaceOperation(cache, existing?.type === 'update'
+          ? { ...existing, bookmark, updatedAt: now, lastError: null }
+          : createOperation('update', key, bookmark, now))
+      }
+    } else if (type === 'delete') {
+      const key = bookmarkKey(bookmarkOrTime?.time ?? bookmarkOrTime)
+      if (key === null) throw new Error('Cannot delete a bookmark without a valid time')
+      const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
+      cache = {
+        ...cache,
+        bookmarks: cache.bookmarks.filter((bookmark) => bookmarkKey(bookmark.time) !== key),
+        tombstones: { ...cache.tombstones, [key]: { deletedAt: now } }
+      }
+      if (existing?.type === 'create' && existing.attempts === 0) {
+        cache = { ...cache, pendingOperations: cache.pendingOperations.filter((operation) => operation.bookmarkKey !== key) }
+        delete cache.tombstones[key]
+      } else {
+        cache = replaceOperation(cache, createOperation('delete', key, null, now))
+      }
+    } else {
+      throw new Error('Unsupported bookmark operation: ' + type)
+    }
+
+    return this.localStore.setBookmarkCache(normalizedIdentity, cache)
+  }
+
+  async fetchServerBookmarks(identity) {
+    if (!isIdentityForActiveAccount(identity, this.store)) throw new Error('Bookmark account is not active')
+    const response = await this.nativeHttp.get('/api/me', this._options(identity))
+    const user = response?.user || response
+    return normalizeServerBookmarks(user?.bookmarks || response?.bookmarks || [], identity.libraryItemId)
+  }
+
+  _isNotFound(error) {
+    return error?.status === 404 || /(?:404|not[ -]?found)/i.test(error?.message || '')
+  }
+
+  async _acknowledgeOperation(identity, cache, operation) {
+    const pendingOperations = cache.pendingOperations.filter((candidate) => candidate.id !== operation.id)
+    const tombstones = { ...cache.tombstones }
+    if (operation.type === 'delete') delete tombstones[operation.bookmarkKey]
+    return { ...cache, pendingOperations, tombstones }
+  }
+
+  async _recordFailure(identity, cache, operation, error) {
+    const updatedOperation = {
+      ...operation,
+      attempts: (Number(operation.attempts) || 0) + 1,
+      updatedAt: Date.now(),
+      lastError: error?.message || String(error)
+    }
+    return replaceOperation(cache, updatedOperation)
+  }
+
+  async _syncUnlocked(identity, { refresh = true, serverBookmarks = null } = {}) {
+    const normalizedIdentity = this._identity(identity)
+    let cache = await this.getCache(normalizedIdentity)
+    let latestServerBookmarks = Array.isArray(serverBookmarks) ? normalizeServerBookmarks(serverBookmarks, normalizedIdentity.libraryItemId) : null
+    let lastError = null
+    const operations = [...cache.pendingOperations].sort((a, b) => operationPriority(a) - operationPriority(b))
+
+    if (!isIdentityForActiveAccount(normalizedIdentity, this.store)) return { cache, error: null }
+
+    for (const operation of operations) {
+      const currentOperation = cache.pendingOperations.find((candidate) => candidate.id === operation.id)
+      if (!currentOperation) continue
+      try {
+        const url = '/api/me/item/' + normalizedIdentity.libraryItemId + '/bookmark'
+        if (currentOperation.type === 'delete') {
+          await this.nativeHttp.delete(url + '/' + currentOperation.bookmarkKey, this._options(normalizedIdentity))
+        } else if (currentOperation.type === 'create') {
+          await this.nativeHttp.post(url, currentOperation.bookmark, this._options(normalizedIdentity))
+        } else {
+          await this.nativeHttp.patch(url, currentOperation.bookmark, this._options(normalizedIdentity))
+        }
+        cache = await this._acknowledgeOperation(normalizedIdentity, cache, currentOperation)
+        await this.localStore.setBookmarkCache(normalizedIdentity, cache)
+      } catch (error) {
+        if (currentOperation.type === 'delete' && this._isNotFound(error)) {
+          cache = await this._acknowledgeOperation(normalizedIdentity, cache, currentOperation)
+        } else if (currentOperation.type === 'create') {
+          try {
+            latestServerBookmarks = await this.fetchServerBookmarks(normalizedIdentity)
+            const acknowledged = latestServerBookmarks.some((bookmark) => bookmarkKey(bookmark.time) === currentOperation.bookmarkKey)
+            if (acknowledged) {
+              cache = await this._acknowledgeOperation(normalizedIdentity, cache, currentOperation)
+            } else {
+              cache = await this._recordFailure(normalizedIdentity, cache, currentOperation, error)
+              lastError = error
+            }
+          } catch (refreshError) {
+            cache = await this._recordFailure(normalizedIdentity, cache, currentOperation, error)
+            lastError = refreshError
+          }
+        } else {
+          cache = await this._recordFailure(normalizedIdentity, cache, currentOperation, error)
+          lastError = error
+        }
+        await this.localStore.setBookmarkCache(normalizedIdentity, cache)
+      }
+    }
+
+    if (refresh && latestServerBookmarks === null) {
+      try {
+        latestServerBookmarks = await this.fetchServerBookmarks(normalizedIdentity)
+      } catch (error) {
+        lastError = lastError || error
+      }
+    }
+
+    if (latestServerBookmarks !== null) {
+      cache = mergeServerBookmarks(cache, latestServerBookmarks, normalizedIdentity)
+      await this.localStore.setBookmarkCache(normalizedIdentity, cache)
+    }
+    return { cache, error: lastError }
+  }
+
+  sync(identity, options = {}) {
+    const normalizedIdentity = this._identity(identity)
+    const key = getIdentityKey(normalizedIdentity)
+    if (!key) return Promise.resolve({ cache: createEmptyBookmarkCache(normalizedIdentity), error: new Error('Incomplete bookmark identity') })
+
+    const previous = this.syncLocks.get(key) || Promise.resolve()
+    const current = previous.catch(() => {}).then(() => this._syncUnlocked(normalizedIdentity, options))
+    this.syncLocks.set(key, current)
+    current.then(() => {
+      if (this.syncLocks.get(key) === current) this.syncLocks.delete(key)
+    }, () => {
+      if (this.syncLocks.get(key) === current) this.syncLocks.delete(key)
+    })
+    return current
+  }
+}
+
+export default ({ app, store }, inject) => {
+  inject('bookmarks', new BookmarkService({
+    localStore: app.$localStore,
+    nativeHttp: app.$nativeHttp,
+    store
+  }))
+}

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -1,5 +1,9 @@
 import { createEmptyBookmarkCache, normalizeBookmarkCache } from '@/plugins/localStore'
 
+const MAX_SYNC_ATTEMPTS = 8
+const RETRY_BASE_DELAY_MS = 30000
+const RETRY_MAX_DELAY_MS = 6 * 60 * 60 * 1000
+
 export function normalizeTime(time) {
   const number = Number(time)
   return Number.isFinite(number) ? Math.floor(number) : null
@@ -83,9 +87,8 @@ export function mergeServerBookmarks(cache, serverBookmarks, identity) {
 
   for (const operation of operations) {
     const key = String(operation.bookmarkKey)
-    if (operation.type === 'delete') {
-      byKey.delete(key)
-    } else if (operation.bookmark) {
+    if (operation.type === 'delete') byKey.delete(key)
+    else if (operation.bookmark) {
       const bookmark = normalizeBookmark(operation.bookmark, normalizedIdentity.libraryItemId, operation.updatedAt || operation.createdAt || 0)
       if (bookmark) byKey.set(key, bookmark)
     }
@@ -111,6 +114,8 @@ function createOperation(type, bookmarkKeyValue, bookmark, now) {
     createdAt: now,
     updatedAt: now,
     attempts: 0,
+    nextAttemptAt: 0,
+    permanentFailure: false,
     lastError: null
   }
 }
@@ -125,6 +130,23 @@ function bookmarksEquivalent(serverBookmark, pendingBookmark, libraryItemId) {
   const server = normalizeBookmark(serverBookmark, libraryItemId)
   const pending = normalizeBookmark(pendingBookmark, libraryItemId)
   return !!server && !!pending && server.libraryItemId === pending.libraryItemId && server.time === pending.time && server.title === pending.title
+}
+
+function errorStatus(error) {
+  return Number(error?.status || error?.response?.status) || null
+}
+
+function isPermanentFailure(error) {
+  const status = errorStatus(error)
+  return status >= 400 && status < 500 && ![408, 409, 425, 429].includes(status)
+}
+
+function retryDelay(attempts) {
+  return Math.min(RETRY_BASE_DELAY_MS * (2 ** Math.max(0, attempts - 1)), RETRY_MAX_DELAY_MS)
+}
+
+function canAttempt(operation, now = Date.now()) {
+  return !operation.permanentFailure && (Number(operation.attempts) || 0) < MAX_SYNC_ATTEMPTS && (Number(operation.nextAttemptAt) || 0) <= now
 }
 
 export class BookmarkService {
@@ -168,40 +190,28 @@ export class BookmarkService {
       const bookmark = normalizeBookmark(bookmarkOrTime, normalizedIdentity.libraryItemId, now)
       if (!bookmark) throw new Error('Cannot ' + type + ' a bookmark without a valid time')
       const key = bookmarkKey(bookmark.time)
-      cache = {
-        ...cache,
-        bookmarks: [...cache.bookmarks.filter((candidate) => bookmarkKey(candidate.time) !== key), bookmark],
-        tombstones: { ...cache.tombstones }
-      }
+      cache = { ...cache, bookmarks: [...cache.bookmarks.filter((candidate) => bookmarkKey(candidate.time) !== key), bookmark], tombstones: { ...cache.tombstones } }
       delete cache.tombstones[key]
       const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
       if (type === 'create' && (existing?.type === 'create' || existing?.type === 'update')) {
-        cache = replaceOperation(cache, { ...existing, type: 'create', bookmark, updatedAt: now, lastError: null })
+        cache = replaceOperation(cache, { ...existing, type: 'create', bookmark, updatedAt: now, attempts: 0, nextAttemptAt: 0, permanentFailure: false, lastError: null })
       } else if (type === 'update' && existing?.type === 'create') {
-        cache = replaceOperation(cache, { ...existing, bookmark: { ...existing.bookmark, ...bookmark }, updatedAt: now, lastError: null })
+        cache = replaceOperation(cache, { ...existing, bookmark: { ...existing.bookmark, ...bookmark }, updatedAt: now, attempts: 0, nextAttemptAt: 0, permanentFailure: false, lastError: null })
       } else {
         cache = replaceOperation(cache, existing?.type === type
-          ? { ...existing, bookmark, updatedAt: now, lastError: null }
+          ? { ...existing, bookmark, updatedAt: now, attempts: 0, nextAttemptAt: 0, permanentFailure: false, lastError: null }
           : createOperation(type, key, bookmark, now))
       }
     } else if (type === 'delete') {
       const key = bookmarkKey(bookmarkOrTime?.time ?? bookmarkOrTime)
       if (key === null) throw new Error('Cannot delete a bookmark without a valid time')
       const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
-      cache = {
-        ...cache,
-        bookmarks: cache.bookmarks.filter((bookmark) => bookmarkKey(bookmark.time) !== key),
-        tombstones: { ...cache.tombstones, [key]: { deletedAt: now } }
-      }
+      cache = { ...cache, bookmarks: cache.bookmarks.filter((bookmark) => bookmarkKey(bookmark.time) !== key), tombstones: { ...cache.tombstones, [key]: { deletedAt: now } } }
       if (existing?.type === 'create' && existing.attempts === 0) {
         cache = { ...cache, pendingOperations: cache.pendingOperations.filter((operation) => operation.bookmarkKey !== key) }
         delete cache.tombstones[key]
-      } else {
-        cache = replaceOperation(cache, createOperation('delete', key, null, now))
-      }
-    } else {
-      throw new Error('Unsupported bookmark operation: ' + type)
-    }
+      } else cache = replaceOperation(cache, createOperation('delete', key, null, now))
+    } else throw new Error('Unsupported bookmark operation: ' + type)
 
     return this.localStore.setBookmarkCache(normalizedIdentity, cache)
   }
@@ -230,10 +240,14 @@ export class BookmarkService {
   }
 
   _recordFailure(cache, operation, error) {
+    const attempts = (Number(operation.attempts) || 0) + 1
+    const permanentFailure = isPermanentFailure(error) || attempts >= MAX_SYNC_ATTEMPTS
     return replaceOperation(cache, {
       ...operation,
-      attempts: (Number(operation.attempts) || 0) + 1,
+      attempts,
       updatedAt: Date.now(),
+      nextAttemptAt: permanentFailure ? 0 : Date.now() + retryDelay(attempts),
+      permanentFailure,
       lastError: error?.message || String(error)
     })
   }
@@ -249,28 +263,22 @@ export class BookmarkService {
 
     for (const operation of operations) {
       const currentOperation = cache.pendingOperations.find((candidate) => candidate.id === operation.id)
-      if (!currentOperation) continue
+      if (!currentOperation || !canAttempt(currentOperation)) continue
       try {
         const url = '/api/me/item/' + normalizedIdentity.libraryItemId + '/bookmark'
-        if (currentOperation.type === 'delete') {
-          await this.nativeHttp.delete(url + '/' + currentOperation.bookmarkKey, this._options(normalizedIdentity))
-        } else if (currentOperation.type === 'create') {
-          await this.nativeHttp.post(url, currentOperation.bookmark, this._options(normalizedIdentity))
-        } else {
-          await this.nativeHttp.patch(url, currentOperation.bookmark, this._options(normalizedIdentity))
-        }
+        if (currentOperation.type === 'delete') await this.nativeHttp.delete(url + '/' + currentOperation.bookmarkKey, this._options(normalizedIdentity))
+        else if (currentOperation.type === 'create') await this.nativeHttp.post(url, currentOperation.bookmark, this._options(normalizedIdentity))
+        else await this.nativeHttp.patch(url, currentOperation.bookmark, this._options(normalizedIdentity))
         cache = this._acknowledgeOperation(cache, currentOperation)
         await this.localStore.setBookmarkCache(normalizedIdentity, cache)
       } catch (error) {
-        if (currentOperation.type === 'delete' && this._isNotFound(error)) {
-          cache = this._acknowledgeOperation(cache, currentOperation)
-        } else if (currentOperation.type === 'create') {
+        if (currentOperation.type === 'delete' && this._isNotFound(error)) cache = this._acknowledgeOperation(cache, currentOperation)
+        else if (currentOperation.type === 'create') {
           try {
             latestServerBookmarks = await this.fetchServerBookmarks(normalizedIdentity)
             const acknowledged = latestServerBookmarks.some((bookmark) => bookmarksEquivalent(bookmark, currentOperation.bookmark, normalizedIdentity.libraryItemId))
-            if (acknowledged) {
-              cache = this._acknowledgeOperation(cache, currentOperation)
-            } else {
+            if (acknowledged) cache = this._acknowledgeOperation(cache, currentOperation)
+            else {
               cache = this._recordFailure(cache, currentOperation, error)
               lastError = error
             }
@@ -293,7 +301,6 @@ export class BookmarkService {
         lastError = lastError || error
       }
     }
-
     if (latestServerBookmarks !== null) {
       cache = mergeServerBookmarks(cache, latestServerBookmarks, normalizedIdentity)
       await this.localStore.setBookmarkCache(normalizedIdentity, cache)
@@ -324,9 +331,5 @@ export class BookmarkService {
 }
 
 export default ({ app, store }, inject) => {
-  inject('bookmarks', new BookmarkService({
-    localStore: app.$localStore,
-    nativeHttp: app.$nativeHttp,
-    store
-  }))
+  inject('bookmarks', new BookmarkService({ localStore: app.$localStore, nativeHttp: app.$nativeHttp, store }))
 }

--- a/plugins/bookmarks.js
+++ b/plugins/bookmarks.js
@@ -91,9 +91,7 @@ export function mergeServerBookmarks(cache, serverBookmarks, identity) {
     }
   }
 
-  for (const key of Object.keys(normalizedCache.tombstones)) {
-    byKey.delete(key)
-  }
+  for (const key of Object.keys(normalizedCache.tombstones)) byKey.delete(key)
 
   return {
     ...normalizedCache,
@@ -105,9 +103,8 @@ export function mergeServerBookmarks(cache, serverBookmarks, identity) {
 }
 
 function createOperation(type, bookmarkKeyValue, bookmark, now) {
-  const id = 'bookmark-' + now + '-' + Math.random().toString(36).slice(2, 10)
   return {
-    id,
+    id: 'bookmark-' + now + '-' + Math.random().toString(36).slice(2, 10),
     type,
     bookmarkKey: String(bookmarkKeyValue),
     ...(bookmark ? { bookmark } : {}),
@@ -122,6 +119,12 @@ function replaceOperation(cache, operation) {
   const pendingOperations = cache.pendingOperations.filter((candidate) => candidate.bookmarkKey !== operation.bookmarkKey)
   pendingOperations.push(operation)
   return { ...cache, pendingOperations }
+}
+
+function bookmarksEquivalent(serverBookmark, pendingBookmark, libraryItemId) {
+  const server = normalizeBookmark(serverBookmark, libraryItemId)
+  const pending = normalizeBookmark(pendingBookmark, libraryItemId)
+  return !!server && !!pending && server.libraryItemId === pending.libraryItemId && server.time === pending.time && server.title === pending.title
 }
 
 export class BookmarkService {
@@ -143,8 +146,7 @@ export class BookmarkService {
   }
 
   async getCache(identity) {
-    const normalizedIdentity = this._identity(identity)
-    return this.localStore.getBookmarkCache(normalizedIdentity)
+    return this.localStore.getBookmarkCache(this._identity(identity))
   }
 
   async load(identity, serverBookmarks = null) {
@@ -162,9 +164,9 @@ export class BookmarkService {
     const now = Date.now()
     let cache = await this.getCache(normalizedIdentity)
 
-    if (type === 'create') {
+    if (type === 'create' || type === 'update') {
       const bookmark = normalizeBookmark(bookmarkOrTime, normalizedIdentity.libraryItemId, now)
-      if (!bookmark) throw new Error('Cannot create a bookmark without a valid time')
+      if (!bookmark) throw new Error('Cannot ' + type + ' a bookmark without a valid time')
       const key = bookmarkKey(bookmark.time)
       cache = {
         ...cache,
@@ -173,28 +175,14 @@ export class BookmarkService {
       }
       delete cache.tombstones[key]
       const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
-      if (existing?.type === 'create' || existing?.type === 'update') {
+      if (type === 'create' && (existing?.type === 'create' || existing?.type === 'update')) {
         cache = replaceOperation(cache, { ...existing, type: 'create', bookmark, updatedAt: now, lastError: null })
-      } else {
-        cache = replaceOperation(cache, createOperation('create', key, bookmark, now))
-      }
-    } else if (type === 'update') {
-      const bookmark = normalizeBookmark(bookmarkOrTime, normalizedIdentity.libraryItemId, now)
-      if (!bookmark) throw new Error('Cannot update a bookmark without a valid time')
-      const key = bookmarkKey(bookmark.time)
-      cache = {
-        ...cache,
-        bookmarks: [...cache.bookmarks.filter((candidate) => bookmarkKey(candidate.time) !== key), bookmark],
-        tombstones: { ...cache.tombstones }
-      }
-      delete cache.tombstones[key]
-      const existing = cache.pendingOperations.find((operation) => operation.bookmarkKey === key)
-      if (existing?.type === 'create') {
+      } else if (type === 'update' && existing?.type === 'create') {
         cache = replaceOperation(cache, { ...existing, bookmark: { ...existing.bookmark, ...bookmark }, updatedAt: now, lastError: null })
       } else {
-        cache = replaceOperation(cache, existing?.type === 'update'
+        cache = replaceOperation(cache, existing?.type === type
           ? { ...existing, bookmark, updatedAt: now, lastError: null }
-          : createOperation('update', key, bookmark, now))
+          : createOperation(type, key, bookmark, now))
       }
     } else if (type === 'delete') {
       const key = bookmarkKey(bookmarkOrTime?.time ?? bookmarkOrTime)
@@ -234,21 +222,20 @@ export class BookmarkService {
     return error?.status === 404 || /(?:404|not[ -]?found)/i.test(error?.message || '')
   }
 
-  async _acknowledgeOperation(identity, cache, operation) {
+  _acknowledgeOperation(cache, operation) {
     const pendingOperations = cache.pendingOperations.filter((candidate) => candidate.id !== operation.id)
     const tombstones = { ...cache.tombstones }
     if (operation.type === 'delete') delete tombstones[operation.bookmarkKey]
     return { ...cache, pendingOperations, tombstones }
   }
 
-  async _recordFailure(identity, cache, operation, error) {
-    const updatedOperation = {
+  _recordFailure(cache, operation, error) {
+    return replaceOperation(cache, {
       ...operation,
       attempts: (Number(operation.attempts) || 0) + 1,
       updatedAt: Date.now(),
       lastError: error?.message || String(error)
-    }
-    return replaceOperation(cache, updatedOperation)
+    })
   }
 
   async _syncUnlocked(identity, { refresh = true, serverBookmarks = null } = {}) {
@@ -272,27 +259,27 @@ export class BookmarkService {
         } else {
           await this.nativeHttp.patch(url, currentOperation.bookmark, this._options(normalizedIdentity))
         }
-        cache = await this._acknowledgeOperation(normalizedIdentity, cache, currentOperation)
+        cache = this._acknowledgeOperation(cache, currentOperation)
         await this.localStore.setBookmarkCache(normalizedIdentity, cache)
       } catch (error) {
         if (currentOperation.type === 'delete' && this._isNotFound(error)) {
-          cache = await this._acknowledgeOperation(normalizedIdentity, cache, currentOperation)
+          cache = this._acknowledgeOperation(cache, currentOperation)
         } else if (currentOperation.type === 'create') {
           try {
             latestServerBookmarks = await this.fetchServerBookmarks(normalizedIdentity)
-            const acknowledged = latestServerBookmarks.some((bookmark) => bookmarkKey(bookmark.time) === currentOperation.bookmarkKey)
+            const acknowledged = latestServerBookmarks.some((bookmark) => bookmarksEquivalent(bookmark, currentOperation.bookmark, normalizedIdentity.libraryItemId))
             if (acknowledged) {
-              cache = await this._acknowledgeOperation(normalizedIdentity, cache, currentOperation)
+              cache = this._acknowledgeOperation(cache, currentOperation)
             } else {
-              cache = await this._recordFailure(normalizedIdentity, cache, currentOperation, error)
+              cache = this._recordFailure(cache, currentOperation, error)
               lastError = error
             }
           } catch (refreshError) {
-            cache = await this._recordFailure(normalizedIdentity, cache, currentOperation, error)
+            cache = this._recordFailure(cache, currentOperation, error)
             lastError = refreshError
           }
         } else {
-          cache = await this._recordFailure(normalizedIdentity, cache, currentOperation, error)
+          cache = this._recordFailure(cache, currentOperation, error)
           lastError = error
         }
         await this.localStore.setBookmarkCache(normalizedIdentity, cache)
@@ -318,16 +305,7 @@ export class BookmarkService {
     const normalizedIdentity = this._identity(identity)
     const key = getIdentityKey(normalizedIdentity)
     if (!key) return Promise.resolve({ cache: createEmptyBookmarkCache(normalizedIdentity), error: new Error('Incomplete bookmark identity') })
-
-    const previous = this.operationLocks.get(key) || Promise.resolve()
-    const current = previous.catch(() => {}).then(() => this._syncUnlocked(normalizedIdentity, options))
-    this.operationLocks.set(key, current)
-    current.then(() => {
-      if (this.operationLocks.get(key) === current) this.operationLocks.delete(key)
-    }, () => {
-      if (this.operationLocks.get(key) === current) this.operationLocks.delete(key)
-    })
-    return current
+    return this._enqueue(normalizedIdentity, () => this._syncUnlocked(normalizedIdentity, options))
   }
 
   _enqueue(identity, operation) {

--- a/plugins/localStore.js
+++ b/plugins/localStore.js
@@ -33,6 +33,8 @@ export function normalizeBookmarkCache(cache, identity) {
     ...operation,
     bookmarkKey: String(operation.bookmarkKey),
     attempts: Number(operation.attempts) || 0,
+    nextAttemptAt: Number(operation.nextAttemptAt) || 0,
+    permanentFailure: operation.permanentFailure === true,
     lastError: operation.lastError || null
   })) : []
   const tombstones = cache.tombstones && typeof cache.tombstones === 'object' ? cache.tombstones : {}
@@ -47,6 +49,15 @@ export function normalizeBookmarkCache(cache, identity) {
     pendingOperations,
     tombstones
   }
+}
+
+function isEmptyBookmarkCache(cache) {
+  return !cache.bookmarks.length && !cache.pendingOperations.length && !Object.keys(cache.tombstones).length
+}
+
+function identityKey(identity) {
+  if (!identity?.serverConnectionConfigId || !identity?.serverUserId || !identity?.libraryItemId) return null
+  return [identity.serverConnectionConfigId, identity.serverUserId, identity.libraryItemId].join(':')
 }
 
 class LocalStorage {
@@ -195,8 +206,8 @@ class LocalStorage {
 
   /**
    * Get preference value by key
-   * 
-   * @param {string} key 
+   *
+   * @param {string} key
    * @returns {Promise<string>}
    */
   async getPreferenceByKey(key) {
@@ -223,24 +234,36 @@ class LocalStorage {
     }
   }
 
+  async _setBookmarkIdentities(identities) {
+    const unique = new Map()
+    for (const identity of identities) {
+      const key = identityKey(identity)
+      if (!key) continue
+      unique.set(key, {
+        key,
+        serverConnectionConfigId: identity.serverConnectionConfigId,
+        serverUserId: identity.serverUserId,
+        libraryItemId: identity.libraryItemId
+      })
+    }
+    await Preferences.set({ key: BOOKMARK_IDENTITIES_KEY, value: JSON.stringify(Array.from(unique.values())) })
+  }
+
   async setBookmarkCache(identity, cache) {
     const key = getBookmarkCacheKey(identity)
     if (!key) throw new Error('Cannot persist bookmark cache without server, user, and item identity')
 
     const normalizedCache = normalizeBookmarkCache(cache, identity)
     try {
+      if (isEmptyBookmarkCache(normalizedCache)) {
+        await this.removeBookmarkCache(normalizedCache)
+        return normalizedCache
+      }
+
       await Preferences.set({ key, value: JSON.stringify(normalizedCache) })
       const identities = await this.getBookmarkIdentities()
-      const identityKey = [normalizedCache.serverConnectionConfigId, normalizedCache.serverUserId, normalizedCache.libraryItemId].join(':')
-      const nextIdentities = identities.filter((candidate) => candidate.key !== identityKey)
-      nextIdentities.push({
-        key: identityKey,
-        serverConnectionConfigId: normalizedCache.serverConnectionConfigId,
-        serverUserId: normalizedCache.serverUserId,
-        libraryItemId: normalizedCache.libraryItemId,
-        serverConnectionConfig: identity?.serverConnectionConfig || null
-      })
-      await Preferences.set({ key: BOOKMARK_IDENTITIES_KEY, value: JSON.stringify(nextIdentities) })
+      identities.push(normalizedCache)
+      await this._setBookmarkIdentities(identities)
     } catch (error) {
       console.error('[LocalStorage] Failed to persist bookmark cache', error)
       throw error
@@ -252,7 +275,13 @@ class LocalStorage {
     try {
       const preference = await Preferences.get({ key: BOOKMARK_IDENTITIES_KEY }) || {}
       const identities = preference.value ? JSON.parse(preference.value) : []
-      return Array.isArray(identities) ? identities : []
+      if (!Array.isArray(identities)) return []
+      return identities.filter((identity) => identityKey(identity)).map((identity) => ({
+        key: identityKey(identity),
+        serverConnectionConfigId: identity.serverConnectionConfigId,
+        serverUserId: identity.serverUserId,
+        libraryItemId: identity.libraryItemId
+      }))
     } catch (error) {
       console.warn('[LocalStorage] Failed to get bookmark identities', error)
       return []
@@ -264,13 +293,15 @@ class LocalStorage {
     if (!key) return
     try {
       await Preferences.remove({ key })
+      const removeKey = identityKey(identity)
+      const identities = await this.getBookmarkIdentities()
+      await this._setBookmarkIdentities(identities.filter((candidate) => identityKey(candidate) !== removeKey))
     } catch (error) {
       console.error('[LocalStorage] Failed to remove bookmark cache', error)
       throw error
     }
   }
 }
-
 
 export default ({ app, store }, inject) => {
   inject('localStore', new LocalStorage(store))

--- a/plugins/localStore.js
+++ b/plugins/localStore.js
@@ -1,6 +1,7 @@
 import { Preferences } from '@capacitor/preferences'
 
 export const BOOKMARK_CACHE_VERSION = 1
+export const BOOKMARK_IDENTITIES_KEY = `bookmarkCacheIdentities:v${BOOKMARK_CACHE_VERSION}`
 
 export function getBookmarkCacheKey(identity) {
   const parts = [identity?.serverConnectionConfigId, identity?.serverUserId, identity?.libraryItemId]
@@ -229,11 +230,33 @@ class LocalStorage {
     const normalizedCache = normalizeBookmarkCache(cache, identity)
     try {
       await Preferences.set({ key, value: JSON.stringify(normalizedCache) })
+      const identities = await this.getBookmarkIdentities()
+      const identityKey = [normalizedCache.serverConnectionConfigId, normalizedCache.serverUserId, normalizedCache.libraryItemId].join(':')
+      const nextIdentities = identities.filter((candidate) => candidate.key !== identityKey)
+      nextIdentities.push({
+        key: identityKey,
+        serverConnectionConfigId: normalizedCache.serverConnectionConfigId,
+        serverUserId: normalizedCache.serverUserId,
+        libraryItemId: normalizedCache.libraryItemId,
+        serverConnectionConfig: identity?.serverConnectionConfig || null
+      })
+      await Preferences.set({ key: BOOKMARK_IDENTITIES_KEY, value: JSON.stringify(nextIdentities) })
     } catch (error) {
       console.error('[LocalStorage] Failed to persist bookmark cache', error)
       throw error
     }
     return normalizedCache
+  }
+
+  async getBookmarkIdentities() {
+    try {
+      const preference = await Preferences.get({ key: BOOKMARK_IDENTITIES_KEY }) || {}
+      const identities = preference.value ? JSON.parse(preference.value) : []
+      return Array.isArray(identities) ? identities : []
+    } catch (error) {
+      console.warn('[LocalStorage] Failed to get bookmark identities', error)
+      return []
+    }
   }
 
   async removeBookmarkCache(identity) {

--- a/plugins/localStore.js
+++ b/plugins/localStore.js
@@ -1,5 +1,53 @@
 import { Preferences } from '@capacitor/preferences'
 
+export const BOOKMARK_CACHE_VERSION = 1
+
+export function getBookmarkCacheKey(identity) {
+  const parts = [identity?.serverConnectionConfigId, identity?.serverUserId, identity?.libraryItemId]
+  if (parts.some((part) => !part)) return null
+  return `bookmarkCache:v${BOOKMARK_CACHE_VERSION}:${parts.map((part) => encodeURIComponent(String(part))).join(':')}`
+}
+
+export function createEmptyBookmarkCache(identity) {
+  return {
+    version: BOOKMARK_CACHE_VERSION,
+    serverConnectionConfigId: identity?.serverConnectionConfigId || null,
+    serverUserId: identity?.serverUserId || null,
+    libraryItemId: identity?.libraryItemId || null,
+    bookmarks: [],
+    pendingOperations: [],
+    tombstones: {}
+  }
+}
+
+export function normalizeBookmarkCache(cache, identity) {
+  const empty = createEmptyBookmarkCache(identity)
+  if (!cache || cache.version !== BOOKMARK_CACHE_VERSION) return empty
+
+  const bookmarks = Array.isArray(cache.bookmarks) ? cache.bookmarks.filter((bookmark) => bookmark && Number.isFinite(Number(bookmark.time))).map((bookmark) => ({
+    ...bookmark,
+    time: Math.floor(Number(bookmark.time))
+  })) : []
+  const pendingOperations = Array.isArray(cache.pendingOperations) ? cache.pendingOperations.filter((operation) => operation && ['create', 'update', 'delete'].includes(operation.type) && operation.bookmarkKey != null).map((operation) => ({
+    ...operation,
+    bookmarkKey: String(operation.bookmarkKey),
+    attempts: Number(operation.attempts) || 0,
+    lastError: operation.lastError || null
+  })) : []
+  const tombstones = cache.tombstones && typeof cache.tombstones === 'object' ? cache.tombstones : {}
+
+  return {
+    ...empty,
+    ...cache,
+    serverConnectionConfigId: identity?.serverConnectionConfigId || cache.serverConnectionConfigId,
+    serverUserId: identity?.serverUserId || cache.serverUserId,
+    libraryItemId: identity?.libraryItemId || cache.libraryItemId,
+    bookmarks,
+    pendingOperations,
+    tombstones
+  }
+}
+
 class LocalStorage {
   constructor(vuexStore) {
     this.vuexStore = vuexStore
@@ -157,6 +205,45 @@ class LocalStorage {
     } catch (error) {
       console.error(`[LocalStorage] Failed to get preference "${key}"`, error)
       return null
+    }
+  }
+
+  async getBookmarkCache(identity) {
+    const key = getBookmarkCacheKey(identity)
+    if (!key) return createEmptyBookmarkCache(identity)
+
+    try {
+      const preference = await Preferences.get({ key }) || {}
+      if (!preference.value) return createEmptyBookmarkCache(identity)
+      return normalizeBookmarkCache(JSON.parse(preference.value), identity)
+    } catch (error) {
+      console.warn('[LocalStorage] Failed to get bookmark cache; using an empty cache', error)
+      return createEmptyBookmarkCache(identity)
+    }
+  }
+
+  async setBookmarkCache(identity, cache) {
+    const key = getBookmarkCacheKey(identity)
+    if (!key) throw new Error('Cannot persist bookmark cache without server, user, and item identity')
+
+    const normalizedCache = normalizeBookmarkCache(cache, identity)
+    try {
+      await Preferences.set({ key, value: JSON.stringify(normalizedCache) })
+    } catch (error) {
+      console.error('[LocalStorage] Failed to persist bookmark cache', error)
+      throw error
+    }
+    return normalizedCache
+  }
+
+  async removeBookmarkCache(identity) {
+    const key = getBookmarkCacheKey(identity)
+    if (!key) return
+    try {
+      await Preferences.remove({ key })
+    } catch (error) {
+      console.error('[LocalStorage] Failed to remove bookmark cache', error)
+      throw error
     }
   }
 }

--- a/store/bookmarks.js
+++ b/store/bookmarks.js
@@ -93,11 +93,27 @@ export const actions = {
     const persistedIdentities = await this.$localStore.getBookmarkIdentities()
     const identitiesByKey = new Map(Object.values(state.identitiesByKey).map((identity) => [getIdentityKey(identity), identity]))
     for (const identity of persistedIdentities) {
-      identitiesByKey.set(getIdentityKey(identity), { ...identity, serverConnectionConfig: activeConfig })
+      const key = getIdentityKey(identity)
+      if (key) identitiesByKey.set(key, { ...identity, serverConnectionConfig: activeConfig })
     }
     const identities = Array.from(identitiesByKey.values()).filter((identity) => isIdentityForActiveAccount(identity, this))
+    if (!identities.length) return
+
+    let serverBookmarks = null
+    try {
+      const response = await this.$nativeHttp.get('/api/me', {
+        connectTimeout: 7000,
+        readTimeout: 7000,
+        serverConnectionConfig: activeConfig
+      })
+      const user = response?.user || response
+      serverBookmarks = user?.bookmarks || response?.bookmarks || []
+    } catch (error) {
+      console.warn('[bookmarks] Failed to prefetch server bookmarks; pending operations will still be attempted', error)
+    }
+
     for (const identity of identities) {
-      await dispatch('syncForIdentity', { identity })
+      await dispatch('syncForIdentity', { identity, serverBookmarks })
     }
   },
 

--- a/store/bookmarks.js
+++ b/store/bookmarks.js
@@ -1,12 +1,14 @@
 import Vue from 'vue'
 import { getIdentityKey, identityForItem, isIdentityForActiveAccount } from '@/plugins/bookmarks'
 
+export const BOOKMARK_CONFLICT_POLICY = 'local-pending-wins'
 export const namespaced = true
 
 export const state = () => ({
   activeIdentity: null,
   cachedByIdentity: {},
   identitiesByKey: {},
+  conflictPolicy: BOOKMARK_CONFLICT_POLICY,
   syncStatus: 'idle',
   syncError: null
 })
@@ -19,6 +21,7 @@ export const getters = {
   hasPendingOperations: (state) => {
     return Object.values(state.cachedByIdentity).some((cache) => cache.pendingOperations?.length)
   },
+  getConflictPolicy: (state) => state.conflictPolicy,
   getSyncStatus: (state) => state.syncStatus,
   getSyncError: (state) => state.syncError
 }
@@ -112,6 +115,9 @@ export const actions = {
       console.warn('[bookmarks] Failed to prefetch server bookmarks; pending operations will still be attempted', error)
     }
 
+    // Conflict policy: an explicit local pending operation represents the newest
+    // user intent on this device and overlays fetched server state until the
+    // operation is acknowledged. Once the queue is empty, server state wins.
     for (const identity of identities) {
       await dispatch('syncForIdentity', { identity, serverBookmarks })
     }

--- a/store/bookmarks.js
+++ b/store/bookmarks.js
@@ -1,0 +1,124 @@
+import Vue from 'vue'
+import { getIdentityKey, identityForItem, isIdentityForActiveAccount } from '@/plugins/bookmarks'
+
+export const namespaced = true
+
+export const state = () => ({
+  activeIdentity: null,
+  cachedByIdentity: {},
+  identitiesByKey: {},
+  syncStatus: 'idle',
+  syncError: null
+})
+
+export const getters = {
+  getBookmarksForIdentity: (state) => (identity) => {
+    const key = getIdentityKey(identity)
+    return key ? state.cachedByIdentity[key]?.bookmarks || [] : []
+  },
+  hasPendingOperations: (state) => {
+    return Object.values(state.cachedByIdentity).some((cache) => cache.pendingOperations?.length)
+  },
+  getSyncStatus: (state) => state.syncStatus,
+  getSyncError: (state) => state.syncError
+}
+
+function commitCache(commit, cache, identity) {
+  commit('replaceLocalState', {
+    libraryItemId: identity.libraryItemId,
+    identity,
+    bookmarks: cache.bookmarks,
+    cache
+  })
+}
+
+export const actions = {
+  async loadForItem({ commit, dispatch, rootState }, { identity, serverBookmarks = null, sync = false } = {}) {
+    if (!identity?.libraryItemId) return []
+    const cache = await this.$bookmarks.load(identity, serverBookmarks)
+    commitCache(commit, cache, identity)
+    if (sync && rootState.networkConnected && isIdentityForActiveAccount(identity, this)) {
+      dispatch('syncForIdentity', { identity }).catch((error) => console.error('[bookmarks] Background sync failed', error))
+    }
+    return cache.bookmarks
+  },
+
+  async createBookmark({ dispatch, state, rootState }, { identity: requestedIdentity, bookmark } = {}) {
+    const identity = requestedIdentity || state.activeIdentity
+    if (!identity || identity.libraryItemId !== bookmark?.libraryItemId) throw new Error('No active bookmark item')
+    const cache = await this.$bookmarks.apply(identity, 'create', bookmark)
+    this.commit('bookmarks/replaceLocalState', { libraryItemId: identity.libraryItemId, identity, bookmarks: cache.bookmarks, cache })
+    if (rootState.networkConnected && isIdentityForActiveAccount(identity, this)) {
+      dispatch('syncForIdentity', { identity }).catch((error) => console.error('[bookmarks] Create sync failed', error))
+    }
+    return cache.bookmarks
+  },
+
+  async updateBookmark({ dispatch, state, rootState }, { identity: requestedIdentity, bookmark } = {}) {
+    const identity = requestedIdentity || state.activeIdentity
+    if (!identity || identity.libraryItemId !== bookmark?.libraryItemId) throw new Error('No active bookmark item')
+    const cache = await this.$bookmarks.apply(identity, 'update', bookmark)
+    this.commit('bookmarks/replaceLocalState', { libraryItemId: identity.libraryItemId, identity, bookmarks: cache.bookmarks, cache })
+    if (rootState.networkConnected && isIdentityForActiveAccount(identity, this)) {
+      dispatch('syncForIdentity', { identity }).catch((error) => console.error('[bookmarks] Update sync failed', error))
+    }
+    return cache.bookmarks
+  },
+
+  async deleteBookmark({ dispatch, state, rootState }, { identity: requestedIdentity, libraryItemId, time }) {
+    const identity = requestedIdentity || state.activeIdentity
+    if (!identity || identity.libraryItemId !== libraryItemId) throw new Error('No active bookmark item')
+    const cache = await this.$bookmarks.apply(identity, 'delete', time)
+    this.commit('bookmarks/replaceLocalState', { libraryItemId, identity, bookmarks: cache.bookmarks, cache })
+    if (rootState.networkConnected && isIdentityForActiveAccount(identity, this)) {
+      dispatch('syncForIdentity', { identity }).catch((error) => console.error('[bookmarks] Delete sync failed', error))
+    }
+    return cache.bookmarks
+  },
+
+  async syncForIdentity({ commit }, { identity, serverBookmarks = null } = {}) {
+    if (!identity?.libraryItemId) return []
+    commit('setSyncStatus', { status: 'syncing', error: null })
+    const result = await this.$bookmarks.sync(identity, { serverBookmarks })
+    commitCache(commit, result.cache, identity)
+    commit('setSyncStatus', { status: result.error ? 'error' : 'idle', error: result.error ? result.error.message : null })
+    return result.cache.bookmarks
+  },
+
+  async syncActiveAccount({ state, dispatch, rootState }) {
+    const activeConfig = rootState.user.serverConnectionConfig
+    const activeUser = rootState.user.user
+    if (!activeConfig?.id || !activeUser?.id || !rootState.networkConnected) return
+
+    const identities = Object.values(state.identitiesByKey).filter((identity) => isIdentityForActiveAccount(identity, this))
+    for (const identity of identities) {
+      await dispatch('syncForIdentity', { identity })
+    }
+  },
+
+  async importServerBookmarks({ state, dispatch, rootState }, bookmarks) {
+    if (!rootState.networkConnected) return
+    const identities = Object.values(state.identitiesByKey).filter((identity) => isIdentityForActiveAccount(identity, this))
+    for (const identity of identities) {
+      await dispatch('loadForItem', { identity, serverBookmarks: bookmarks, sync: false })
+    }
+  },
+
+  resolveIdentity({ rootState }, { libraryItemId, playbackSession } = {}) {
+    return identityForItem(libraryItemId, playbackSession, this)
+  }
+}
+
+export const mutations = {
+  replaceLocalState(state, { identity, cache }) {
+    const key = getIdentityKey(identity)
+    if (!key) return
+    Vue.set(state.cachedByIdentity, key, cache)
+    Vue.set(state.identitiesByKey, key, identity)
+    state.activeIdentity = identity
+  },
+  setSyncStatus(state, { status, error }) {
+    state.syncStatus = status
+    state.syncError = error || null
+  }
+}

--- a/store/bookmarks.js
+++ b/store/bookmarks.js
@@ -90,7 +90,12 @@ export const actions = {
     const activeUser = rootState.user.user
     if (!activeConfig?.id || !activeUser?.id || !rootState.networkConnected) return
 
-    const identities = Object.values(state.identitiesByKey).filter((identity) => isIdentityForActiveAccount(identity, this))
+    const persistedIdentities = await this.$localStore.getBookmarkIdentities()
+    const identitiesByKey = new Map(Object.values(state.identitiesByKey).map((identity) => [getIdentityKey(identity), identity]))
+    for (const identity of persistedIdentities) {
+      identitiesByKey.set(getIdentityKey(identity), { ...identity, serverConnectionConfig: activeConfig })
+    }
+    const identities = Array.from(identitiesByKey.values()).filter((identity) => isIdentityForActiveAccount(identity, this))
     for (const identity of identities) {
       await dispatch('syncForIdentity', { identity })
     }


### PR DESCRIPTION
## Brief summary

  Add offline-first audiobook bookmarks with durable local caching and queued
  synchronization.

  ## Which issue is fixed?

  Offline playback currently loses bookmarks and disables bookmark controls.
  This PR fixes offline bookmark persistence and synchronization.
#163 

  ## Pull Request Type

  Both Android and iOS. Frontend and Capacitor JavaScript changes only; native
  database schemas are unchanged.

  ## In-depth Description

  Bookmarks are now cached through Capacitor Preferences using an account- and
  library-item-specific identity.

  The implementation:

  - Restores bookmarks during offline playback.
  - Applies create, edit, and delete actions locally immediately.
  - Queues pending operations for later synchronization.
  - Preserves local changes across app restarts.
  - Synchronizes after login, reconnect, foreground resume, and network
  recovery.
  - Prevents bookmark data from leaking between server accounts.
  - Allows bookmark controls without requiring an active WebSocket connection.
  - Handles retries, delete-not-found responses, and ambiguous create responses.

  ## How have you tested this?

  - `npm run build`
  - `npm run sync`
  - `./gradlew assembleDebug`
  - JavaScript and Vue syntax checks
  - `git diff --check`
  - In-memory bookmark queue tests
  - Account-isolation test using the same library item across two accounts
  - Verified APK installation artifact generation

  ## Screenshots

  Not included. The UI changes are limited to enabling and wiring the existing
  bookmark controls.
