### PR TITLE
Recover interrupted audiobook downloads

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -78,6 +78,16 @@ class DownloadItemManager(
         checkDownloadItemFinished(item)
         return@forEach
       }
+      val recoverTerminalFailure =
+              item.terminalFailureAt != null &&
+                      item.downloadItemParts.any { part ->
+                        part.failed && File(part.destinationPath).exists()
+                      }
+      if (recoverTerminalFailure) {
+        Log.i(tag, "Retrying interrupted download ${item.id}")
+        item.terminalFailureAt = null
+        IncompleteDownloadCleanup.cancel(context, item.id)
+      }
       item.downloadItemParts.forEach { part ->
         if (part.moved) return@forEach
         if (item.terminalFailureAt != null && part.failed) return@forEach

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -138,6 +138,29 @@ class DownloadItemManager(
   }
 
   @Synchronized
+  fun retryDownloadItem(downloadItemId: String): Boolean {
+    val item = downloadItemQueue.find { it.id == downloadItemId } ?: return false
+    if (item.downloadItemParts.any { it in currentDownloadItemParts }) return false
+    if (item.isDownloadFinished) return false
+
+    item.terminalFailureAt = null
+    IncompleteDownloadCleanup.cancel(context, item.id)
+    item.downloadItemParts.filter { !it.moved }.forEach { part ->
+      part.failed = false
+      part.completed = false
+      part.isMoving = false
+      part.waitingForSpace = false
+      part.downloadId = null
+      part.retryCount = 0
+      part.lastUpdateTime = System.currentTimeMillis()
+    }
+    persist(item, force = true)
+    checkUpdateDownloadQueue()
+    notifyQueueChanged()
+    return true
+  }
+
+  @Synchronized
   fun cancelAll() {
     activeCalls.values.forEach(Call::cancel)
     activeCalls.clear()

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.StatFs
 import android.util.Log
 import androidx.documentfile.provider.DocumentFile
+import com.anggrayudi.storage.file.fullName
 import com.audiobookshelf.app.device.DeviceManager
 import com.audiobookshelf.app.device.FolderScanner
 import com.audiobookshelf.app.models.DownloadItem
@@ -374,13 +375,13 @@ class DownloadItemManager(
         }
         if (temporary.length() != staging.length())
                 throw IllegalStateException("SAF copy size mismatch")
-        val existing = folder.findFile(part.filename)
+        val existing = findDocumentByFilename(folder, part)
         if (existing != null && !existing.delete())
                 throw IllegalStateException("Could not replace existing file")
         if (!temporary.renameTo(part.filename))
                 throw IllegalStateException("Could not finalize SAF temporary file")
         val destination =
-                folder.findFile(part.filename)
+                findDocumentByFilename(folder, part)
                         ?: throw IllegalStateException("Could not reopen finalized SAF file")
         if (destination.length() != staging.length())
                 throw IllegalStateException("SAF final size mismatch")
@@ -512,11 +513,32 @@ class DownloadItemManager(
       if (segment == "." || segment == "..") return null
       folder = folder.findFile(segment) ?: return null
     }
-    val file = folder.findFile(part.filename) ?: return null
+    val file = findDocumentByFilename(folder, part) ?: return null
     if (!file.isFile) return null
     if (part.fileSize > 0L && file.length() != part.fileSize) return null
     if (part.fileSize <= 0L && file.length() <= 0L) return null
     return file
+  }
+
+  /**
+   * Some Android document providers hide or add the extension supplied through the MIME type.
+   * In that case DocumentFile.findFile() cannot reopen a file that was just renamed, even though
+   * it is present and complete. Match the provider's display and full names as a fallback.
+   */
+  private fun findDocumentByFilename(
+          folder: DocumentFile,
+          part: DownloadItemPart
+  ): DocumentFile? {
+    folder.findFile(part.filename)?.let { return it }
+    val expectedBaseName = part.filename.substringBeforeLast('.')
+    return folder.listFiles().firstOrNull { document ->
+      document.name == part.filename ||
+              document.fullName == part.filename ||
+              (part.audioTrack != null &&
+                      document.isFile &&
+                      ((document.name ?: "").substringBeforeLast('.') == expectedBaseName ||
+                              document.fullName.substringBeforeLast('.') == expectedBaseName))
+    }
   }
 
   private fun mimeTypeFor(part: DownloadItemPart): String =

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -53,6 +53,19 @@ class InternalDownloadManager(
                       progressCallback.onComplete(false)
                       return
                     }
+                    if (response.code == 416 && existingBytes > 0L) {
+                      Log.w(
+                              tag,
+                              "Server rejected resume offset $existingBytes; restarting download"
+                      )
+                      if (!destinationFile.delete()) {
+                        Log.e(tag, "Could not remove invalid staging file")
+                      } else {
+                        progressCallback.onProgress(0L, 0L)
+                      }
+                      progressCallback.onComplete(true)
+                      return
+                    }
                     val append =
                             existingBytes > 0L &&
                                     response.code == 206 &&

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
@@ -88,6 +88,10 @@ class AbsDownloader : Plugin() {
 
     val downloadId = if (episodeId.isEmpty()) libraryItemId else "$libraryItemId-$episodeId"
     if (downloadItemManager.downloadItemQueue.find { it.id == downloadId } != null) {
+      if (downloadItemManager.retryDownloadItem(downloadId)) {
+        Log.i(tag, "Restarted interrupted download $downloadId")
+        return call.resolve()
+      }
       Log.d(tag, "Download already started for this media entity $downloadId")
       return call.resolve(JSObject("{\"error\":\"Download already started for this media entity\"}"))
     }


### PR DESCRIPTION
## What changed

- recover interrupted terminal downloads when their staging files are still present
- retry an existing unfinished download instead of only reporting that it was already started
- handle HTTP 416 by accepting a complete local file or restarting a stale partial file from byte zero
- finalize downloads correctly when Android document providers normalize or hide filename extensions

## Why

Interrupted multi-file audiobook downloads could leave a small number of tracks at 100% without marking them complete. Retrying the book then returned `Download already started for this media entity`, leaving no way to recover without clearing application data and downloading the entire book again.

The server files and advertised sizes can be valid in this situation. The failures occur while restoring a terminal queue entry, recovering from an invalid byte range, or reopening a file after Android's Storage Access Framework has normalized its name.

## User impact

Users can retry an interrupted book download. Completed files are reused, stale partial files restart safely, and files copied successfully into shared storage are recognized and finalized.

## Validation

- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:assembleDebug`
- verified a debug APK is produced successfully
