### PR TITLE
Fix custom folder downloads stuck at 0% on Android 17

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -63,6 +63,7 @@ class DownloadItemManager(
 
   companion object {
     var isDownloading: Boolean = false
+    private const val APP_MANAGED_DOWNLOAD_ID = -1L
   }
 
   /** Adds a download item to the queue and starts processing the queue. */
@@ -100,20 +101,31 @@ class DownloadItemManager(
   /** Processes the download item parts. */
   private fun processDownloadItemParts(nextDownloadItemParts: List<DownloadItemPart>) {
     nextDownloadItemParts.forEach {
-      if (it.isInternalStorage) {
-        startInternalDownload(it)
-      } else {
-        startExternalDownload(it)
-      }
+      startAppManagedDownload(it)
     }
   }
 
-  /** Starts an internal download. */
-  private fun startInternalDownload(downloadItemPart: DownloadItemPart) {
-    val file = File(downloadItemPart.finalDestinationPath)
+  /** Starts a download into app-owned storage before optional SAF move to a custom folder. */
+  private fun startAppManagedDownload(downloadItemPart: DownloadItemPart) {
+    val destinationPath =
+            if (downloadItemPart.isInternalStorage) {
+              downloadItemPart.finalDestinationPath
+            } else {
+              downloadItemPart.destinationUri.path
+            }
+
+    if (destinationPath.isNullOrEmpty()) {
+      Log.e(tag, "Start app managed download failed, destination path missing")
+      downloadItemPart.failed = true
+      downloadItemPart.completed = true
+      downloadItemPart.downloadId = APP_MANAGED_DOWNLOAD_ID
+      currentDownloadItemParts.add(downloadItemPart)
+      return
+    }
+
+    val file = File(destinationPath)
     file.parentFile?.mkdirs()
 
-    val fileOutputStream = FileOutputStream(downloadItemPart.finalDestinationPath)
     val internalProgressCallback =
             object : InternalProgressCallback {
               override fun onProgress(totalBytesWritten: Long, progress: Long) {
@@ -129,11 +141,18 @@ class DownloadItemManager(
 
     Log.d(
             tag,
-            "Start internal download to destination path ${downloadItemPart.finalDestinationPath} from ${downloadItemPart.serverUrl}"
+            "Start app managed download to destination path $destinationPath from ${downloadItemPart.serverUrl}"
     )
-    InternalDownloadManager(fileOutputStream, internalProgressCallback)
-            .download(downloadItemPart.serverUrl)
-    downloadItemPart.downloadId = 1
+    try {
+      val fileOutputStream = FileOutputStream(destinationPath)
+      InternalDownloadManager(fileOutputStream, internalProgressCallback)
+              .download(downloadItemPart.serverUrl)
+    } catch (e: Exception) {
+      Log.e(tag, "Failed to start app managed download to $destinationPath", e)
+      downloadItemPart.failed = true
+      downloadItemPart.completed = true
+    }
+    downloadItemPart.downloadId = APP_MANAGED_DOWNLOAD_ID
     currentDownloadItemParts.add(downloadItemPart)
   }
 
@@ -157,8 +176,8 @@ class DownloadItemManager(
       while (currentDownloadItemParts.isNotEmpty()) {
         val itemParts = currentDownloadItemParts.filter { !it.isMoving }
         for (downloadItemPart in itemParts) {
-          if (downloadItemPart.isInternalStorage) {
-            handleInternalDownloadPart(downloadItemPart)
+          if (downloadItemPart.downloadId == APP_MANAGED_DOWNLOAD_ID) {
+            handleAppManagedDownloadPart(downloadItemPart)
           } else {
             handleExternalDownloadPart(downloadItemPart)
           }
@@ -176,14 +195,24 @@ class DownloadItemManager(
     }
   }
 
-  /** Handles an internal download part. */
-  private fun handleInternalDownloadPart(downloadItemPart: DownloadItemPart) {
+  /** Handles a download part written by the app-owned downloader. */
+  private fun handleAppManagedDownloadPart(downloadItemPart: DownloadItemPart) {
     clientEventEmitter.onDownloadItemPartUpdate(downloadItemPart)
 
     if (downloadItemPart.completed) {
       val downloadItem = downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }
-      downloadItem?.let { checkDownloadItemFinished(it) }
-      currentDownloadItemParts.remove(downloadItemPart)
+      if (downloadItem == null) {
+        Log.e(
+                tag,
+                "Download item part finished but download item not found ${downloadItemPart.filename}"
+        )
+        currentDownloadItemParts.remove(downloadItemPart)
+      } else if (!downloadItemPart.isInternalStorage && !downloadItemPart.failed) {
+        moveDownloadedFile(downloadItem, downloadItemPart)
+      } else {
+        checkDownloadItemFinished(downloadItem)
+        currentDownloadItemParts.remove(downloadItemPart)
+      }
     }
   }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -12,7 +12,7 @@ import okhttp3.*
  * @property progressCallback The callback to report download progress.
  */
 class InternalDownloadManager(
-        private val outputStream: FileOutputStream,
+        private val outputStream: OutputStream,
         private val progressCallback: DownloadItemManager.InternalProgressCallback
 ) : AutoCloseable {
 
@@ -35,21 +35,47 @@ class InternalDownloadManager(
                     object : Callback {
                       override fun onFailure(call: Call, e: IOException) {
                         Log.e(tag, "Download URL $url FAILED", e)
+                        closeOutput()
                         progressCallback.onComplete(true)
                       }
 
                       override fun onResponse(call: Call, response: Response) {
-                        response.body?.let { responseBody ->
-                          val length: Long = response.header("Content-Length")?.toLongOrNull() ?: 0L
-                          writer.write(responseBody.byteStream(), length)
+                        response.use {
+                          if (!it.isSuccessful) {
+                            Log.e(tag, "Download URL $url failed with response code ${it.code}")
+                            closeOutput()
+                            progressCallback.onComplete(true)
+                            return
+                          }
+
+                          it.body?.let { responseBody ->
+                            try {
+                              val length: Long = responseBody.contentLength()
+                              writer.write(responseBody.byteStream(), length)
+                            } catch (e: IOException) {
+                              Log.e(tag, "Download URL $url failed while writing response", e)
+                              progressCallback.onComplete(true)
+                            } finally {
+                              closeOutput()
+                            }
+                          }
+                                  ?: run {
+                                    Log.e(tag, "Response doesn't contain a file")
+                                    closeOutput()
+                                    progressCallback.onComplete(true)
+                                  }
                         }
-                                ?: run {
-                                  Log.e(tag, "Response doesn't contain a file")
-                                  progressCallback.onComplete(true)
-                                }
                       }
                     }
             )
+  }
+
+  private fun closeOutput() {
+    try {
+      close()
+    } catch (e: Exception) {
+      Log.e(tag, "Failed to close download output stream", e)
+    }
   }
 
   /**
@@ -91,7 +117,8 @@ class BinaryFileWriter(
       while (input.read(dataBuffer).also { readBytes = it } != -1) {
         totalBytes += readBytes
         outputStream.write(dataBuffer, 0, readBytes)
-        progressCallback.onProgress(totalBytes, (totalBytes * 100L) / length)
+        val progress = if (length > 0L) (totalBytes * 100L) / length else 0L
+        progressCallback.onProgress(totalBytes, progress)
       }
       progressCallback.onComplete(false)
       return totalBytes

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
@@ -132,7 +132,15 @@ class AbsDownloader : Plugin() {
   private fun startLibraryItemDownload(libraryItem: LibraryItem, localFolder: LocalFolder, episode:PodcastEpisode?) {
     val isInternal = localFolder.id.startsWith("internal-")
 
-    val tempFolderPath = if (isInternal) "${mainActivity.filesDir}/downloads/${libraryItem.id}" else mainActivity.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+    val tempFolderPath =
+            if (isInternal) {
+              File(mainActivity.filesDir, "downloads/${libraryItem.id}").absolutePath
+            } else {
+              val externalDownloadsDir =
+                      mainActivity.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)
+                              ?: mainActivity.filesDir
+              File(externalDownloadsDir, "downloads/${libraryItem.id}").absolutePath
+            }
 
     Log.d(tag, "downloadCacheDirectory=$tempFolderPath")
 


### PR DESCRIPTION
## Summary
- Fixes Android custom-folder downloads that could start but remain stuck at 0% on Android 17 devices.
- Routes custom-folder downloads through the app-managed OkHttp downloader instead of Android DownloadManager.
- Keeps the existing SAF move into the selected folder after each temp download completes.
- Hardens download stream handling by closing output streams reliably, failing non-success HTTP responses, and avoiding divide-by-zero when content length is unknown.

## Context
On Android, internal/default downloads already used the app-managed downloader. Custom-folder downloads used a different path: Android DownloadManager fetched into an app temp file, then the app moved the completed file into the selected SAF folder. On Android 17 this path could appear to start but never report progress or produce files in the selected folder.

This change removes DownloadManager from the custom-folder fetch path so both internal and custom-folder downloads use the same app-managed download behavior. Custom-folder downloads still use SAF for the final move into the user-selected folder.

## Testing
- Built debug APK with ./gradlew assembleDebug.
- Installed the debug APK locally on an Android 17 Pixel.
- Verified a book download to a custom folder progresses beyond 0% and completes successfully.