### PR TITLE
feat: add list view and sorting to Authors tab

### DIFF
--- a/components/cards/AuthorListRow.vue
+++ b/components/cards/AuthorListRow.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="flex items-center w-full px-4 py-2 border-b border-white border-opacity-10 active:bg-white active:bg-opacity-5" @click="navigate">
+    <div class="rounded overflow-hidden flex-shrink-0" style="width: 48px; height: 60px">
+      <covers-author-image :author="author" />
+    </div>
+    <div class="flex-grow px-3 overflow-hidden">
+      <p class="text-base font-semibold truncate text-fg">{{ name }}</p>
+      <p class="text-sm text-gray-400">{{ numBooks }} {{ $strings.LabelBooks }}</p>
+    </div>
+    <span class="material-symbols text-fg text-opacity-40 text-xl">chevron_right</span>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    author: {
+      type: Object,
+      default: () => {}
+    }
+  },
+  computed: {
+    name() {
+      return this.author.name || ''
+    },
+    numBooks() {
+      return this.author.numBooks || 0
+    }
+  },
+  methods: {
+    navigate() {
+      this.$router.push(`/bookshelf/library?filter=authors.${this.$encode(this.author.id)}`)
+    }
+  }
+}
+</script>

--- a/pages/bookshelf/authors.vue
+++ b/pages/bookshelf/authors.vue
@@ -1,23 +1,49 @@
 <template>
-  <div>
-    <div id="bookshelf" class="w-full h-full p-4 overflow-y-auto">
-      <div class="flex flex-wrap justify-center">
-        <template v-for="author in authors">
-          <cards-author-card :key="author.id" :author="author" :width="cardWidth" :height="cardHeight" class="p-2" />
-        </template>
+  <div class="flex flex-col h-full">
+    <!-- Toolbar: sort selector + list/grid toggle -->
+    <div class="flex items-center px-4 py-2 border-b border-white border-opacity-10 flex-shrink-0">
+      <div class="flex items-center border border-white border-opacity-25 rounded px-2 cursor-pointer" @click="cycleSortKey">
+        <p class="text-sm text-fg">{{ sortLabel }}</p>
+        <span class="material-symbols ml-1 text-fg">{{ sortDir === 'asc' ? 'arrow_drop_up' : 'arrow_drop_down' }}</span>
+      </div>
+      <div class="flex-grow" />
+      <span class="material-symbols text-2xl px-2 cursor-pointer text-fg" @click="toggleListView">{{ listView ? 'grid_view' : 'view_list' }}</span>
+    </div>
+
+    <!-- Content -->
+    <div id="bookshelf" class="flex-grow overflow-y-auto">
+      <!-- Grid view -->
+      <div v-if="!listView" class="flex flex-wrap justify-center p-4">
+        <div v-for="author in sortedAuthors" :key="author.id" class="p-2 cursor-pointer" @click="navigateToAuthor(author)">
+          <cards-author-card :author="author" :width="cardWidth" :height="cardHeight" />
+        </div>
+      </div>
+
+      <!-- List view -->
+      <div v-else class="w-full">
+        <cards-author-list-row v-for="author in sortedAuthors" :key="author.id" :author="author" />
       </div>
     </div>
   </div>
 </template>
 
 <script>
