### PR TITLE
Android TV (3/10): hide "Go to Web Client" on Android TV

### DIFF
--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -81,6 +81,9 @@ export default {
     userIsAdminOrUp() {
       return this.$store.getters['user/getIsAdminOrUp']
     },
+    isAndroidTv() {
+      return this.$store.state.isAndroidTv
+    },
     navItems() {
       var items = [
         {
@@ -139,11 +142,15 @@ export default {
       })
 
       if (this.serverConnectionConfig) {
-        items.push({
-          icon: 'language',
-          text: this.$strings.ButtonGoToWebClient,
-          action: 'openWebClient'
-        })
+        // Web client opens the server URL in an external browser. Android TV
+        // typically has no browser, so the action dead-ends — hide it on TV.
+        if (!this.isAndroidTv) {
+          items.push({
+            icon: 'language',
+            text: this.$strings.ButtonGoToWebClient,
+            action: 'openWebClient'
+          })
+        }
 
         items.push({
           icon: 'login',

--- a/docs/pr-03-drawer-webclient-gate.md
+++ b/docs/pr-03-drawer-webclient-gate.md
@@ -1,0 +1,36 @@
+# PR 03 — Hide "Go to Web Client" on Android TV
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+A one-item behavior gate in the side drawer (`components/app/SideDrawer.vue`).
+The "Go to Web Client" action opens the server URL in an external browser;
+Android TV devices typically have no browser, so the action dead-ends. This PR
+hides that single nav item when running on a TV, gated on the `isAndroidTv`
+Vuex flag. Phone/tablet behavior is unchanged — the item still appears and works.
+
+~19 LOC: an `isAndroidTv` computed plus wrapping the existing web-client
+`items.push(...)` in `if (!this.isAndroidTv)`.
+
+## Architecture context (fork-hosted)
+
+- [TV_USER_GUIDE.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_USER_GUIDE.md) — end-user TV feature documentation.
+
+## Testing
+
+Verified on a Google TV Streamer 4K (the item is hidden) and an Android phone
+(the item is present and opens the web client as before).
+
+## Relationship to the series
+
+- **Depends on:** PR1 (`isAndroidTv` flag); the gate is inert until that lands.
+- **Note:** also edits `components/app/SideDrawer.vue`, which PR2 touches in
+  different regions — whichever of the two merges second may need a trivial rebase.
+- **Layer:** 1 of 3


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

### Scope
Hide the "Go to Web Client" side-drawer item on Android TV (a TV has no browser, so the action dead-ends). ~19 LOC: an `isAndroidTv` computed plus gating the existing `items.push(...)`.

### Safety
Gated on `isAndroidTv`; phone/tablet unchanged (item still shows). Inert until the `isAndroidTv` flag from #1983 merges.

### Testing
GTV Streamer 4K: item hidden. Phone: item present and opens the web client as before.

Depends on the `isAndroidTv` flag from #1983. Also edits `components/app/SideDrawer.vue`, which #1984 touches in different regions — whichever merges second may need a trivial rebase.
