### PR TITLE
Android TV (7/10): audio player behavior on TV

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -133,6 +133,7 @@
 import { Capacitor } from '@capacitor/core'
 import { AbsAudioPlayer } from '@/plugins/capacitor'
 import { Dialog } from '@capacitor/dialog'
+import { KeepAwake } from '@capacitor-community/keep-awake'
 import { getAverageColorFromCoverUrl } from '@/utils/coverAverageColor'
 import WrappingMarquee from '@/assets/WrappingMarquee.js'
 import jumpLabelMixin from '@/mixins/jumpLabel'
@@ -209,7 +210,10 @@ export default {
     menuItems() {
       const items = []
       // TODO: Implement on iOS
-      if (this.$platform !== 'ios' && !this.isPodcast && this.mediaId) {
+      // Android TV: hide History here — it routes to a separate page which collapses
+      // the fullscreen player into the retired mini-player state. History remains
+      // accessible from book detail pages.
+      if (this.$platform !== 'ios' && !this.isPodcast && this.mediaId && !this.$store.state.isAndroidTv) {
         items.push({
           text: this.$strings.ButtonHistory,
           value: 'history',
@@ -473,6 +477,13 @@ export default {
       })
     },
     collapseFullscreen() {
+      // On Android TV, close the player entirely instead of minimizing.
+      // The mini player is difficult to navigate back to on TV. A future
+      // user setting will allow toggling between minimize and close behavior.
+      if (this.$store.state.isAndroidTv) {
+        this.closePlayback()
+        return
+      }
       this.showFullscreen = false
       if (this.titleMarquee) this.titleMarquee.reset()
 
@@ -820,6 +831,21 @@ export default {
       this.isEnded = false
       this.isLoading = false
       this.playbackSession = null
+      this.updateKeepAwake(false)
+    },
+    // Android TV only: hold a screen-wake lock during active playback so the
+    // Ambient Mode screensaver does not kick in (which kills playback on CCwGTV).
+    async updateKeepAwake(shouldKeepAwake) {
+      if (!this.$store.state.isAndroidTv) return
+      try {
+        if (shouldKeepAwake) {
+          await KeepAwake.keepAwake()
+        } else {
+          await KeepAwake.allowSleep()
+        }
+      } catch (error) {
+        console.error('[AudioPlayer] Failed to update keep awake state', error)
+      }
     },
     async loadPlayerSettings() {
       const savedPlayerSettings = await this.$localStore.getPlayerSettings()
@@ -857,6 +883,7 @@ export default {
       } else {
         this.stopPlayInterval()
       }
+      this.updateKeepAwake(this.isPlaying)
     },
     onMetadata(data) {
       console.log('onMetadata', JSON.stringify(data))

--- a/docs/pr-07-audio-player-behavior.md
+++ b/docs/pr-07-audio-player-behavior.md
@@ -1,0 +1,48 @@
+# PR 07 — Audio player behavior on Android TV
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+Four TV-gated behavior changes in `components/app/AudioPlayer.vue`, each
+guarded on the `isAndroidTv` Vuex flag so phone and tablet behavior is
+unchanged:
+
+- **Close instead of minimize.** On TV, leaving fullscreen closes the player
+  rather than collapsing it to the mini bar. The mini player is very hard to
+  navigate back to with a D-pad — there is no taskbar or system tray to reach
+  it from. A user setting to choose between the two behaviors is planned.
+- **Keep-awake during playback.** Holds a screen-wake lock while audio is
+  playing so the Ambient Mode screensaver does not kick in, which otherwise
+  kills playback on Chromecast with Google TV. Uses the
+  `@capacitor-community/keep-awake` plugin already in `package.json`.
+- **Hide History in the player menu.** The History item routes to a separate
+  page, which collapses the fullscreen player into the mini-player state that
+  TV no longer uses. History stays reachable from book detail pages.
+- Screen-wake state is released when playback closes.
+
+## Architecture context (fork-hosted)
+
+- [TV_USER_GUIDE.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_USER_GUIDE.md) — end-user TV feature documentation, including player behavior.
+
+## Testing
+
+Verified on a Google TV Streamer 4K: playback survives an idle period that
+previously triggered the screensaver, Back and the collapse control both stop
+playback and close the player, and the menu no longer offers History. Verified
+on an Android phone that minimize, History, and sleep behavior are unchanged.
+
+## Relationship to the series
+
+- **Depends on:** PR1 (`isAndroidTv` state) and PR6 (live engine for focus
+  restore after the player closes).
+- **Note:** also edits `components/app/AudioPlayer.vue`, which PR2 touches in
+  different regions (keyboard hygiene); whichever merges second may need a
+  trivial rebase.
+- **Layer:** 3 of 3


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

### Scope
Four TV-gated behavior changes in `components/app/AudioPlayer.vue`:
- **Close instead of minimize** — on TV, leaving fullscreen closes the player rather than collapsing to the mini bar, which is very hard to get back to with a D-pad (no taskbar or tray to reach it from). A user setting to choose between the two is planned.
- **Keep-awake during playback** — holds a screen-wake lock while audio plays so Ambient Mode does not kick in, which otherwise kills playback on Chromecast with Google TV. Uses `@capacitor-community/keep-awake`, already in `package.json`.
- **Hide History in the player menu** — it routes to a page that collapses fullscreen into the mini-player state TV no longer uses. History stays reachable from book detail pages.
- The wake lock is released when playback closes.

### Safety
Every change is guarded on `isAndroidTv`; phone and tablet behavior is unchanged.

### Testing
GTV Streamer 4K: playback survives an idle period that previously triggered the screensaver; Back and the collapse control both stop playback and close the player; the menu no longer offers History. Phone: minimize, History, and sleep behavior unchanged.

Depends on the `isAndroidTv` flag from #1892 and on the live engine for focus restore after close. Also edits `AudioPlayer.vue`, which #1893 touches in different regions — whichever merges second may need a trivial rebase.
