### PR TITLE
Fix Stage Manager resize issue on iPadOS (#1563)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@capacitor/ios": "^7.0.0",
         "@capacitor/network": "^7.0.0",
         "@capacitor/preferences": "^7.0.0",
-        "@capacitor/status-bar": "^7.0.0",
+        "@capacitor/status-bar": "^7.0.6",
         "@nuxtjs/axios": "^5.13.6",
         "@teckel/vue-pdf": "^4.3.5",
         "@webnativellc/capacitor-filesharer": "7.0.4",
@@ -1883,9 +1883,9 @@
       }
     },
     "node_modules/@capacitor/status-bar": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.1.tgz",
-      "integrity": "sha512-iDv3mXYo9CdxYRVwt3/pRyuk25p7Sn4GfaS/zMZyVIqTzsvKLCIIH3GdKK+ta+nsNcAVpCw/t5jFEBt1D18ctA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.6.tgz",
+      "integrity": "sha512-7AVqj46b26QikImQzWfsJmzG8NUJZBGkrVSuoeTo+SX/YH3hXH0MqwwFgMqMGHfa/BICDgSvTjM9miVFlq0+RQ==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@capacitor/ios": "^7.0.0",
     "@capacitor/network": "^7.0.0",
     "@capacitor/preferences": "^7.0.0",
-    "@capacitor/status-bar": "^7.0.0",
+    "@capacitor/status-bar": "^7.0.6",
     "@nuxtjs/axios": "^5.13.6",
     "@teckel/vue-pdf": "^4.3.5",
     "buffer": "^6.0.3",


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

The app would not resize properly in iPadOS Stage Manager - content would get cut off. It turned out to be a `@capacitor/status-bar` related issue ([details](https://github.com/ionic-team/capacitor-plugins/issues/2337)). The fix was simply to update the `@capacitor/status-bar` package from `^7.0.0` to `^7.0.6`.

## Which issue is fixed?

Fixes #1563

## Pull Request Type

**Does this affect only Android, only iOS, or both?**
Both platforms get a dependency update, but the fix is aimed specifically at iPadOS.

**Does this change the frontend or the backend of the apps?**
Frontend (dependency update).

## In-depth Description

**How does it work?**
Upgrades `@capacitor/status-bar` to `^7.0.6`, which is a version that includes the resize fix.

**Why is this the best solution?**
It's the best solution, because the package is now at the latest version (for v7), and it doesn't require any code changes.

**Does it solve a problem that affects multiple users or is this an edge case for your setup?**
It fixes #1563 (and my own setup too).

## How have you tested this?

Yes, I've tested this on an iPadOS simulator and my own iPad. Further testing might be required for Android.
1. Compile this branch & Run the app.
2. Enter Stage Manager.
3. Resize window.
4. After some delay, it will resize (previously it wouldn't resize at all).

> **Note**: There also seems to be a delay when resizing. However, I feel like it's out-of-scope of this PR.

## Screenshots
### Before
https://github.com/user-attachments/assets/e8442580-95b6-4bba-bd5f-7d2c00683ddd
### After
https://github.com/user-attachments/assets/fd394990-29ba-4031-9497-fb3135ca9b07


