### PR TITLE
Don't clear the saved-state Bundle in onSaveInstanceState

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
@@ -160,7 +160,6 @@ class MainActivity : BridgeActivity() {
   override fun onSaveInstanceState(outState: Bundle) {
     storageHelper.onSaveInstanceState(outState)
     super.onSaveInstanceState(outState)
-    outState.clear()
   }
 
   override fun onRestoreInstanceState(savedInstanceState: Bundle) {


### PR DESCRIPTION
### What

`MainActivity.onSaveInstanceState()` clears the `Bundle` immediately after
`SimpleStorage` has written its state into it:

```kotlin
override fun onSaveInstanceState(outState: Bundle) {
  storageHelper.onSaveInstanceState(outState)
  super.onSaveInstanceState(outState)
  outState.clear()          // <- discards what was just saved
}
```

This removes that one line.

### Why

`storageHelper.onSaveInstanceState(outState)` exists to persist SimpleStorage's
pending request state (the in-flight folder/file picker and permission request
codes) across an activity restart. Clearing the bundle in the same method throws
that away before the framework serializes it, so `onRestoreInstanceState()` gets
nothing back and the library's state is lost on any configuration change or
process death — screen rotation, theme switch, font-size change, returning to
the app after Android has reclaimed it.

The practical symptom is a storage/folder selection flow that silently forgets
where it was if the device rotates while the system picker is up.

### Scope

One line, no behaviour added. `super.onSaveInstanceState(outState)` continues to
do the normal save; only the discard is removed. The paired
`onRestoreInstanceState()` already calls `storageHelper.onRestoreInstanceState(...)`,
so restoration works once the data actually survives.

### Testing

Verified against the current `master` (the line is still present at
`MainActivity.kt:163`). This is a removal of a state-discarding call rather than
new logic, so there is no new code path to exercise — the existing SimpleStorage
save/restore pair simply becomes effective.

Opened as a **draft** — happy to add a targeted rotation test or adjust the
approach if you would rather keep an explicit clear somewhere with different
ordering.