+const SORT_CYCLE = [
+  { key: 'name', dir: 'asc', label: 'Name (A-Z)' },
+  { key: 'name', dir: 'desc', label: 'Name (Z-A)' },
+  { key: 'numBooks', dir: 'desc', label: 'Most Books' },
+  { key: 'numBooks', dir: 'asc', label: 'Fewest Books' }
+]
+
 export default {
   data() {
     return {
       loading: true,
       authors: [],
       loadedLibraryId: null,
-      cardWidth: 200
+      cardWidth: 200,
+      listView: false,
+      sortIndex: 0
     }
   },
   computed: {
@@ -26,6 +52,26 @@ export default {
     },
     cardHeight() {
       return this.cardWidth * 1.25
+    },
+    sortKey() {
+      return SORT_CYCLE[this.sortIndex].key
+    },
+    sortDir() {
+      return SORT_CYCLE[this.sortIndex].dir
+    },
+    sortLabel() {
+      return SORT_CYCLE[this.sortIndex].label
+    },
+    sortedAuthors() {
+      return [...this.authors].sort((a, b) => {
+        let av = a[this.sortKey]
+        let bv = b[this.sortKey]
+        if (typeof av === 'string') av = av.toLowerCase()
+        if (typeof bv === 'string') bv = bv.toLowerCase()
+        if (av < bv) return this.sortDir === 'asc' ? -1 : 1
+        if (av > bv) return this.sortDir === 'asc' ? 1 : -1
+        return 0
+      })
     }
   },
   methods: {
@@ -45,6 +91,16 @@ export default {
       console.log('Loaded authors', this.authors)
       this.$eventBus.$emit('bookshelf-total-entities', this.authors.length)
       this.loading = false
+    },
+    cycleSortKey() {
+      this.sortIndex = (this.sortIndex + 1) % SORT_CYCLE.length
+    },
+    toggleListView() {
+      this.listView = !this.listView
+      this.$localStore.setAuthorsListView(this.listView)
+    },
+    navigateToAuthor(author) {
+      this.$router.push(`/bookshelf/library?filter=authors.${this.$encode(author.id)}`)
     },
     authorAdded(author) {
       if (!this.authors.some((au) => au.id === author.id)) {
@@ -74,7 +130,8 @@ export default {
       }
     }
   },
-  mounted() {
+  async mounted() {
+    this.listView = await this.$localStore.getAuthorsListView()
     this.init()
     this.$socket.$on('author_added', this.authorAdded)
     this.$socket.$on('author_updated', this.authorUpdated)

--- a/plugins/localStore.js
+++ b/plugins/localStore.js
@@ -78,6 +78,24 @@ class LocalStorage {
     }
   }
 
+  async setAuthorsListView(useIt) {
+    try {
+      await Preferences.set({ key: 'authorsListView', value: useIt ? '1' : '0' })
+    } catch (error) {
+      console.error('[LocalStorage] Failed to set authors list view', error)
+    }
+  }
+
+  async getAuthorsListView() {
+    try {
+      var obj = await Preferences.get({ key: 'authorsListView' }) || {}
+      return obj.value === '1'
+    } catch (error) {
+      console.error('[LocalStorage] Failed to get authors list view', error)
+      return false
+    }
+  }
+
   async setLastLibraryId(libraryId) {
     try {
       await Preferences.set({ key: 'lastLibraryId', value: libraryId })


### PR DESCRIPTION
## Summary

The Authors tab currently only supports a fixed grid layout with no sorting. This PR adds:

- **List/grid toggle** — switches between the existing card grid and a compact list row (thumbnail + name + book count + chevron). The preference is persisted independently via `authorsListView` in local store so it doesn't affect the main bookshelf grid setting.
- **Sort cycling** — tap the sort button to cycle through: Name A→Z, Name Z→A, Most Books, Fewest Books. Sorting is done client-side on the already-loaded authors array.
- **Click-to-filter navigation** — grid cards now navigate to the filtered library view on tap (matching the behavior of the search results and list rows).

## Changes

- `pages/bookshelf/authors.vue` — toolbar with sort selector and grid/list toggle; `sortedAuthors` computed; `navigateToAuthor` method; `listView` and `sortIndex` state restored from local store on mount
- `components/cards/AuthorListRow.vue` — new compact list row component
- `plugins/localStore.js` — `getAuthorsListView` / `setAuthorsListView` using Capacitor Preferences key `authorsListView`

## Test plan

- [x] Authors tab loads in grid view by default
- [x] Tapping the sort button cycles through all 4 sort modes and list re-orders correctly
- [x] Tapping the list toggle switches to list view; each row shows author image, name, book count, and navigates to filtered library on tap
- [x] Tapping the grid toggle returns to card grid; cards navigate to filtered library on tap
- [x] List/grid preference survives navigating away and returning to the tab
- [x] List/grid preference is independent from the main bookshelf grid setting
- [ ] Works correctly when library is switched