### PR TITLE
Android TV (10/10): author detail page

### DIFF
--- a/components/cards/AuthorCard.vue
+++ b/components/cards/AuthorCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <div :style="{ width: width + 'px', height: height + 'px' }" class="bg-primary box-shadow-book rounded-md relative overflow-hidden">
+  <div tabindex="0" class="author-card-wrapper" :style="{ width: width + 'px', height: (height + (nameBelow ? 30 : 0)) + 'px' }" @click="clickCard" @keydown.enter.prevent="clickCard">
+    <div :style="{ width: width + 'px', height: height + 'px' }" class="author-card-inner bg-primary box-shadow-book rounded-md relative overflow-hidden">
       <!-- Image or placeholder -->
       <covers-author-image :author="author" />
 
@@ -55,7 +55,17 @@ export default {
       return this._author.numBooks || 0
     }
   },
-  methods: {},
+  methods: {
+    clickCard() {
+      if (this.authorId) {
+        if (this.$store.state.isAndroidTv) {
+          this.$router.push(`/author/${this.authorId}`)
+        } else {
+          this.$router.push(`/bookshelf/library?filter=authors.${this.$encode(this.authorId)}`)
+        }
+      }
+    }
+  },
   mounted() {}
 }
 </script>

--- a/components/covers/AuthorImage.vue
+++ b/components/covers/AuthorImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <nuxt-link :to="`/bookshelf/library?filter=authors.${$encode(authorId)}`" ref="wrapper" :class="`rounded-${rounded}`" class="w-full h-full bg-primary overflow-hidden">
+  <nuxt-link :to="`/bookshelf/library?filter=authors.${$encode(authorId)}`" ref="wrapper" :class="`rounded-${rounded}`" class="w-full h-full bg-primary overflow-hidden" tabindex="-1">
     <svg v-if="!imagePath" width="140%" height="140%" style="margin-left: -20%; margin-top: -20%; opacity: 0.6" viewBox="0 0 177 266" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path fill="white" d="M40.7156 165.47C10.2694 150.865 -31.5407 148.629 -38.0532 155.529L63.3191 204.159L76.9443 190.899C66.828 181.394 54.006 171.846 40.7156 165.47Z" stroke="white" stroke-width="4" transform="translate(-2 -1)" />
       <path d="M-38.0532 155.529C-31.5407 148.629 10.2694 150.865 40.7156 165.47C54.006 171.846 66.828 181.394 76.9443 190.899L95.0391 173.37C80.6681 159.403 64.7526 149.155 51.5747 142.834C21.3549 128.337 -46.2471 114.563 -60.6897 144.67L-71.5489 167.307L44.5864 223.019L63.3191 204.159L-38.0532 155.529Z" fill="white" />

