### PR TITLE
Android: back-button handling (drawer dismiss + TV exit when logged out)

### DIFF
--- a/docs/pr-back-button.md
+++ b/docs/pr-back-button.md
@@ -1,0 +1,28 @@
+# PR — Android back-button handling (drawer dismiss + TV exit)
+
+A small related PR alongside the 10-PR Android TV series (see
+[PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)).
+Self-contained; not part of the numbered wave sequence.
+
+## This PR's scope
+
+Two improvements to the Android hardware **back-button** handler in
+`plugins/init.client.js`:
+
+1. **Dismiss the side drawer on Back** (all Android) — if the side drawer is
+   open, Back closes it instead of navigating. General UX fix, not TV-specific.
+2. **Reliable exit on Android TV** — when logged out and on Home, treat Back as
+   "exit app" regardless of history depth. Stale history entries left from
+   before logout could otherwise trap the user on a TV with no other way out.
+   Gated on the `android-tv` class (set in PR1), so phones are unaffected.
+
+## Testing
+
+Phone: Back closes the drawer when open, otherwise behaves as before. Google TV
+Streamer 4K: from a logged-out Home screen, Back prompts the exit dialog.
+
+## Relationship to the series
+
+- **Depends on:** PR1 (the `android-tv` class) for the TV-exit branch; the
+  drawer-dismiss part is independent.
+- **Layer:** none — a companion PR outside the numbered series, independent of all of it.

--- a/plugins/init.client.js
+++ b/plugins/init.client.js
@@ -300,6 +300,10 @@ export default ({ store, app }, inject) => {
 
   // Android only
   App.addListener('backButton', async ({ canGoBack }) => {
+    if (store.state.showSideDrawer) {
+      store.commit('setShowSideDrawer', false)
+      return
+    }
     if (store.state.globals.isModalOpen) {
       eventBus.$emit('close-modal')
       return
@@ -312,7 +316,13 @@ export default ({ store, app }, inject) => {
       eventBus.$emit('minimize-player')
       return
     }
-    if (!canGoBack) {
+    // On Android TV, if logged out and on Home, treat as exit regardless
+    // of history depth — stale history entries from before logout should
+    // not prevent the user from exiting.
+    const isTV = document.documentElement.classList.contains('android-tv')
+    const isLoggedOut = !store.state.user?.user
+    const isHome = window.location.pathname === '/' || window.location.pathname === '/bookshelf'
+    if (!canGoBack || (isTV && isLoggedOut && isHome)) {
       const { value } = await Dialog.confirm({
         title: eventBus.$strings.HeaderConfirm,
         message: eventBus.$strings.MessageConfirmAppExit


### PR DESCRIPTION
A small companion PR alongside the Android TV series replacing #1843 — independent of the series except where noted.

### Scope
Android back-button handling in `plugins/init.client.js`, around 12 LOC:
- **All Android:** pressing Back while the side drawer is open dismisses the drawer instead of navigating away. This is standard Android behavior and applies to phones and tablets too, not just TV.
- **Android TV only:** pressing Back on the Home screen while logged out exits the app, rather than leaving the user on a dead screen with nowhere to go.

### Safety
The drawer-dismiss half is a general Android improvement and is not TV-gated. The exit-when-logged-out half is gated on TV.

### Testing
GTV Streamer 4K and an Android phone: the drawer dismisses on Back on both; TV exits cleanly from logged-out Home; normal back-navigation elsewhere is unaffected.

The TV-exit branch depends on the `android-tv` class from #1892. The drawer-dismiss part is fully independent and can merge on its own.
