### PR TITLE
Restart finished local media from the beginning

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/LocalLibraryItem.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/LocalLibraryItem.kt
@@ -111,7 +111,7 @@ class LocalLibraryItem(
     // Get current progress for local media
     val mediaProgressId = if (localEpisodeId.isNullOrEmpty()) id else "$id-$localEpisodeId"
     val mediaProgress = DeviceManager.dbManager.getLocalMediaProgress(mediaProgressId)
-    val currentTime = mediaProgress?.currentTime ?: 0.0
+    val currentTime = if (mediaProgress?.isFinished == true) 0.0 else mediaProgress?.currentTime ?: 0.0
 
 
     val mediaMetadata = media.metadata

--- a/android/app/src/main/java/com/audiobookshelf/app/data/LocalMediaProgress.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/LocalMediaProgress.kt
@@ -46,6 +46,10 @@ class LocalMediaProgress(
       progress = if (finished) 1.0 else 0.0
     }
 
+    if (finished) {
+      currentTime = 0.0
+    }
+
     isFinished = finished
     lastUpdate = System.currentTimeMillis()
     finishedAt = if (isFinished) lastUpdate else null


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Finished local books now start from 0:00 instead of resuming at the stored progress position.

## Which issue is fixed?

Fixes #1946 

## Pull Request Type

Android only, native (Kotlin). No frontend changes.

## In-depth Description

`LocalLibraryItem.getPlaybackSession` reads `mediaProgress?.currentTime` unconditionally, so a book marked finished began playback at whatever position was stored rather than at the beginning.

The guard is applied at the read site rather than by zeroing `currentTime` on write, for two reasons. It covers every route that can set `isFinished` — local mark-finished, playback completion, and server sync via `updateFromServerMediaProgress` — rather than needing each writer patched individually. And it is non-destructive: the stored position is preserved, so clearing the finished flag restores it, whereas zeroing on write discards it permanently.

For reference, iOS already zeroes `currentTime` in its own `updateIsFinished`, and Android's `AbsDatabase.updateLocalMediaProgressFinished` does the same when it *creates* a progress record — only the Android update path leaves the stale value behind.

iOS has the same unguarded read in its `getPlaybackSession` (`ios/App/Shared/models/local/LocalLibraryItem.swift`). It is left alone in this PR since I have no way to build or test it, but it likely warrants the same one-line guard.

## How have you tested this?

Reproduced on a Pixel 10 Pro XL running Android 17, app version 0.13.0-beta:

1. Downloaded a book for offline playback
2. Played a few seconds so a progress position was stored, then paused
3. Marked the book as finished from the item menu
4. Pressed play — playback resumed at the stored position instead of starting over

Confirmed via logcat, where the seek on play matched the stored position rather than 0:

onPositionDiscontinuity: oldPosition=0/0, newPosition=29950/0, isPlaying=false reason=SEEK
STATE_BUFFERING : 29950



Reproduced three times with stored positions of 17.9s, 20.6s, and 29.9s — each play started at the stored value.

After applying the fix and rebuilding, playback of a finished book starts at 0. Unfinished books still resume from their stored position as before.

## Screenshots
None
