### PR TITLE
Added progress for download.

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/services/DownloadService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/services/DownloadService.kt
@@ -74,11 +74,23 @@ class DownloadService : Service() {
             .setSmallIcon(R.drawable.icon)
             .setContentTitle(DownloadServiceHost.notificationStrings(this).downloads)
             .setContentText(text)
+            .setContentIntent(appLaunchIntent())
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .setOnlyAlertOnce(true)
             .setOngoing(true)
+            .setAutoCancel(false)
             .setProgress(100, progress, !determinate)
             .addAction(0, DownloadServiceHost.notificationStrings(this).cancel, cancelIntent)
             .build()
+  }
+
+  private fun appLaunchIntent(): PendingIntent {
+    val intent = Intent(this, com.audiobookshelf.app.MainActivity::class.java)
+            .setAction(Intent.ACTION_MAIN)
+            .addCategory(Intent.CATEGORY_LAUNCHER)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+    return PendingIntent.getActivity(this, 0, intent, pendingIntentFlags())
   }
 
   private fun createChannel() {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Adding notification to android app that seems to help with background downloading of files, this is something I have seen other apps do and it keeps the app in focus so downloads complete.  

## Which issue is fixed?

#4802 and maybe #1479 

## Pull Request Type

iOS and Android, back end 

## In-depth Description

Honestly I poked around at it for a while because this has been bugging me. 

## How have you tested this?

Tested only on Android Pixel 9a 

## Screenshots

Only front end change is download bar from  os.
