### PR TITLE
Download delete fix

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 /** Removes terminally failed downloads after their retention window elapses. */
 object IncompleteDownloadCleanup {
   private const val tag = "IncompleteDownloadCleanup"
-  private const val RETENTION_MS = 5L * 60L * 1000L
+  private const val RETENTION_MS = 24L * 60L * 60L * 1000L
   private const val WORK_PREFIX = "incomplete-download-"
 
   fun schedule(context: Context, item: DownloadItem) {

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 /** Removes terminally failed downloads after their retention window elapses. */
 object IncompleteDownloadCleanup {
   private const val tag = "IncompleteDownloadCleanup"
-  private const val RETENTION_MS = 24L * 60L * 60L * 1000L
+  private const val RETENTION_MS = 5L * 60L * 1000L
   private const val WORK_PREFIX = "incomplete-download-"
 
   fun schedule(context: Context, item: DownloadItem) {

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
@@ -1,9 +1,7 @@
 package com.audiobookshelf.app.managers
 
 import android.content.Context
-import android.net.Uri
 import android.util.Log
-import androidx.documentfile.provider.DocumentFile
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -40,7 +38,12 @@ object IncompleteDownloadCleanup {
     DeviceManager.dbManager.getDownloadItems()
             .filter { item -> isEligible(item, now) }
             .forEach { item ->
-              deleteItem(context, item)
+              item.downloadItemParts.forEach { part ->
+                deleteAppOwnedFile(context, File(part.destinationPath))
+              }
+              DeviceManager.dbManager.removeDownloadItem(item.id)
+              cancel(context, item.id)
+              Log.i(tag, "Deleted terminally failed download item ${item.id}")
             }
   }
 
@@ -50,26 +53,6 @@ object IncompleteDownloadCleanup {
     return item.downloadItemParts.all { part ->
       part.moved || (part.failed && !part.isMoving)
     }
-  }
-
-  private fun deleteItem(context: Context, item: DownloadItem) {
-    item.downloadItemParts.forEach { part ->
-      deleteAppOwnedFile(context, File(part.destinationPath))
-      if (part.isInternalStorage && part.moved) {
-        deleteAppOwnedFile(context, File(part.finalDestinationPath))
-      } else if (!part.isInternalStorage && part.moved) {
-        part.completedDestinationUri?.let { uriString ->
-          try {
-            DocumentFile.fromSingleUri(context, Uri.parse(uriString))?.delete()
-          } catch (e: Exception) {
-            Log.w(tag, "Could not delete expired SAF document for ${part.filename}", e)
-          }
-        }
-      }
-    }
-    DeviceManager.dbManager.removeDownloadItem(item.id)
-    cancel(context, item.id)
-    Log.i(tag, "Deleted terminally failed download item ${item.id}")
   }
 
   private fun deleteAppOwnedFile(context: Context, file: File) {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR updates the Android delete incomplete download logic.

## Which issue is fixed?

Fixes https://github.com/advplyr/audiobookshelf-app/issues/1911#issuecomment-5192178531

## Pull Request Type

Android backend

## In-depth Description

PR https://github.com/advplyr/audiobookshelf-app/pull/1937 made a lot of updates to the Android download logic. One part of this update was to delete incomplete downloads to prevent them from filling up internal storage. Incomplete downloads were checked after 24 hours, and the current behavior is to delete any items that have incomplete file downloads from:
- temporary app storage
- completed Internal App Storage
- completed Shared Storage

This change removes the deletion from Internal App Storage and Shared Storage, so now incomplete file downloads only occur for:
- temporary app storage

This probably needs some more investigation, but since the app was submitted to the play store yesterday, we probably want to prepare for another Android patch release so downloads don't suddenly start disappearing.

## How have you tested this?

Changed incomplete deletion check threshold to 60 seconds (from 24 hours).

I was *unable* to recreate the original issue on Android 16, but figure this is safer behavior regardless.

## Screenshots

N/A