### PR TITLE
Remember sort & filter options for podcast episodes

### DIFF
--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -234,8 +234,8 @@ export default {
     },
     sortDesc: {
       get() {
-        const desc = this.$store.state.user.settings.podcastEpisodesOrderDesc
-        if (desc === null || desc === undefined) return this.mediaMetadata.type === 'episodic'
+        const desc = this.$store.getters['user/getUserSetting']('podcastEpisodesOrderDesc')
+        if (desc == null) return this.mediaMetadata.type === 'episodic'
         return desc
       },
       set(val) {

--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -50,7 +50,7 @@
 
     <modals-podcast-episodes-feed-modal v-model="showPodcastEpisodeFeed" :library-item="libraryItem" :episodes="podcastFeedEpisodes" />
 
-    <modals-order-modal v-model="showSortModal" :order-by.sync="sortKey" :descending.sync="sortDesc" episodes />
+    <modals-order-modal v-model="showSortModal" :order-by.sync="sortKey" :descending.sync="sortDesc" episodes @change="saveSort" />
   </div>
 </template>
 
@@ -79,9 +79,9 @@ export default {
       episodesCopy: [],
       showFiltersModal: false,
       showSortModal: false,
-      sortKey: 'publishedAt',
-      sortDesc: true,
-      filterKey: 'incomplete',
+      sortKey: this.$store.state.user.settings.podcastEpisodesOrderBy || 'publishedAt',
+      sortDesc: this.$store.state.user.settings.podcastEpisodesOrderDesc,
+      filterKey: this.$store.state.user.settings.podcastEpisodesFilterBy || 'incomplete',
       fetchingRSSFeed: false,
       podcastFeedEpisodes: [],
       showPodcastEpisodeFeed: false,
@@ -279,6 +279,10 @@ export default {
     setFilter(filter) {
       this.filterKey = filter
       this.showFiltersModal = false
+      this.$store.dispatch('user/updateUserSettings', { podcastEpisodesFilterBy: filter })
+    },
+    saveSort() {
+      this.$store.dispatch('user/updateUserSettings', { podcastEpisodesOrderBy: this.sortKey, podcastEpisodesOrderDesc: this.sortDesc })
     },
     showFilters() {
       this.showFiltersModal = true
@@ -291,7 +295,6 @@ export default {
       return this.$store.getters['user/getUserMediaProgress'](this.libraryItemId, episode.id)
     },
     init() {
-      this.sortDesc = this.mediaMetadata.type === 'episodic'
       this.episodesCopy = this.episodes.map((ep) => {
         return { ...ep }
       })
@@ -315,6 +318,10 @@ export default {
     }
   },
   mounted() {
+    if (this.sortDesc === null || this.sortDesc === undefined) {
+      this.sortDesc = this.mediaMetadata.type === 'episodic'
+    }
+
     if (this.$route.query['episodefilter'] === 'downloaded') {
       this.filterKey = 'downloaded'
     }

--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -234,7 +234,7 @@ export default {
     },
     sortDesc: {
       get() {
-        const desc = this.$store.getters['user/getUserSetting']('podcastEpisodesOrderDesc')
+        const desc = this.$store.state.user.settings.podcastEpisodesOrderDesc
         if (desc === null || desc === undefined) return this.mediaMetadata.type === 'episodic'
         return desc
       },

--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -50,7 +50,7 @@
 
     <modals-podcast-episodes-feed-modal v-model="showPodcastEpisodeFeed" :library-item="libraryItem" :episodes="podcastFeedEpisodes" />
 
-    <modals-order-modal v-model="showSortModal" :order-by.sync="sortKey" :descending.sync="sortDesc" episodes @change="saveSort" />
+    <modals-order-modal v-model="showSortModal" :order-by.sync="sortKey" :descending.sync="sortDesc" episodes />
   </div>
 </template>
 
@@ -79,9 +79,6 @@ export default {
       episodesCopy: [],
       showFiltersModal: false,
       showSortModal: false,
-      sortKey: this.$store.state.user.settings.podcastEpisodesOrderBy || 'publishedAt',
-      sortDesc: this.$store.state.user.settings.podcastEpisodesOrderDesc,
-      filterKey: this.$store.state.user.settings.podcastEpisodesFilterBy || 'incomplete',
       fetchingRSSFeed: false,
       podcastFeedEpisodes: [],
       showPodcastEpisodeFeed: false,
@@ -223,6 +220,27 @@ export default {
       if (!this.sortKey) return ''
       const _sel = this.episodeSortItems.find((i) => i.value === this.sortKey)
       return _sel?.text || ''
+    },
+    filterKey() {
+      return this.$store.getters['user/getUserSetting']('podcastEpisodesFilterBy') || 'incomplete'
+    },
+    sortKey: {
+      get() {
+        return this.$store.getters['user/getUserSetting']('podcastEpisodesOrderBy') || 'publishedAt'
+      },
+      set(val) {
+        this.$store.dispatch('user/updateUserSettings', { podcastEpisodesOrderBy: val })
+      }
+    },
+    sortDesc: {
+      get() {
+        const desc = this.$store.getters['user/getUserSetting']('podcastEpisodesOrderDesc')
+        if (desc === null || desc === undefined) return this.mediaMetadata.type === 'episodic'
+        return desc
+      },
+      set(val) {
+        this.$store.dispatch('user/updateUserSettings', { podcastEpisodesOrderDesc: val })
+      }
     }
   },
   methods: {
@@ -277,12 +295,8 @@ export default {
       this.$store.commit('globals/setShowPlaylistsAddCreateModal', true)
     },
     setFilter(filter) {
-      this.filterKey = filter
       this.showFiltersModal = false
       this.$store.dispatch('user/updateUserSettings', { podcastEpisodesFilterBy: filter })
-    },
-    saveSort() {
-      this.$store.dispatch('user/updateUserSettings', { podcastEpisodesOrderBy: this.sortKey, podcastEpisodesOrderDesc: this.sortDesc })
     },
     showFilters() {
       this.showFiltersModal = true
@@ -318,12 +332,8 @@ export default {
     }
   },
   mounted() {
-    if (this.sortDesc === null || this.sortDesc === undefined) {
-      this.sortDesc = this.mediaMetadata.type === 'episodic'
-    }
-
     if (this.$route.query['episodefilter'] === 'downloaded') {
-      this.filterKey = 'downloaded'
+      this.$store.dispatch('user/updateUserSettings', { podcastEpisodesFilterBy: 'downloaded' })
     }
     this.$socket.$on('episode_download_queued', this.episodeDownloadQueued)
     this.$socket.$on('episode_download_started', this.episodeDownloadStarted)

--- a/store/user.js
+++ b/store/user.js
@@ -48,7 +48,7 @@ export const getters = {
     return state.user.bookmarks.filter((bm) => bm.libraryItemId === libraryItemId)
   },
   getUserSetting: (state) => (key) => {
-    return state.settings?.[key] || null
+    return state.settings?.[key] ?? null
   },
   getUserCanUpdate: (state) => {
     return !!state.user?.permissions?.update

--- a/store/user.js
+++ b/store/user.js
@@ -12,7 +12,10 @@ export const state = () => ({
     mobileFilterBy: 'all',
     playbackRate: 1,
     collapseSeries: false,
-    collapseBookSeries: false
+    collapseBookSeries: false,
+    podcastEpisodesOrderBy: 'publishedAt',
+    podcastEpisodesOrderDesc: null,
+    podcastEpisodesFilterBy: 'incomplete'
   }
 })
 


### PR DESCRIPTION
## Brief summary

Fixes a pet-peeve bug/missing feature I noticed, namely that podcast episode sorting/filtering options weren't saved and always defaulted to "incomplete".

## Which issue is fixed?

Fixes #304

## Pull Request Type

Affects both Android and iOS, frontend only.

## In-depth Description

I will disclaimer that I am not a Node/JS/mobile developer, so the coding was done using Claude. It took several rounds as I immediately noticed the solutions were totally different than the rest of the codebase.

I do want to bring up something Claude noticed, but I refused to change as I'm not familiar enough with the code base, snippet (it's talking about [Fix ascending bug](https://github.com/advplyr/audiobookshelf-app/commit/9562e8f25271693116060a77dc1d309c081a5a0e)):

> Root cause: getUserSetting uses ||, collapsing falsy-but-valid values (false, 0, '') to null. Broke podcastEpisodesOrderDesc: false (ascending).
> Fix, store/user.js:51:
return state.settings?.[key] ?? null

Reasoning is that function is called many other places and since this isn't my field of expertise, I'd rather not change it blindly.

If you don't want AI assisted code merged, I totally understand. I'll keep using this build for myself until a fix is merged upstream some other way.

## How have you tested this?

In the Android emulator and on a Pixel 9 Pro. I have not tested the iOS app but I do have a Mac so I could perhaps try it on the emulator if need be.

It's pretty simple to test, in the master branch, any changes to sorting/filtering for podcasts are lost when navigating away, either going back or tapping on a podcast episode. The scroll position is maintained.

With this branch, this doesn't happen. Both sorting and filtering are preserved when going into an episode or backing out.

## Screenshots

I don't think this is necessary, if you insist I can add a video later.
