### PR TITLE
Fix Android background playback stops caused by WebView bridge traffic

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -1069,6 +1069,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     DeviceManager.widgetUpdater?.onPlayerClosed()
     stopForeground(Service.STOP_FOREGROUND_REMOVE)
     stopSelf()
+    PlayerNotificationListener.isForegroundService = false
+    isStarted = false
   }
 
   fun sendClientMetadata(playerState: PlayerState) {

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -96,10 +96,12 @@ class AbsAudioPlayer : Plugin() {
         }
 
         override fun onProgressSyncFailing() {
+          if (!isInForeground) return
           emit("onProgressSyncFailing", "")
         }
 
         override fun onProgressSyncSuccess() {
+          if (!isInForeground) return
           emit("onProgressSyncSuccess", "")
         }
 
@@ -108,6 +110,7 @@ class AbsAudioPlayer : Plugin() {
         }
 
         override fun onMediaItemHistoryUpdated(mediaItemHistory:MediaItemHistory) {
+          if (!isInForeground) return
           notifyListeners("onMediaItemHistoryUpdated", JSObject(jacksonMapper.writeValueAsString(mediaItemHistory)))
         }
 

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -683,7 +683,14 @@ export default {
     },
     startPlayInterval() {
       clearInterval(this.playInterval)
+      if (document.visibilityState !== 'visible') return
+
       this.playInterval = setInterval(async () => {
+        if (document.visibilityState !== 'visible') {
+          this.stopPlayInterval()
+          return
+        }
+
         var data = await AbsAudioPlayer.getCurrentTime()
         this.currentTime = Number(data.value.toFixed(2))
         this.bufferedTime = Number(data.bufferedTime.toFixed(2))
@@ -982,6 +989,13 @@ export default {
     minimizePlayerEvt() {
       this.collapseFullscreen()
     },
+    deviceFocused(hasFocus) {
+      if (hasFocus && this.isPlaying) {
+        this.startPlayInterval()
+      } else {
+        this.stopPlayInterval()
+      }
+    },
     showProgressSyncIsFailing() {
       this.syncStatus = this.$constants.SyncStatus.FAILED
     },
@@ -1000,6 +1014,7 @@ export default {
     window.addEventListener('resize', this.screenOrientationChange)
 
     this.$eventBus.$on('minimize-player', this.minimizePlayerEvt)
+    this.$eventBus.$on('device-focus-update', this.deviceFocused)
     document.body.addEventListener('touchstart', this.touchstart, { passive: false })
     document.body.addEventListener('touchend', this.touchend)
     document.body.addEventListener('touchmove', this.touchmove)
@@ -1021,6 +1036,7 @@ export default {
 
     this.forceCloseDropdownMenu()
     this.$eventBus.$off('minimize-player', this.minimizePlayerEvt)
+    this.$eventBus.$off('device-focus-update', this.deviceFocused)
     document.body.removeEventListener('touchstart', this.touchstart)
     document.body.removeEventListener('touchend', this.touchend)
     document.body.removeEventListener('touchmove', this.touchmove)


### PR DESCRIPTION
## Brief summary

Reduce WebView/native bridge traffic while the Android app is backgrounded, preventing Android from killing the application during playback because of excessive cached-process Binder traffic.

## Which issue is fixed?

Fixes #1530

## Pull Request Type

Android only. This changes the frontend player lifecycle and Android native bridge event delivery.

## In-depth Description

Process exit diagnostics captured on a Pixel 10 Pro running Android 17 showed the application being killed with:

```text
reason=9 (EXCESSIVE RESOURCE USAGE)
description=excessive binder traffic during cached
```

The app already avoids sending several frequent native display events to a backgrounded WebView. Two recurring sources of bridge traffic remained:

1. `AudioPlayer.vue` continued calling native `getCurrentTime()` once per second while the WebView was hidden.
2. Every 15-second progress sync could still send sync-status events and a serialized, growing media-history object to the hidden WebView.

This change:

- Stops the one-second player UI polling interval when the app loses visibility.
- Restarts polling when the app becomes visible again and playback is active.
- Adds a visibility guard inside the interval to handle lifecycle races.
- Suppresses recurring progress-sync status and media-history display events while the native plugin is backgrounded.

Native playback and progress synchronization continue normally in the background. Only UI updates that cannot be displayed are skipped.

## How have you tested this?

Build verification following the repository's Android workflow:

- `npm run generate`
- `npx cap sync android`
- `gradlew.bat assembleDebug --no-daemon`

Device verification on a Pixel 10 Pro running Android 17:

1. Installed the debug APK and started streamed audiobook playback.
2. Confirmed that the visible player called `getCurrentTime()` once per second.
3. Sent the app to the background and monitored Logcat for 45 seconds.
4. Confirmed that no further `getCurrentTime()` bridge calls occurred after the visibility transition.
5. Confirmed that native progress synchronization continued at 15-second intervals without emitting the suppressed WebView events.
6. Confirmed that the media session remained in the `PLAYING` state and `PlayerNotificationService` remained a foreground service.
7. Returned to the app and confirmed that one-second player UI polling resumed immediately.
8. Paused playback after testing.

## Screenshots

Not applicable; there are no visual changes.
