### PR TITLE
Fix: Prevent crashes when decoding corrupted cover images

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/LocalLibraryItem.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/LocalLibraryItem.kt
@@ -142,11 +142,17 @@ class LocalLibraryItem(
 
     var bitmap:Bitmap? = null
     if (coverContentUrl != null) {
-      bitmap = if (Build.VERSION.SDK_INT < 28) {
-        MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
-      } else {
-        val source: ImageDecoder.Source = ImageDecoder.createSource(ctx.contentResolver, coverUri)
-        ImageDecoder.decodeBitmap(source)
+      bitmap = try {
+        if (Build.VERSION.SDK_INT < 28) {
+          @Suppress("DEPRECATION")
+          MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
+        } else {
+          val source: ImageDecoder.Source = ImageDecoder.createSource(ctx.contentResolver, coverUri)
+          ImageDecoder.decodeBitmap(source)
+        }
+      } catch (e: Exception) {
+        Log.e(tag, "Failed to decode cover bitmap: ${e.message}")
+        null
       }
     }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/data/LocalLibraryItem.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/LocalLibraryItem.kt
@@ -151,7 +151,7 @@ class LocalLibraryItem(
           ImageDecoder.decodeBitmap(source)
         }
       } catch (e: Exception) {
-        Log.e(tag, "Failed to decode cover bitmap: ${e.message}")
+        Log.e("LocalLibraryItem", "Failed to decode cover bitmap: ${e.message}")
         null
       }
     }

--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.support.v4.media.MediaMetadataCompat
+import android.util.Log
 import androidx.core.content.FileProvider
 import androidx.core.net.toFile
 import com.audiobookshelf.app.BuildConfig
