### PR TITLE
Fix Android downloads to custom folders stuck at 0%

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -1,6 +1,5 @@
 package com.audiobookshelf.app.managers
 
-import android.app.DownloadManager
 import android.net.Uri
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
@@ -28,7 +27,6 @@ import kotlinx.coroutines.launch
 
 /** Manages download items and their parts. */
 class DownloadItemManager(
-        var downloadManager: DownloadManager,
         private var folderScanner: FolderScanner,
         var mainActivity: MainActivity,
         private var clientEventEmitter: DownloadEventEmitter
@@ -38,12 +36,6 @@ class DownloadItemManager(
   private var jacksonMapper =
           jacksonObjectMapper()
                   .enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
-
-  enum class DownloadCheckStatus {
-    InProgress,
-    Successful,
-    Failed
-  }
 
   var downloadItemQueue: MutableList<DownloadItem> =
           mutableListOf() // All pending and downloading items
@@ -108,12 +100,27 @@ class DownloadItemManager(
     }
   }
 
-  /** Starts an internal download. */
+  /** Starts an internal download, writing directly to its final destination. */
   private fun startInternalDownload(downloadItemPart: DownloadItemPart) {
-    val file = File(downloadItemPart.finalDestinationPath)
+    startFileDownload(downloadItemPart, downloadItemPart.finalDestinationPath)
+  }
+
+  /**
+   * Starts an external (custom SAF folder) download to a cache path, later moved into place by
+   * moveDownloadedFile(). Avoids the system DownloadManager: on API 29+ its destination must be
+   * app-owned or the top-level Downloads dir, which a custom folder is neither.
+   * See https://developer.android.com/privacy-and-security/risks/unsafe-download-manager
+   */
+  private fun startExternalDownload(downloadItemPart: DownloadItemPart) {
+    startFileDownload(downloadItemPart, downloadItemPart.destinationPath)
+  }
+
+  /** Downloads a download item part's contents to [destinationPath] via OkHttp/FileOutputStream. */
+  private fun startFileDownload(downloadItemPart: DownloadItemPart, destinationPath: String) {
+    val file = File(destinationPath)
     file.parentFile?.mkdirs()
 
-    val fileOutputStream = FileOutputStream(downloadItemPart.finalDestinationPath)
+    val fileOutputStream = FileOutputStream(destinationPath)
     val internalProgressCallback =
             object : InternalProgressCallback {
               override fun onProgress(totalBytesWritten: Long, progress: Long) {
@@ -127,22 +134,10 @@ class DownloadItemManager(
               }
             }
 
-    Log.d(
-            tag,
-            "Start internal download to destination path ${downloadItemPart.finalDestinationPath} from ${downloadItemPart.serverUrl}"
-    )
+    Log.d(tag, "Start download to destination path $destinationPath from ${downloadItemPart.serverUrl}")
     InternalDownloadManager(fileOutputStream, internalProgressCallback)
             .download(downloadItemPart.serverUrl)
     downloadItemPart.downloadId = 1
-    currentDownloadItemParts.add(downloadItemPart)
-  }
-
-  /** Starts an external download. */
-  private fun startExternalDownload(downloadItemPart: DownloadItemPart) {
-    val dlRequest = downloadItemPart.getDownloadRequest()
-    val downloadId = downloadManager.enqueue(dlRequest)
-    downloadItemPart.downloadId = downloadId
-    Log.d(tag, "checkUpdateDownloadQueue: Starting download item part, downloadId=$downloadId")
     currentDownloadItemParts.add(downloadItemPart)
   }
 
@@ -176,103 +171,39 @@ class DownloadItemManager(
     }
   }
 
+  /** Finds the parent download item for [downloadItemPart], if it's still queued. */
+  private fun findDownloadItem(downloadItemPart: DownloadItemPart): DownloadItem? =
+          downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }
+
+  /** Finishes [downloadItem] if all its parts are done, and drops [downloadItemPart] from the active list. */
+  private fun finishDownloadItemPart(downloadItem: DownloadItem?, downloadItemPart: DownloadItemPart) {
+    downloadItem?.let { checkDownloadItemFinished(it) }
+    currentDownloadItemParts.remove(downloadItemPart)
+  }
+
   /** Handles an internal download part. */
   private fun handleInternalDownloadPart(downloadItemPart: DownloadItemPart) {
     clientEventEmitter.onDownloadItemPartUpdate(downloadItemPart)
 
     if (downloadItemPart.completed) {
-      val downloadItem = downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }
-      downloadItem?.let { checkDownloadItemFinished(it) }
-      currentDownloadItemParts.remove(downloadItemPart)
+      finishDownloadItemPart(findDownloadItem(downloadItemPart), downloadItemPart)
     }
   }
 
-  /** Handles an external download part. */
+  /** Handles an external download part: moves it into its SAF folder once downloaded. */
   private fun handleExternalDownloadPart(downloadItemPart: DownloadItemPart) {
-    val downloadCheckStatus = checkDownloadItemPart(downloadItemPart)
     clientEventEmitter.onDownloadItemPartUpdate(downloadItemPart)
 
-    // Will move to final destination, remove current item parts, and check if download item is
-    // finished
-    handleDownloadItemPartCheck(downloadCheckStatus, downloadItemPart)
-  }
+    if (!downloadItemPart.completed) return
 