--- a/docs/pr-10-author-detail-page.md
+++ b/docs/pr-10-author-detail-page.md
@@ -1,0 +1,47 @@
+# PR 10 — Author detail page
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+Adds `pages/author/_id.vue`, an author detail page listing that author's books,
+and makes author cards navigate to it.
+
+- `pages/author/_id.vue` — new page: author image, name, and a grid of the
+  author's items.
+- `components/cards/AuthorCard.vue` — the card becomes navigable to the new
+  page and gains a `tabindex` so a D-pad can reach it.
+- `components/covers/AuthorImage.vue` — a one-line adjustment for the new page's
+  layout.
+- `pages/bookshelf/authors.vue` — routes card activation to the detail page.
+
+**A note on scope:** this one is arguably not TV-specific. The app currently has
+no author detail page on any platform — tapping an author on a phone does not
+open one either. The page was built for TV because browsing by author with a
+remote is common, but mobile users would get the same feature. Flagging it
+explicitly for your discretion: it can ship as-is, be reworked as a general
+(non-TV) feature, or be dropped from the series without affecting PRs 1-9.
+
+## Architecture context (fork-hosted)
+
+- [TV_USER_GUIDE.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_USER_GUIDE.md) — end-user TV feature documentation.
+
+## Testing
+
+Verified on a Google TV Streamer 4K: author cards are reachable and open the
+detail page, the item grid is navigable, and Back returns to the author
+bookshelf with focus restored to the originating card. Verified on an Android
+phone that the new page renders correctly when reached by tap.
+
+## Relationship to the series
+
+- **Depends on:** PR2 (keyboard hygiene) for the shared card components.
+- **Independent of:** PRs 5-9 — this one does not require the engine to be
+  useful, though focus restore on Back does come from PR6.
+- **Layer:** 3 of 3

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -1,0 +1,99 @@
+<template>
+  <div v-if="!author" class="w-full h-full relative flex items-center justify-center bg-bg">
+    <ui-loading-indicator />
+  </div>
+  <div v-else id="author-page-wrapper" class="w-full h-full overflow-y-auto px-2 py-6 md:p-8">
+    <div class="flex flex-col items-center">
+      <!-- Author image -->
+      <div class="rounded-full overflow-hidden bg-primary" :style="{ width: imageSize + 'px', height: imageSize + 'px' }">
+        <img v-if="authorImageSrc" :src="authorImageSrc" class="w-full h-full object-cover" />
+        <div v-else class="w-full h-full flex items-center justify-center">
+          <span class="material-symbols text-6xl text-fg-muted">person</span>
+        </div>
+      </div>
+
+      <!-- Author name -->
+      <h1 class="text-2xl font-semibold mt-4 text-center">{{ author.name }}</h1>
+      <p v-if="numBooks" class="text-fg-muted text-sm mt-1">{{ numBooks }} {{ numBooks === 1 ? 'Book' : 'Books' }}</p>
+    </div>
+
+    <!-- Description / Bio -->
+    <div v-if="author.description" class="mt-6 px-4 max-w-2xl mx-auto">
+      <p class="text-base text-fg leading-relaxed">{{ author.description }}</p>
+    </div>
+
+    <!-- Author's books -->
+    <div v-if="libraryItems.length" class="mt-8">
+      <h2 class="text-lg font-semibold px-4 mb-4">Books by {{ author.name }}</h2>
+      <div class="flex flex-wrap justify-center">
+        <div v-for="item in libraryItems" :key="item.id" tabindex="0" :id="`author-book-${item.id}`" class="p-2 cursor-pointer relative" @click="openItem(item)" @keydown.enter="openItem(item)">
+          <div :style="{ width: bookWidth + 'px', height: bookHeight + 'px' }" class="bg-primary box-shadow-book rounded-sm relative overflow-hidden">
+            <covers-book-cover :library-item="item" :width="bookWidth" :book-cover-aspect-ratio="bookCoverAspectRatio" />
+          </div>
+          <p class="text-center text-sm mt-1 truncate" :style="{ width: bookWidth + 'px' }">{{ item.media?.metadata?.title }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  async asyncData({ store, params, app, redirect, route }) {
+    if (!store.state.user.user) {
+      return redirect(`/connect?redirect=${route.path}`)
+    }
+
+    const author = await app.$nativeHttp.get(`/api/authors/${params.id}?include=items`).catch((error) => {
+      console.error('Failed to load author', error)
+      return false
+    })
+
+    if (!author) {
+      return redirect('/bookshelf')
+    }
+
+    return { author }
+  },
+  data() {
+    return {}
+  },
+  computed: {
+    bookCoverAspectRatio() {
+      return this.$store.getters['libraries/getBookCoverAspectRatio']
+    },
+    imageSize() {
+      return Math.min(window.innerWidth * 0.3, 200)
+    },
+    bookWidth() {
+      const cols = window.innerWidth >= 1280 ? 8 : window.innerWidth >= 640 ? 4 : 2
+      return Math.min((window.innerWidth - 64) / cols, 150)
+    },
+    bookHeight() {
+      return this.bookWidth * this.bookCoverAspectRatio
+    },
+    authorImageSrc() {
+      if (!this.author?.imagePath) return null
+      const serverAddress = this.$store.getters['user/getServerAddress']
+      if (!serverAddress) return null
+      const urlQuery = new URLSearchParams({ ts: this.author.updatedAt || '' })
+      if (this.$store.getters.getDoesServerImagesRequireToken) {
+        urlQuery.append('token', this.$store.getters['user/getToken'])
+      }
+      return `${serverAddress}/api/authors/${this.author.id}/image?${urlQuery.toString()}`
+    },
+    libraryItems() {
+      return this.author?.libraryItems || []
+    },
+    numBooks() {
+      return this.libraryItems.length || this.author?.numBooks || 0
+    }
+  },
+  methods: {
+    openItem(item) {
+      this.$router.push(`/item/${item.id}`)
+    }
+  },
+  mounted() {}
+}
+</script>

--- a/pages/bookshelf/authors.vue
+++ b/pages/bookshelf/authors.vue
@@ -30,7 +30,11 @@ export default {
   },
   methods: {
     async init() {
-      this.cardWidth = (window.innerWidth - 64) / 2
+      var cols = 2
+      if (window.innerWidth >= 1280) cols = 8
+      else if (window.innerWidth >= 960) cols = 6
+      else if (window.innerWidth >= 640) cols = 4
+      this.cardWidth = (window.innerWidth - 64) / cols
       if (!this.currentLibraryId) {
         return
       }


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

### Scope
Adds `pages/author/_id.vue`, an author detail page listing that author's books, and makes author cards navigate to it. Also a `tabindex` on `AuthorCard.vue` so a D-pad can reach it, a one-line layout tweak in `AuthorImage.vue`, and routing in `pages/bookshelf/authors.vue`.

### A note on scope — your call
**This one is arguably not TV-specific.** The app has no author detail page on any platform today: tapping an author on a phone does not open one either. It was built for TV because browsing by author with a remote is common, but mobile users would get the same feature, and it is not gated on `isAndroidTv`.

Flagging it explicitly rather than slipping it in: happy for this to ship as-is, be reworked as a general non-TV feature, or be dropped from the series entirely. Nothing in PRs 1-9 depends on it.

### Testing
GTV Streamer 4K: author cards reachable, open the detail page, item grid navigable, Back returns to the author bookshelf with focus restored to the originating card. Phone: the new page renders correctly when reached by tap.

Depends on the keyboard hygiene in #1893 for the shared card components.