@@ -263,14 +264,22 @@ class PlaybackSession(
     // Local covers get bitmap synchronously, no async fetch needed
     if (localLibraryItem?.coverContentUrl != null) {
       resolvedCoverBitmap =
-              if (Build.VERSION.SDK_INT < 28) {
-                MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
-              } else {
-                val source: ImageDecoder.Source =
-                        ImageDecoder.createSource(ctx.contentResolver, coverUri)
-                ImageDecoder.decodeBitmap(source)
+              try {
+                if (Build.VERSION.SDK_INT < 28) {
+                  @Suppress("DEPRECATION")
+                  MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
+                } else {
+                  val source: ImageDecoder.Source =
+                          ImageDecoder.createSource(ctx.contentResolver, coverUri)
+                  ImageDecoder.decodeBitmap(source)
+                }
+              } catch (e: Exception) {
+                Log.e(tag, "Failed to decode cover bitmap: ${e.message}")
+                null
               }
-      onArtResolved()
+      if (resolvedCoverBitmap != null) {
+        onArtResolved()
+      }
       return null
     }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -274,7 +274,7 @@ class PlaybackSession(
                   ImageDecoder.decodeBitmap(source)
                 }
               } catch (e: Exception) {
-                Log.e(tag, "Failed to decode cover bitmap: ${e.message}")
+                Log.e("PlaybackSession", "Failed to decode cover bitmap: ${e.message}")
                 null
               }
       if (resolvedCoverBitmap != null) {

--- a/android/app/src/main/java/com/audiobookshelf/app/player/AbMediaDescriptionAdapter.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/AbMediaDescriptionAdapter.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.provider.MediaStore
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaControllerCompat
+import android.util.Log
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.ui.PlayerNotificationManager
 import kotlinx.coroutines.*
@@ -48,12 +49,17 @@ class AbMediaDescriptionAdapter (private val controller: MediaControllerCompat, 
       currentIconUri = albumArtUri
 
       if (currentIconUri.toString().startsWith("content://")) {
-        currentBitmap = if (Build.VERSION.SDK_INT < 28) {
-          @Suppress("DEPRECATION")
-          MediaStore.Images.Media.getBitmap(playerNotificationService.contentResolver, currentIconUri)
-        } else {
-          val source: ImageDecoder.Source = ImageDecoder.createSource(playerNotificationService.contentResolver, currentIconUri!!)
-          ImageDecoder.decodeBitmap(source)
+        currentBitmap = try {
+          if (Build.VERSION.SDK_INT < 28) {
+            @Suppress("DEPRECATION")
+            MediaStore.Images.Media.getBitmap(playerNotificationService.contentResolver, currentIconUri)
+          } else {
+            val source: ImageDecoder.Source = ImageDecoder.createSource(playerNotificationService.contentResolver, currentIconUri!!)
+            ImageDecoder.decodeBitmap(source)
+          }
+        } catch (e: Exception) {
+          Log.e("AbMediaDescriptionAdapter", "Failed to decode bitmap: ${e.message}")
+          null
         }
         currentBitmap
       } else {

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -336,12 +336,18 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                 // so we create and set the bitmap here instead of AbMediaDescriptionAdapter
                 if (currentPlaybackSession!!.localLibraryItem?.coverContentUrl != null) {
                   bitmap =
-                    if (Build.VERSION.SDK_INT < 28) {
-                      MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
-                    } else {
-                      val source: ImageDecoder.Source =
-                        ImageDecoder.createSource(ctx.contentResolver, coverUri)
-                      ImageDecoder.decodeBitmap(source)
+                    try {
+                      if (Build.VERSION.SDK_INT < 28) {
+                        @Suppress("DEPRECATION")
+                        MediaStore.Images.Media.getBitmap(ctx.contentResolver, coverUri)
+                      } else {
+                        val source: ImageDecoder.Source =
+                          ImageDecoder.createSource(ctx.contentResolver, coverUri)
+                        ImageDecoder.decodeBitmap(source)
+                      }
+                    } catch (e: Exception) {
+                      Log.e(tag, "Failed to decode cover bitmap: ${e.message}")
+                      null
                     }
                 }
 

--- a/components/covers/BookCover.vue
+++ b/components/covers/BookCover.vue
@@ -55,13 +55,17 @@ export default {
     return {
       loading: true,
       imageFailed: false,
+      rawFailed: false,
       showCoverBg: false,
       imageReady: false
     }
   },
   watch: {
     cover() {
-      this.imageFailed = false
+      this.resetCoverState()
+    },
+    'libraryItem.id'() {
+      this.resetCoverState()
     }
   },
   computed: {
@@ -109,6 +113,9 @@ export default {
     placeholderUrl() {
       return '/book_placeholder.jpg'
     },
+    useRawCover() {
+      return this.raw && !this.rawFailed
+    },
     fullCoverUrl() {
       if (this.isLocal) {
         if (this.localCover) return Capacitor.convertFileSrc(this.localCover)
@@ -117,7 +124,7 @@ export default {
       if (this.downloadCover) return this.downloadCover
       if (!this.libraryItem) return null
       var store = this.$store || this.$nuxt.$store
-      return store.getters['globals/getLibraryItemCoverSrc'](this.libraryItem, this.placeholderUrl, this.raw)
+      return store.getters['globals/getLibraryItemCoverSrc'](this.libraryItem, this.placeholderUrl, this.useRawCover)
     },
     cover() {
       return this.media.coverPath || this.placeholderUrl
@@ -144,6 +151,13 @@ export default {
     }
   },
   methods: {
+    resetCoverState() {
+      this.imageFailed = false
+      this.rawFailed = false
+      this.loading = true
+      this.imageReady = false
+      this.showCoverBg = false
+    },
     setCoverBg() {
       if (this.$refs.coverBg) {
         this.$refs.coverBg.style.backgroundImage = `url("${this.fullCoverUrl}")`
@@ -171,8 +185,16 @@ export default {
       this.$emit('imageLoaded', this.fullCoverUrl)
     },
     imageError(err) {
+      // Prefer resized/cached cover when the full-resolution (raw) image fails
+      if (this.useRawCover) {
+        console.warn('ImgError raw cover failed, falling back to resized', this.fullCoverUrl, err)
+        this.rawFailed = true
+        this.loading = true
+        this.imageReady = false
+        return
+      }
       this.loading = false
-      console.error('ImgError', err)
+      console.error('ImgError', this.fullCoverUrl, err)
       this.imageFailed = true
     }
   },


### PR DESCRIPTION
App crashes on Android 9+ with `ImageDecoder$DecodeException` when trying to load corrupted or unsupported cover images.

FATAL EXCEPTION: main
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
Caused by: android.graphics.ImageDecoder$DecodeException: Failed to create image decoder with message 'unimplemented'Input contained an error.

Wrapped all `ImageDecoder.decodeBitmap()` and `MediaStore.Images.Media.getBitmap()` calls in try-catch blocks. Now returns `null` on decode failure and logs the error instead of crashing.

- `PlaybackSession.kt` - `resolveCoverBitmap()`
- `PlayerNotificationService.kt` - `updateMediaSession()`
- `AbMediaDescriptionAdapter.kt` - `getCurrentLargeIcon()`
- `LocalLibraryItem.kt` - `getMediaDescription()`

Tested with corrupted cover images - app no longer crashes, shows placeholder image instead.