-  /** Checks the status of a download item part. */
-  private fun checkDownloadItemPart(downloadItemPart: DownloadItemPart): DownloadCheckStatus {
-    val downloadId = downloadItemPart.downloadId ?: return DownloadCheckStatus.Failed
-
-    val query = DownloadManager.Query().setFilterById(downloadId)
-    downloadManager.query(query).use {
-      if (it.moveToFirst()) {
-        val bytesColumnIndex = it.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
-        val statusColumnIndex = it.getColumnIndex(DownloadManager.COLUMN_STATUS)
-        val bytesDownloadedColumnIndex =
-                it.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
-
-        val totalBytes = if (bytesColumnIndex >= 0) it.getInt(bytesColumnIndex) else 0
-        val downloadStatus = if (statusColumnIndex >= 0) it.getInt(statusColumnIndex) else 0
-        val bytesDownloadedSoFar =
-                if (bytesDownloadedColumnIndex >= 0) it.getLong(bytesDownloadedColumnIndex) else 0
-        Log.d(
-                tag,
-                "checkDownloads Download ${downloadItemPart.filename} bytes $totalBytes | bytes dled $bytesDownloadedSoFar | downloadStatus $downloadStatus"
-        )
-
-        return when (downloadStatus) {
-          DownloadManager.STATUS_SUCCESSFUL -> {
-            Log.d(tag, "checkDownloads Download ${downloadItemPart.filename} Successful")
-            downloadItemPart.completed = true
-            downloadItemPart.progress = 1
-            downloadItemPart.bytesDownloaded = bytesDownloadedSoFar
-
-            DownloadCheckStatus.Successful
-          }
-          DownloadManager.STATUS_FAILED -> {
-            Log.d(tag, "checkDownloads Download ${downloadItemPart.filename} Failed")
-            downloadItemPart.completed = true
-            downloadItemPart.failed = true
-
-            DownloadCheckStatus.Failed
-          }
-          else -> {
-            val percentProgress =
-                    if (totalBytes > 0) ((bytesDownloadedSoFar * 100L) / totalBytes) else 0
-            Log.d(
-                    tag,
-                    "checkDownloads Download ${downloadItemPart.filename} Progress = $percentProgress%"
-            )
-            downloadItemPart.progress = percentProgress
-            downloadItemPart.bytesDownloaded = bytesDownloadedSoFar
-
-            DownloadCheckStatus.InProgress
-          }
-        }
-      } else {
-        Log.d(tag, "Download ${downloadItemPart.filename} not found in dlmanager")
-        downloadItemPart.completed = true
-        downloadItemPart.failed = true
-        return DownloadCheckStatus.Failed
+    val downloadItem = findDownloadItem(downloadItemPart)
+    when {
+      downloadItem == null -> {
+        Log.e(tag, "Download item part finished but download item not found ${downloadItemPart.filename}")
+        currentDownloadItemParts.remove(downloadItemPart)
       }
-    }
-  }
-
-  /** Handles the result of a download item part check. */
-  private fun handleDownloadItemPartCheck(
-          downloadCheckStatus: DownloadCheckStatus,
-          downloadItemPart: DownloadItemPart
-  ) {
-    val downloadItem = downloadItemQueue.find { it.id == downloadItemPart.downloadItemId }
-    if (downloadItem == null) {
-      Log.e(
-              tag,
-              "Download item part finished but download item not found ${downloadItemPart.filename}"
-      )
-      currentDownloadItemParts.remove(downloadItemPart)
-    } else if (downloadCheckStatus == DownloadCheckStatus.Successful) {
-      moveDownloadedFile(downloadItem, downloadItemPart)
-    } else if (downloadCheckStatus != DownloadCheckStatus.InProgress) {
-      checkDownloadItemFinished(downloadItem)
-      currentDownloadItemParts.remove(downloadItemPart)
+      downloadItemPart.failed -> finishDownloadItemPart(downloadItem, downloadItemPart)
+      else -> moveDownloadedFile(downloadItem, downloadItemPart)
     }
   }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
@@ -1,6 +1,5 @@
 package com.audiobookshelf.app.models
 
-import android.app.DownloadManager
 import android.net.Uri
 import android.util.Log
 import com.audiobookshelf.app.data.AudioTrack
@@ -16,6 +15,7 @@ data class DownloadItemPart(
   val downloadItemId: String,
   val filename: String,
   val fileSize: Long,
+  val destinationPath: String,
   val finalDestinationPath:String,
   val serverPath: String,
   val localFolderName: String,
@@ -53,6 +53,7 @@ data class DownloadItemPart(
         downloadItemId,
         filename = filename,
         fileSize = fileSize,
+        destinationPath = destinationFile.absolutePath,
         finalDestinationPath = finalDestinationFile.absolutePath,
         serverPath = serverPath,
         localFolderName = localFolder.name,
@@ -81,14 +82,4 @@ data class DownloadItemPart(
 
   @get:JsonIgnore
   val serverUrl get() = uri.toString()
-
-  @JsonIgnore
-  fun getDownloadRequest(): DownloadManager.Request {
-    val dlRequest = DownloadManager.Request(uri)
-    dlRequest.setTitle(filename)
-    dlRequest.setDescription("Downloading to $localFolderName with filename $filename")
-    dlRequest.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE)
-    dlRequest.setDestinationUri(destinationUri)
-    return dlRequest
-  }
 }

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
@@ -1,7 +1,5 @@
 package com.audiobookshelf.app.plugins
 
-import android.app.DownloadManager
-import android.content.Context
 import android.os.Environment
 import android.util.Log
 import com.audiobookshelf.app.MainActivity
@@ -27,7 +25,6 @@ class AbsDownloader : Plugin() {
   private var jacksonMapper = jacksonObjectMapper().enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
 
   lateinit var mainActivity: MainActivity
-  lateinit var downloadManager: DownloadManager
   lateinit var apiHandler: ApiHandler
   lateinit var folderScanner: FolderScanner
   lateinit var downloadItemManager: DownloadItemManager
@@ -46,10 +43,9 @@ class AbsDownloader : Plugin() {
 
   override fun load() {
     mainActivity = (activity as MainActivity)
-    downloadManager = activity.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
     folderScanner = FolderScanner(mainActivity)
     apiHandler = ApiHandler(mainActivity)
-    downloadItemManager = DownloadItemManager(downloadManager, folderScanner, mainActivity, clientEventEmitter)
+    downloadItemManager = DownloadItemManager(folderScanner, mainActivity, clientEventEmitter)
   }
 
   @PluginMethod


### PR DESCRIPTION
## Brief summary

Fixes downloads to a custom local folder getting stuck at "Downloading... (0%)" indefinitely and never completing. Downloads to Internal Storage were unaffected.

## Which issue is fixed?

Fixes #1273

## Pull Request Type

Android only. Native/backend change (Kotlin) — no frontend, UI, or iOS changes.

## In-depth Description

Downloads to a custom SAF-picked folder were routed through the system `DownloadManager` via `DownloadManager.Request.setDestinationUri()` with a raw `file://` URI. On API 29+, `DownloadManager` only permits destinations that are either app-owned or the top-level Downloads directory — a user-picked custom folder is neither, so the enqueued download silently sat at `STATUS_PAUSED` with 0 bytes downloaded, permission or no permission. This is a hard platform restriction, not a fixable permission gap (see [Android's own documentation](https://developer.android.com/privacy-and-security/risks/unsafe-download-manager)), and this code path had been unchanged since January 2023.

A recent Android/Pixel OS update appears to have tightened enforcement of this restriction — verified via a controlled test across two physical devices (a Pixel 7a and a Pixel 9a), where the same production app version downloaded successfully to a custom folder on the 9a until it received the same OS update the 7a had already gotten, at which point both devices exhibited identical failures. So this isn't limited to old OS versions or specific hardware — it will likely affect more users as their devices take routine OS updates.

The fix routes custom-folder downloads through the same OkHttp/`FileOutputStream` mechanism already used (and already working) for Internal Storage downloads, caching into the app's own external files directory before moving the finished file into the user's chosen folder via the existing, unmodified Storage Access Framework move step (`moveDownloadedFile()` / `moveFileTo()`). This removes the system `DownloadManager` dependency from downloads entirely, along with its dead status-polling code, and unifies what were previously two divergent code paths into one.

Trade-off: downloads no longer get automatic retry/resume on a dropped network connection, or an OS-level download notification — both were only ever provided by the system `DownloadManager`, and Internal Storage downloads already lived without them, so this isn't a new class of risk, just extending an existing, working approach to the second path.

## How have you tested this?

Manually, on a physical Pixel 7a (Android 15) connected via ADB:
1. Built a debug APK (`./gradlew assembleDebug`) and installed it via `adb install -r`.
2. Reproduced the original failure first: downloading to a custom folder named "Audiobooks" got stuck at 0% indefinitely (confirmed via live `logcat`, tracks stuck at `STATUS_PAUSED`, `bytesDownloaded=0`).
3. Applied the fix, rebuilt, reinstalled.
4. Retried the same download to the same "Audiobooks" custom folder while tailing `logcat`. Confirmed all chapter files and cover art downloaded, moved into the custom folder, and the app logged `Download Item finished` followed by successful local library item creation.
5. Confirmed Internal Storage downloads are unaffected (unchanged code path).
6. Full debug build passes (`./gradlew assembleDebug` — BUILD SUCCESSFUL, no new warnings introduced).

No automated test coverage exists for the downloader in this repo (`app/src/test` / `app/src/androidTest` contain only unmodified Capacitor boilerplate), so this PR relies on the manual on-device verification above.

## Screenshots

Not applicable — this PR contains no frontend/UI changes.