### PR TITLE
Android TV (5/10): navigation engine kit (dormant library)

### DIFF
--- a/docs/pr-05-engine-kit.md
+++ b/docs/pr-05-engine-kit.md
@@ -1,0 +1,42 @@
+# PR 05 — TV navigation engine kit (utility modules + page handlers)
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+The D-pad navigation engine as a **library only**. Seventeen modules under
+`plugins/tv/` that export functions and attach to nothing at runtime — no
+listener is registered, no router hook is installed, no store is touched. On
+its own this PR changes no behavior on any device; it is dormant until PR6
+wires it up.
+
+The split is deliberate: it lets the function library be reviewed separately
+from the wiring that turns it on. Nine utility modules (focus memory, spatial
+navigation, scroll helpers, visibility tests, overlay focus, focus entry,
+focus color, selectors, shared context) and eight per-page handlers under
+`plugins/tv/pageHandlers/`. Every file is under 235 LOC.
+
+## Architecture context (fork-hosted)
+
+- [TV_FOCUS_SYSTEM.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_FOCUS_SYSTEM.md) — developer reference for the focus model, the fingerprint restore tiers, and the virtualizer interaction.
+- [TV_USER_GUIDE.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_USER_GUIDE.md) — end-user TV feature documentation.
+
+## Testing
+
+The modules are exercised end-to-end by PR6 and verified on a Google TV
+Streamer 4K across a 13-batch manual smoke suite (library grid, item detail,
+podcast episodes, author pages, logs, stats, settings, player). This PR alone
+is inert, so it is verified by build only: `npm run generate` succeeds and
+phone/tablet behavior is byte-identical to upstream.
+
+## Relationship to the series
+
+- **Depends on:** PR1 (`isAndroidTv` detection state).
+- **Required by:** PR6, which registers these functions and activates them.
+- **Layer:** 2 of 3

--- a/plugins/tv/context.js
+++ b/plugins/tv/context.js
@@ -1,0 +1,83 @@
+/**
+ * TV Navigation shared state singleton.
+ *
+ * Replaces the module-level mutable vars from the original
+ * plugins/tv-navigation.js. All other plugins/tv/* modules import
+ * tvContext and read/write through it.
+ *
+ * The previous module-level vars were:
+ *   let _store = null
+ *   const focusHistory = []
+ *   let verticalNavInProgress = false
+ *   let lastFocusRect = null
+ *   const pageFocusMemory = {}
+ *   const cssEscape = ...
+ *
+ * Plus three closure-scoped vars promoted from inside registerTvListeners:
+ *   let refocusIntervalId, refocusTimeoutId, fingerprintRestoreActive
+ */
+export const tvContext = {
+  // Vuex store reference. Set by index.js during plugin init.
+  // Used by handleKeyDown for overlay dismissal (drawer/modal close).
+  store: null,
+
+  // Focus history stack. Tracks which element was focused before an overlay opened.
+  // Supports nested overlays (e.g. menu -> submenu).
+  focusHistory: [],
+
+  // Vertical navigation guard. Suppresses the focusout recovery handler while a
+  // vertical nav scroll is settling. The virtualizer may appendChild a still-focused
+  // card (series, collection, playlist) which briefly detaches it, firing focusout.
+  // Without this guard the 200 ms focusout timer beats the 350 ms recovery timer
+  // and snaps focus to the first card.
+  verticalNavInProgress: false,
+
+  // Last known focus position. Tracks the bounding rect center of the last
+  // focused card so that when the virtualizer detaches a card during rapid
+  // scrolling (focus falls to body), findVerticalTarget can still pick the
+  // correct column.
+  lastFocusRect: null,
+
+  // Grid vertical-nav state for the column-stable D-pad fix. `gridIntendedCol`
+  // is the user's chosen column (set only on Left/Right + first focus), kept
+  // SEPARATE from live focus so the native TV focus engine — which re-homes
+  // focus to an edge column when the virtualizer unmounts the focused card —
+  // can't corrupt it. Vertical nav takes the ROW from where focus actually is
+  // but re-asserts `gridIntendedCol`; a focusin watcher (listeners.js) then
+  // re-asserts it every 100ms for ~2s after a hijack (gridCorrectionInterval /
+  // gridCorrectionUntil) to out-persist the engine, time-boxed by the
+  // `lastVerticalNavAt` window so it only acts in the wake of a fast scroll.
+  // All reset on route change.
+  lastGridIndex: null,
+  lastGridPrefix: null,
+  gridItemsPerRow: null,
+  gridIntendedCol: null,
+  lastVerticalNavAt: 0,
+  gridCorrectionInterval: null,
+  gridCorrectionUntil: 0,
+
+  // Page focus memory. Saves the focused element selector per route so Back
+  // navigation can restore focus to where the user was. TV only.
+  pageFocusMemory: {},
+
+  // CSS.escape polyfill for older Android TV WebViews (Chrome < 46).
+  cssEscape:
+    typeof CSS !== 'undefined' && CSS.escape
+      ? CSS.escape
+      : (s) => s.replace(/([^\w-])/g, '\\$1'),
+
+  // Set by focusEntry helpers + listeners.js when fingerprint restoration is
+  // in flight. Causes refocusAfterContentChange to no-op so polling doesn't
+  // fight the restore. Promoted from closure inside registerTvListeners.
+  fingerprintRestoreActive: false,
+
+  // Timer + interval handles for refocusAfterContentChange's poll loop.
+  // Tracked so reentrant calls can cancel a stale loop before starting a new one.
+  // Promoted from closure inside registerTvListeners.
+  refocusTimeoutId: null,
+  refocusIntervalId: null,
+
+  // Last keypress timestamp. Used by getScrollBehavior to switch from smooth
+  // to instant scrolling on rapid sustained-hold D-pad bursts.
+  lastKeyTime: 0
+}

--- a/plugins/tv/focusColor.js
+++ b/plugins/tv/focusColor.js
@@ -1,0 +1,25 @@
+/**
+ * TV focus-ring color application + preset list.
+ *
+ * Reads/writes only the DOM (--tv-focus-color CSS variable) and Vuex
+ * via the passed store argument. No tvContext access — store is passed
+ * by the caller (listeners.js).
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+export const VALID_TV_FOCUS_HEXES = [
+  '#1ad691', '#3ea6ff', '#ffb74d', '#ff5252',
+  '#e040fb', '#ffeb3b', '#ffffff'
+]
+
+export const DEFAULT_TV_FOCUS_HEX = '#1ad691'
+
+export function applyTvFocusColor(value, store) {
+  const hex = VALID_TV_FOCUS_HEXES.includes(value) ? value : DEFAULT_TV_FOCUS_HEX
+  document.documentElement.style.setProperty('--tv-focus-color', hex)
+  // Self-heal: if the stored value was bad, dispatch a corrective save.
+  if (value && hex !== value && store) {
+    store.dispatch('user/updateUserSettings', { tvFocusColor: DEFAULT_TV_FOCUS_HEX })
+  }
+}

--- a/plugins/tv/focusEntry.js
+++ b/plugins/tv/focusEntry.js
@@ -1,0 +1,130 @@
+/**
+ * TV focus entry/restore helpers + content-change refocus poll.
+ *
+ * Used by pageHandlers/* and listeners.js to land focus on the right
+ * element after navigation or content changes.
+ *
+ * refocusAfterContentChange was previously closure-scoped inside
+ * registerTvListeners; its three timer/flag vars are now on tvContext.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+import { tvContext } from './context.js'
+import { isGridPage, scrollParentToReveal } from './scrollHelpers.js'
+import { restoreFromFingerprint } from './focusMemory.js'
+import { findPlayButton } from './selectors.js'
+
+export function focusFirstContentElement() {
+  // Try cards first (bookshelf pages)
+  const card = document.querySelector('[id^="book-card-"], [id^="series-card-"], [id^="collection-card-"], [id^="playlist-card-"], [id^="author-book-"], .author-card-wrapper')
+  if (card) {
+    card.focus({ preventScroll: true })
+    // On grid pages, snap the first card to 10px from top immediately
+    if (isGridPage()) {
+      scrollParentToReveal(card)
+    }
+    return true
+  }
+  // On author detail page or stats page, don't focus anything — let content
+  // show at top. D-pad scrolling is handled in handleKeyDown.
+  if (document.getElementById('author-page-wrapper') || document.getElementById('stats-page')) {
+    // Blur anything that might have auto-focused
+    if (document.activeElement && document.activeElement !== document.body) {
+      document.activeElement.blur()
+    }
+    return true
+  }
+  // On detail pages (playlist, collection, item), focus the Play button.
+  // Don't scroll — the page starts at the top and the Play button is
+  // already visible below the cover art. Scrolling to "reveal" it pushes
+  // the cover image out of view.
+  const playBtn = findPlayButton()
+  if (playBtn) {
+    playBtn.focus({ preventScroll: true })
+    return true
+  }
+  // Fallback: any focusable element in content area, excluding nav bars and toolbars
+  const contentArea = document.getElementById('bookshelf-wrapper') || document.querySelector('#content > div > .overflow-y-auto') || document.getElementById('content')
+  if (contentArea) {
+    const fallback = contentArea.querySelector('[tabindex="0"], button, a[href]:not([tabindex="-1"]):not([aria-hidden="true"])')
+    if (fallback) {
+      fallback.focus({ preventScroll: true })
+      scrollParentToReveal(fallback)
+      return true
+    }
+  }
+  // Last resort: if logged out with no content on a main nav page,
+  // navigate to Home where the Connect button is always visible.
+  // Only triggers on standard navigable pages — NOT on connect, settings,
+  // account, or other pages where the user is actively trying to log in.
+  if (!tvContext.store?.state?.user?.user) {
+    const currentPath = window.location.pathname
+    const loggedOutRedirectPages = [
+      '/bookshelf/library', '/bookshelf/authors', '/bookshelf/collections',
+      '/bookshelf/series', '/bookshelf/playlists', '/bookshelf/latest'
+    ]
+    if (loggedOutRedirectPages.includes(currentPath)) {
+      Object.keys(tvContext.pageFocusMemory).forEach((k) => delete tvContext.pageFocusMemory[k])
+      tvContext.focusHistory.length = 0
+      tvContext.lastFocusRect = null
+      // Access toast via Vuex store's internal Vue instance (Vue.prototype.$toast)
+      const toast = tvContext.store._vm?.$toast
+      if (toast) {
+        toast.info('No user logged in. Returning Home. Click Connect to Login.', { timeout: 5000 })
+      }
+      tvContext.store.app.router.replace('/')
+      return true
+    }
+  }
+  return false
+}
+
+// Single entry point for all player-close focus-restore paths (Back button,
+// MutationObserver on streamContainer class change, store.watch on session
+// state). All three previously raced and called focusFirstContentElement
+// independently; this helper unifies them so the pre-playback fingerprint
+// (saved by the store.watch on playback start) is consulted regardless of
+// which path wins the race.
+export async function focusAfterPlayerClose() {
+  const currentPath = tvContext.store?.app?.router?.currentRoute?.fullPath || window.location.pathname
+  const saved = tvContext.pageFocusMemory[currentPath]
+
+  // If we have a saved fingerprint for the current page, ALWAYS restore it.
+  // Android TV's native focus engine aggressively re-focuses a "nearby" element
+  // (often the primary Play button) the instant the fullscreen player's focused
+  // element is unmounted — guarding against that auto-focus is precisely why
+  // this function exists. Any non-body activeElement at this point is almost
+  // certainly the native engine's recovery guess, not user intent.
+  if (saved) {
+    const restored = await restoreFromFingerprint(saved)
+    if (restored) return
+  }
+
+  // No saved fingerprint OR restore failed — only set focus if we genuinely
+  // have no active element (don't steal from whatever the user is using).
+  if (!document.activeElement || document.activeElement === document.body) {
+    focusFirstContentElement()
+  }
+}
+
+// Re-focus helper — polls for first book card after content changes.
+// Was closure-scoped inside registerTvListeners; promoted to module scope
+// with state migrated to tvContext during v1.0.10 refactor.
+export function refocusAfterContentChange() {
+  if (tvContext.fingerprintRestoreActive) return
+  // Clear any existing poll to prevent stacking
+  clearTimeout(tvContext.refocusTimeoutId)
+  clearInterval(tvContext.refocusIntervalId)
+  tvContext.refocusTimeoutId = setTimeout(() => {
+    if (tvContext.fingerprintRestoreActive) return
+    let attempts = 0
+    tvContext.refocusIntervalId = setInterval(() => {
+      attempts++
+      if (tvContext.fingerprintRestoreActive || focusFirstContentElement() || attempts > 10) {
+        clearInterval(tvContext.refocusIntervalId)
+        tvContext.refocusIntervalId = null
+      }
+    }, 500)
+  }, 500)
+}

--- a/plugins/tv/focusMemory.js
+++ b/plugins/tv/focusMemory.js
@@ -1,0 +1,223 @@
+/**
+ * TV focus memory / fingerprint system.
+ *
+ * Tracks focused elements via stable fingerprints (ID + structural path +
+ * position) so Back navigation can restore focus to the same logical
+ * element even if the virtualizer recycled the DOM node.
+ *
+ * Reads/writes tvContext.pageFocusMemory and uses tvContext.cssEscape.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+import { tvContext } from './context.js'
+import { isVisible, getAllFocusable } from './visibility.js'
+import { findPageScrollContainer, scrollParentToReveal } from './scrollHelpers.js'
+
+export function getElementFingerprint(el) {
+  if (!el || el === document.body) return null
+
+  const rect = el.getBoundingClientRect()
+  const scrollContainer = findPageScrollContainer(el)
+  const scrollTop = scrollContainer?.scrollTop || 0
+
+  const fingerprint = {
+    scrollTop,
+    relativeTop: scrollContainer ? rect.top - scrollContainer.getBoundingClientRect().top + scrollTop : rect.top,
+    relativeLeft: rect.left,
+    tagName: el.tagName
+  }
+
+  // Prefer ID-based selectors
+  if (el.id) {
+    fingerprint.selector = '#' + tvContext.cssEscape(el.id)
+    fingerprint.idIsUnique = document.querySelectorAll('#' + tvContext.cssEscape(el.id)).length === 1
+  }
+  // For author cards
+  if (el.classList.contains('author-card-wrapper')) {
+    const siblings = Array.from(document.querySelectorAll('.author-card-wrapper'))
+    fingerprint.authorIndex = siblings.indexOf(el)
+  }
+  // For buttons with aria-label
+  if (el.tagName === 'BUTTON' && el.getAttribute('aria-label')) {
+    const label = el.getAttribute('aria-label').replace(/"/g, '\\"')
+    fingerprint.selector = `button[aria-label="${label}"]`
+  }
+
+  // Build a structural path: find the element's index among same-tag siblings
+  // within its parent, walking up to a parent with an ID or a known class
+  fingerprint.structuralPath = buildStructuralPath(el)
+
+  // Save index among all focusable elements as last resort
+  const allFocusable = getAllFocusable()
+  fingerprint.focusableIndex = allFocusable.indexOf(el)
+  fingerprint.totalFocusable = allFocusable.length
+
+  return fingerprint
+}
+
+// Internal: not exported. Used by getElementFingerprint + restoreFromFingerprint.
+function buildStructuralPath(el) {
+  const parts = []
+  let current = el
+  let depth = 0
+  while (current && current !== document.body && depth < 10) {
+    const parent = current.parentElement
+    if (!parent) break
+    const siblings = Array.from(parent.children).filter((c) => c.tagName === current.tagName)
+    const index = siblings.indexOf(current)
+    parts.unshift({ tag: current.tagName, index, id: current.id || null })
+    if (current.id) break // Stop at first ancestor with an ID
+    current = parent
+    depth++
+  }
+  return parts
+}
+
+// Internal: not exported.
+function findByStructuralPath(path) {
+  if (!path || path.length === 0) return null
+  // Start from the element with an ID (if any) and walk down
+  let root = null
+  let startIdx = 0
+  for (let i = 0; i < path.length; i++) {
+    if (path[i].id) {
+      root = document.getElementById(path[i].id)
+      startIdx = i + 1
+      break
+    }
+  }
+  if (!root) {
+    // No ID anchor — walk from body
+    root = document.body
+    startIdx = 0
+  }
+  let current = root
+  for (let i = startIdx; i < path.length; i++) {
+    const step = path[i]
+    const candidates = Array.from(current.children).filter((c) => c.tagName === step.tag)
+    if (step.index >= candidates.length) return null
+    current = candidates[step.index]
+  }
+  return current
+}
+
+export function restoreFromFingerprint(fingerprint) {
+  if (!fingerprint) return false
+
+  // Ensure scroll position is restored before looking for the element.
+  // Called synchronously at the start of each tryRestore attempt so the
+  // target element is in the viewport when isVisible runs.
+  // Looks up the scroll container fresh each time — the page may not have
+  // mounted yet on the first call (afterEach fires before Vue renders).
+  const ensureScroll = () => {
+    if (fingerprint.scrollTop <= 0) return
+    const scrollContainer = document.getElementById('bookshelf-wrapper') || document.querySelector('.overflow-y-auto')
+    if (scrollContainer && scrollContainer.scrollTop < fingerprint.scrollTop * 0.5) {
+      scrollContainer.scrollTop = fingerprint.scrollTop
+    }
+  }
+
+  // Wait for content to mount after scroll, then find the element.
+  // Use multiple attempts to handle slow-loading content (server fetch on first visit).
+  // ID-based lookups retry longer before falling through to position fallback.
+  return new Promise((resolve) => {
+    let attempts = 0
+    const maxAttempts = 12
+    // Fast-poll first, then slow down for patient retries
+    const retryDelay = () => attempts < 5 ? 250 : 500
+    const tryRestore = () => {
+      attempts++
+      // Apply scroll before element lookup so target is in viewport
+      ensureScroll()
+      // Look up scroll container fresh — page may have just mounted
+      const scrollContainer = document.getElementById('bookshelf-wrapper') || document.querySelector('.overflow-y-auto')
+      let el = null
+
+      // 1. Try unique ID — but verify visibility (the virtualizer may leave
+      //    stale orphan nodes in the DOM with the same ID as the live card)
+      if (!el && fingerprint.selector && fingerprint.idIsUnique) {
+        const candidates = Array.from(document.querySelectorAll(fingerprint.selector))
+        // Prefer the visible one; stale orphans have zero-size bounding rects
+        el = candidates.find((c) => isVisible(c)) || null
+      }
+
+      // 2. Author cards by index
+      if (!el && fingerprint.authorIndex !== undefined) {
+        const authors = document.querySelectorAll('.author-card-wrapper')
+        el = authors[fingerprint.authorIndex]
+      }
+
+      // 3. Non-unique IDs — position match (filter to visible candidates only)
+      if (!el && fingerprint.selector && !fingerprint.idIsUnique) {
+        const candidates = Array.from(document.querySelectorAll(fingerprint.selector)).filter((c) => isVisible(c))
+        if (candidates.length === 1) {
+          el = candidates[0]
+        } else if (candidates.length > 1) {
+          let bestDist = Infinity
+          // Container rect is invariant across candidates — compute once (I4).
+          const containerRect = scrollContainer?.getBoundingClientRect()
+          const containerScrollTop = scrollContainer?.scrollTop || 0
+          for (const candidate of candidates) {
+            const rect = candidate.getBoundingClientRect()
+            const relTop = containerRect ? rect.top - containerRect.top + containerScrollTop : rect.top
+            const dist = Math.abs(relTop - fingerprint.relativeTop) + Math.abs(rect.left - fingerprint.relativeLeft)
+            if (dist < bestDist) {
+              bestDist = dist
+              el = candidate
+            }
+          }
+        }
+      }
+
+      // 4. Structural path (for elements without IDs, like playlist buttons)
+      if (!el && fingerprint.structuralPath && !fingerprint.selector) {
+        el = findByStructuralPath(fingerprint.structuralPath)
+        if (el && fingerprint.tagName && el.tagName !== fingerprint.tagName) el = null
+        if (el && !isVisible(el)) el = null
+      }
+
+      // If we have a specific lookup method (ID selector, author index, or
+      // structural path) and haven't found the element yet, keep retrying —
+      // page content may still be loading after navigation.
+      // Only fall through to position fallback on the final attempts.
+      const hasSpecificLookup = fingerprint.selector || fingerprint.authorIndex !== undefined || fingerprint.structuralPath
+      if (!el && hasSpecificLookup && attempts < maxAttempts - 2) {
+        setTimeout(tryRestore, retryDelay())
+        return
+      }
+
+      // 5. Fallback: position match among content focusable elements (not nav/toolbar)
+      if (!el) {
+        const allFocusable = getAllFocusable().filter((c) =>
+          !c.closest('#appbar') && !c.closest('#bookshelf-navbar') && !c.closest('#bookshelf-toolbar')
+        )
+        if (allFocusable.length > 0) {
+          let bestDist = Infinity
+          const expectedTop = fingerprint.relativeTop - fingerprint.scrollTop + (scrollContainer?.getBoundingClientRect()?.top || 0)
+          for (const candidate of allFocusable) {
+            const cRect = candidate.getBoundingClientRect()
+            // Prefer same tag type
+            const tagPenalty = (fingerprint.tagName && candidate.tagName !== fingerprint.tagName) ? 200 : 0
+            const dist = Math.abs(cRect.left - fingerprint.relativeLeft) + Math.abs(cRect.top - expectedTop) + tagPenalty
+            if (dist < bestDist) {
+              bestDist = dist
+              el = candidate
+            }
+          }
+        }
+      }
+
+      if (el) {
+        el.focus({ preventScroll: true })
+        scrollParentToReveal(el)
+        resolve(true)
+      } else if (attempts < maxAttempts) {
+        setTimeout(tryRestore, retryDelay())
+      } else {
+        resolve(false)
+      }
+    }
+    setTimeout(tryRestore, 300)
+  })
+}

--- a/plugins/tv/overlayFocus.js
+++ b/plugins/tv/overlayFocus.js
@@ -1,0 +1,92 @@
+/**
+ * Overlay (modal / side-drawer / menu) focus save + restore + navigation.
+ *
+ * Reads/writes tvContext.focusHistory. Uses getAllFocusable for trap-within-overlay.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+import { tvContext } from './context.js'
+import { getAllFocusable } from './visibility.js'
+import { findVisibleSideDrawer } from './selectors.js'
+
+export function saveFocusBeforeOverlay() {
+  const active = document.activeElement
+  if (active && active !== document.body) {
+    tvContext.focusHistory.push(active)
+  }
+}
+
+export function restoreFocusAfterOverlay() {
+  if (tvContext.focusHistory.length === 0) return false
+  const previous = tvContext.focusHistory.pop()
+  if (!previous || !document.contains(previous)) return false
+
+  // Focus immediately, then re-focus after a short delay to ensure
+  // the focus ring renders after the overlay close animation completes
+  previous.focus()
+  setTimeout(() => {
+    if (document.activeElement !== previous) {
+      previous.focus()
+    }
+  }, 100)
+  return true
+}
+
+/**
+ * Check if a modal or overlay is currently open.
+ * Returns the overlay element if found, null otherwise.
+ *
+ * Detection methods:
+ * 1. modal-open class on <html> (set by modals-modal base component via Vuex)
+ * 2. Side drawer panel without translate-x-64 class (visible drawer)
+ */
+export function getActiveOverlay() {
+  // Check for side drawer first (it doesn't use the modal system)
+  const drawerPanel = findVisibleSideDrawer()
+  if (drawerPanel) return drawerPanel
+
+  // Check for any open modal (the Modal.vue base component adds modal-open to <html>
+  // and appends the modal to document.body)
+  if (document.documentElement.classList.contains('modal-open')) {
+    // Find the visible modal in document.body
+    const modals = document.querySelectorAll('body > .modal')
+    for (const modal of modals) {
+      if (modal.style.opacity !== '0') {
+        // Dynamically add tabindex to li[role="option"] elements so they're focusable
+        modal.querySelectorAll('li[role="option"]:not([tabindex])').forEach((li) => {
+          li.setAttribute('tabindex', '0')
+        })
+        return modal
+      }
+    }
+  }
+
+  return null
+}
+
+export function handleOverlayNavigation(event, overlay) {
+  const { key } = event
+  // Inside overlays, include scrolled-off items in the focusable set so long
+  // lists (e.g. OrderModal's 13 sort options in a 70vh scroll container) wrap
+  // correctly — scrollIntoView below brings the newly-focused item into view.
+  const focusables = getAllFocusable(overlay, { ignoreViewport: true })
+  const currentIndex = focusables.indexOf(document.activeElement)
+
+  if (key === 'ArrowDown' || key === 'ArrowRight') {
+    event.preventDefault()
+    const nextIndex = currentIndex < focusables.length - 1 ? currentIndex + 1 : 0
+    focusables[nextIndex]?.focus({ preventScroll: true })
+    focusables[nextIndex]?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  } else if (key === 'ArrowUp' || key === 'ArrowLeft') {
+    event.preventDefault()
+    const prevIndex = currentIndex > 0 ? currentIndex - 1 : focusables.length - 1
+    focusables[prevIndex]?.focus({ preventScroll: true })
+    focusables[prevIndex]?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  } else if (key === 'Enter') {
+    // Trigger a click on the focused element (modal items use @click, not @keydown)
+    event.preventDefault()
+    document.activeElement?.click()
+    return
+  }
+}

--- a/plugins/tv/pageHandlers/authorPage.js
+++ b/plugins/tv/pageHandlers/authorPage.js
@@ -1,0 +1,68 @@
+/**
+ * Author bio page D-pad handler.
+ *
+ * Handles all vertical navigation on author detail pages. Book cards
+ * within the page get prioritized focus when in view; otherwise the
+ * page scrolls and looks for newly visible cards.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if handled, false to fall through.
+ */
+
+import { scrollParentToReveal } from '../scrollHelpers.js'
+import { findVerticalTarget } from '../spatialNav.js'
+
+export function handleAuthorPage(event, key, activeEl, authorWrapper) {
+  if (key !== 'ArrowDown' && key !== 'ArrowUp') return false
+
+  const focusedIsBookCard = activeEl?.id?.startsWith('author-book-')
+
+  if (focusedIsBookCard) {
+    // Currently on a book card — try to find another card in the direction
+    const next = findVerticalTarget(key)
+    if (next && next.id?.startsWith('author-book-')) {
+      event.preventDefault()
+      next.focus({ preventScroll: true })
+      scrollParentToReveal(next)
+      return true
+    }
+    // No more book cards in this direction — blur and scroll
+    event.preventDefault()
+    document.activeElement.blur()
+    authorWrapper.scrollBy({ top: key === 'ArrowDown' ? 150 : -150, behavior: 'smooth' })
+    // When scrolling down past books, check for more cards
+    if (key === 'ArrowDown') {
+      setTimeout(() => {
+        const wrapperRect = authorWrapper.getBoundingClientRect()
+        const children = authorWrapper.querySelectorAll('[id^="author-book-"]')
+        for (const child of children) {
+          const childRect = child.getBoundingClientRect()
+          if (childRect.top >= wrapperRect.top && childRect.bottom <= wrapperRect.bottom) {
+            child.focus({ preventScroll: true })
+            return
+          }
+        }
+      }, 250)
+    }
+    return true
+  }
+
+  // No book card focused — scroll the page
+  event.preventDefault()
+  authorWrapper.scrollBy({ top: key === 'ArrowDown' ? 150 : -150, behavior: 'smooth' })
+  // After scrolling down, check if book cards are now visible
+  if (key === 'ArrowDown') {
+    setTimeout(() => {
+      const wrapperRect = authorWrapper.getBoundingClientRect()
+      const children = authorWrapper.querySelectorAll('[id^="author-book-"]')
+      for (const child of children) {
+        const childRect = child.getBoundingClientRect()
+        if (childRect.top >= wrapperRect.top && childRect.bottom <= wrapperRect.bottom) {
+          child.focus({ preventScroll: true })
+          return
+        }
+      }
+    }, 250)
+  }
+  return true
+}

--- a/plugins/tv/pageHandlers/episodeRow.js
+++ b/plugins/tv/pageHandlers/episodeRow.js
@@ -1,0 +1,124 @@
+/**
+ * Podcast episode row D-pad handler.
+ *
+ * Handles intra-episode navigation (title ↔ controls) and inter-episode
+ * navigation (snap-to-top on next/previous episode).
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if handled, false to fall through.
+ */
+
+import { findPageScrollContainer, getScrollBehavior, scrollParentToReveal } from '../scrollHelpers.js'
+import { findVerticalTarget } from '../spatialNav.js'
+
+export function handleEpisodeRow(event, key, activeEl, episodeRow) {
+  const isOnEpisodeTitle = activeEl?.id?.startsWith('episode-')
+
+  if (isOnEpisodeTitle && key === 'ArrowDown') {
+    // Title → Play button (first focusable in the controls row)
+    const playBtn = episodeRow.querySelector('div[tabindex="0"]')
+    if (playBtn) {
+      event.preventDefault()
+      playBtn.focus({ preventScroll: true })
+      return true
+    }
+  }
+  if (!isOnEpisodeTitle && key === 'ArrowUp') {
+    // Controls → back up to episode title (only if we're below the title)
+    const title = episodeRow.querySelector('p[id^="episode-"]')
+    if (title) {
+      const titleRect = title.getBoundingClientRect()
+      const activeRect = activeEl.getBoundingClientRect()
+      if (activeRect.top >= titleRect.bottom - 5) {
+        // We're below the title (controls area) — go up to title
+        // and scroll to show the full episode row
+        event.preventDefault()
+        title.focus({ preventScroll: true })
+        const scrollContainer = findPageScrollContainer(title)
+        if (scrollContainer) {
+          const rowRect = episodeRow.getBoundingClientRect()
+          const containerRect = scrollContainer.getBoundingClientRect()
+          if (rowRect.top < containerRect.top) {
+            scrollContainer.scrollBy({ top: rowRect.top - containerRect.top + 5, behavior: getScrollBehavior() })
+          }
+        }
+        return true
+      }
+      // We're above the title (podcast name link) — go to previous episode's play button
+      const next = findVerticalTarget(key)
+      if (next) {
+        event.preventDefault()
+        const prevRow = next.closest?.('.border-b')
+        let target = next
+        if (prevRow && prevRow !== episodeRow) {
+          const playBtn = prevRow.querySelector('div[tabindex="0"]')
+          if (playBtn) target = playBtn
+        }
+        target.focus({ preventScroll: true })
+        // Snap the previous episode row to top
+        const targetRow = target.closest?.('.border-b')
+        if (targetRow) {
+          const scrollContainer = findPageScrollContainer(target)
+          if (scrollContainer) {
+            const rowRect = targetRow.getBoundingClientRect()
+            const containerRect = scrollContainer.getBoundingClientRect()
+            const offset = rowRect.top - containerRect.top + 5
+            if (offset < 0) scrollContainer.scrollBy({ top: offset, behavior: getScrollBehavior() })
+          }
+        } else {
+          scrollParentToReveal(target)
+        }
+        return true
+      }
+    }
+  }
+  if (isOnEpisodeTitle && key === 'ArrowUp') {
+    // Title → previous episode's play button or page content above
+    const next = findVerticalTarget(key)
+    if (next) {
+      event.preventDefault()
+      // If landing in another episode row, force focus to its play button
+      const nextRow = next.closest?.('.border-b')
+      let target = next
+      if (nextRow && nextRow !== episodeRow) {
+        const playBtn = nextRow.querySelector('div[tabindex="0"]')
+        if (playBtn) target = playBtn
+      }
+      target.focus({ preventScroll: true })
+      // Scroll to show the episode row
+      if (nextRow) {
+        const scrollContainer = findPageScrollContainer(target)
+        if (scrollContainer) {
+          const rowRect = nextRow.getBoundingClientRect()
+          const containerRect = scrollContainer.getBoundingClientRect()
+          const offset = rowRect.top - containerRect.top + 5
+          if (offset < 0) scrollContainer.scrollBy({ top: offset, behavior: getScrollBehavior() })
+        }
+      } else {
+        scrollParentToReveal(target)
+      }
+      return true
+    }
+  }
+  if (!isOnEpisodeTitle && key === 'ArrowDown') {
+    // From controls, move to next episode title — snap to top
+    const next = findVerticalTarget(key)
+    if (next) {
+      event.preventDefault()
+      next.focus({ preventScroll: true })
+      // Snap the next episode row to the top of the viewport
+      const nextRow = next.closest?.('.border-b')
+      const scrollTarget = nextRow || next
+      const scrollContainer = findPageScrollContainer(next)
+      if (scrollContainer) {
+        const targetRect = scrollTarget.getBoundingClientRect()
+        const containerRect = scrollContainer.getBoundingClientRect()
+        const offset = targetRect.top - containerRect.top + 5
+        if (Math.abs(offset) > 10) scrollContainer.scrollBy({ top: offset, behavior: getScrollBehavior() })
+      }
+      return true
+    }
+  }
+
+  return false
+}

--- a/plugins/tv/pageHandlers/gridNav.js
+++ b/plugins/tv/pageHandlers/gridNav.js
@@ -1,0 +1,122 @@
+/**
+ * General grid D-pad handler — the catch-all for ArrowLeft/Right and
+ * ArrowUp/Down when no more specific page handler matched.
+ *
+ * Includes virtualizer recovery: re-finds and re-focuses the target card
+ * after scroll settles, since series/collection/playlist cards can be
+ * briefly detached during scroll.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Always preventDefaults on arrow keys — this is the terminal handler.
+ * Returns true (always handled when an arrow key) or false (non-arrow).
+ */
+
+import { tvContext } from '../context.js'
+import { getScrollBehavior, scrollParentToReveal, findPageScrollContainer } from '../scrollHelpers.js'
+import { isVisible } from '../visibility.js'
+import { findHorizontalTarget, findVerticalTarget, findShelfVerticalTarget, rememberGridCol, rememberGridRow } from '../spatialNav.js'
+
+export function handleGridNav(event, key) {
+  if (key === 'ArrowLeft' || key === 'ArrowRight') {
+    const next = findHorizontalTarget(key)
+    if (next) {
+      event.preventDefault()
+      rememberGridCol(next)
+      next.focus({ preventScroll: true })
+      tvContext.lastFocusRect = next.getBoundingClientRect()
+      scrollParentToReveal(next)
+    } else {
+      event.preventDefault()
+    }
+    return true
+  }
+
+  if (key === 'ArrowUp' || key === 'ArrowDown') {
+    event.preventDefault()
+    // Guard: the virtualizer can't remove series/collection/playlist cards
+    // (wrong ID prefix) so it re-appends them via appendChild, which briefly
+    // detaches the focused element.  Suppress focusout recovery during scroll.
+    tvContext.verticalNavInProgress = true
+    const clearNavGuard = () => { tvContext.verticalNavInProgress = false }
+    // Column-stable structural target first. It resolves the column from the
+    // remembered grid position when focus has dropped to <body> during
+    // virtualizer churn — exactly when the geometric finder sampled a
+    // half-rendered row and collapsed focus to column 1 / the last column.
+    // Falls through to geometry for grid-exit moves (e.g. ArrowUp to the
+    // toolbar) and non-shelf pages; a not-yet-mounted target row takes the
+    // scroll-and-retry path below.
+    const shelfHit = findShelfVerticalTarget(key)
+    const next = shelfHit ? shelfHit.card : findVerticalTarget(key)
+    if (next) {
+      if (shelfHit) {
+        tvContext.lastGridIndex = shelfHit.index
+        tvContext.lastGridPrefix = shelfHit.prefix
+        tvContext.gridIntendedCol = shelfHit.col
+      } else {
+        // Geometry fallback: track the row anchor only — NEVER let a fallback
+        // (which may land on the engine's hijacked column) overwrite the
+        // intended column.
+        rememberGridRow(next)
+      }
+      tvContext.lastVerticalNavAt = Date.now()
+      const targetId = next.id
+      next.focus({ preventScroll: true })
+      tvContext.lastFocusRect = next.getBoundingClientRect()
+      scrollParentToReveal(next)
+      // The virtualizer may remount cards during scroll, which can drop focus.
+      // Re-find and re-focus the target card after the scroll settles.
+      if (targetId) {
+        setTimeout(() => {
+          try {
+            if (!document.activeElement || document.activeElement === document.body) {
+              // Prefer the visible instance (stale orphans may share the same ID)
+              const matches = Array.from(document.querySelectorAll('#' + tvContext.cssEscape(targetId)))
+              const refound = matches.find((m) => isVisible(m))
+              if (refound) {
+                refound.focus({ preventScroll: true })
+                tvContext.lastFocusRect = refound.getBoundingClientRect()
+              }
+            }
+          } finally {
+            clearNavGuard()
+          }
+        }, 500)
+      } else {
+        setTimeout(clearNavGuard, 500)
+      }
+    } else {
+      // Virtualized rows — scroll to trigger rendering, then retry
+      const scrollContainer = document.getElementById('bookshelf-wrapper') || findPageScrollContainer()
+      if (scrollContainer) {
+        const scrollAmount = key === 'ArrowDown' ? 240 : -240
+        scrollContainer.scrollBy({ top: scrollAmount, behavior: getScrollBehavior() })
+        setTimeout(() => {
+          try {
+            const retryHit = findShelfVerticalTarget(key)
+            const retryTarget = retryHit ? retryHit.card : findVerticalTarget(key)
+            if (retryTarget) {
+              if (retryHit) {
+                tvContext.lastGridIndex = retryHit.index
+                tvContext.lastGridPrefix = retryHit.prefix
+                tvContext.gridIntendedCol = retryHit.col
+              } else {
+                rememberGridRow(retryTarget)
+              }
+              tvContext.lastVerticalNavAt = Date.now()
+              retryTarget.focus({ preventScroll: true })
+              tvContext.lastFocusRect = retryTarget.getBoundingClientRect()
+              scrollParentToReveal(retryTarget)
+            }
+          } finally {
+            clearNavGuard()
+          }
+        }, 500)
+      } else {
+        clearNavGuard()
+      }
+    }
+    return true
+  }
+
+  return false
+}

--- a/plugins/tv/pageHandlers/itemPage.js
+++ b/plugins/tv/pageHandlers/itemPage.js
@@ -1,0 +1,40 @@
+/**
+ * Item detail page D-pad handler.
+ *
+ * When no focusable target exists in the pressed direction, scroll the
+ * page so users can browse non-focusable content (cover, metadata,
+ * description). When a focusable element scrolls into view, transfer focus.
+ *
+ * Grid pages (Series, Collections, etc.) skip this — they use the general
+ * grid handler which has virtualizer recovery for re-appended cards.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if handled, false to fall through.
+ */
+
+import { getScrollBehavior, scrollParentToReveal, isGridPage } from '../scrollHelpers.js'
+import { findVerticalTarget } from '../spatialNav.js'
+
+export function handleItemPage(event, key, activeEl, itemPage) {
+  if (isGridPage()) return false
+  if (key !== 'ArrowDown' && key !== 'ArrowUp') return false
+
+  const next = findVerticalTarget(key)
+  if (next) {
+    event.preventDefault()
+    next.focus({ preventScroll: true })
+    scrollParentToReveal(next)
+    return true
+  }
+  // No focusable target — scroll the page and check for newly visible elements
+  event.preventDefault()
+  itemPage.scrollBy({ top: key === 'ArrowDown' ? 150 : -150, behavior: getScrollBehavior() })
+  setTimeout(() => {
+    const retryTarget = findVerticalTarget(key)
+    if (retryTarget) {
+      retryTarget.focus({ preventScroll: true })
+      scrollParentToReveal(retryTarget)
+    }
+  }, 300)
+  return true
+}

--- a/plugins/tv/pageHandlers/logsContainer.js
+++ b/plugins/tv/pageHandlers/logsContainer.js
@@ -1,0 +1,64 @@
+/**
+ * Logs page D-pad handler.
+ *
+ * No focusable elements in the log itself — just scroll. Header buttons
+ * (copy, share, ellipsis) are reachable only when scrolled to the top.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if handled, false to fall through.
+ */
+
+import { getScrollBehavior } from '../scrollHelpers.js'
+
+export function handleLogsContainer(event, key, activeEl, logsContainer) {
+  const logsPage = logsContainer.parentElement
+  const focusOnHeader = activeEl && activeEl !== document.body && logsPage?.contains(activeEl) && !logsContainer.contains(activeEl)
+  const focusInAppbar = activeEl && activeEl !== document.body && activeEl.closest('#appbar')
+
+  // Left/Right on header: use generic horizontal nav — fall through
+  if (focusOnHeader && (key === 'ArrowLeft' || key === 'ArrowRight')) {
+    return false
+  }
+  // Left/Right elsewhere: ignore
+  if (key === 'ArrowLeft' || key === 'ArrowRight') {
+    event.preventDefault()
+    return true
+  }
+  // Down from appbar: return to logs
+  if (focusInAppbar && key === 'ArrowDown') {
+    event.preventDefault()
+    const headerBtn = logsPage?.querySelector('button')
+    if (headerBtn) headerBtn.focus({ preventScroll: true })
+    return true
+  }
+  // Up from header: escape to nav bar — fall through
+  if (focusOnHeader && key === 'ArrowUp') {
+    return false
+  }
+  // Down from header: blur and enter log scrolling
+  if (focusOnHeader && key === 'ArrowDown') {
+    event.preventDefault()
+    document.activeElement.blur()
+    logsContainer.scrollBy({ top: 200, behavior: getScrollBehavior() })
+    return true
+  }
+  // Up: scroll log up. When at top, move to header buttons
+  if (key === 'ArrowUp') {
+    event.preventDefault()
+    if (logsContainer.scrollTop < 10) {
+      const headerBtn = logsPage?.querySelector('button')
+      if (headerBtn) headerBtn.focus({ preventScroll: true })
+    } else {
+      logsContainer.scrollBy({ top: -200, behavior: getScrollBehavior() })
+    }
+    return true
+  }
+  // Down: scroll log down
+  if (key === 'ArrowDown') {
+    event.preventDefault()
+    logsContainer.scrollBy({ top: 200, behavior: getScrollBehavior() })
+    return true
+  }
+
+  return false
+}

--- a/plugins/tv/pageHandlers/navBarEscape.js
+++ b/plugins/tv/pageHandlers/navBarEscape.js
@@ -1,0 +1,38 @@
+/**
+ * Nav bar escape handler.
+ *
+ * On any page, when pressing Up and no focusable element exists above
+ * within the page content, focus the appbar back button or first appbar
+ * element. Handles pages like Account, Stats, Settings where content
+ * is inside a scroll container separate from the appbar.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if handled, false to fall through.
+ */
+
+import { findPageScrollContainer } from '../scrollHelpers.js'
+import { findVerticalTarget } from '../spatialNav.js'
+
+export function handleNavBarEscape(event, key, activeEl) {
+  if (key !== 'ArrowUp') return false
+  if (!activeEl || activeEl === document.body) return false
+
+  const pageContainer = findPageScrollContainer()
+  if (!pageContainer || !pageContainer.contains(activeEl) || activeEl.closest('#appbar')) return false
+
+  const next = findVerticalTarget(key)
+  // Only escape to appbar if there's truly no target above at all.
+  // If there IS a target outside the container (e.g. bookshelf-navbar),
+  // let the normal handlers deal with it.
+  if (next) return false
+  if (pageContainer.scrollTop >= 50) return false
+
+  event.preventDefault()
+  const appbar = document.getElementById('appbar')
+  if (!appbar) return false
+  const appbarFocusable = appbar.querySelector('a[tabindex="0"], button, a[href]:not([tabindex="-1"])')
+  if (!appbarFocusable) return false
+
+  appbarFocusable.focus({ preventScroll: true })
+  return true
+}

--- a/plugins/tv/pageHandlers/playerNav.js
+++ b/plugins/tv/pageHandlers/playerNav.js
@@ -1,0 +1,102 @@
+/**
+ * Audio player D-pad navigation handler.
+ *
+ * Handles:
+ * - Back/Escape while fullscreen → close player + restore focus
+ * - Fullscreen player left/right nav (intra-row, including top-row toggle)
+ * - Fullscreen player up/down nav (top row ↔ controls ↔ utility)
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if the event was handled (caller should return), false to fall through.
+ */
+
+import { findHorizontalTarget, findVerticalTarget } from '../spatialNav.js'
+import { focusAfterPlayerClose } from '../focusEntry.js'
+
+export function handlePlayerNav(event, key, activeEl, streamContainer) {
+  const isFullscreen = streamContainer.classList.contains('fullscreen')
+  const focusInPlayer = streamContainer.contains(document.activeElement)
+
+  // Back/Escape while player is fullscreen: close the player entirely.
+  // collapseFullscreen() on TV calls closePlayback() instead of minimizing.
+  if (isFullscreen && (key === 'Escape' || key === 'GoBack' || event.keyCode === 4)) {
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    document.activeElement?.blur()
+    const collapseSpan = streamContainer.querySelector('.top-4.left-4 [tabindex="0"]')
+    if (collapseSpan) collapseSpan.click()
+    // Player closes — restore pre-playback fingerprint if one was saved,
+    // else fall back to first content element.
+    setTimeout(() => focusAfterPlayerClose(), 500)
+    return true
+  }
+
+  // Mini player navigation removed — on TV the player always closes
+  // entirely instead of minimizing. A future user setting will allow
+  // toggling between minimize and close behavior.
+
+  // Navigation within fullscreen player — explicit row-based nav since
+  // absolute positioning makes generic findVerticalTarget unreliable.
+  // Rows: top (collapse, more_vert) ↔ controls (transport) ↔ utility (bookmark, speed, etc.)
+  if (isFullscreen && focusInPlayer) {
+    if (key === 'ArrowLeft' || key === 'ArrowRight') {
+      event.preventDefault()
+      const inTopRow = document.activeElement.closest('.top-4.left-4') ||
+        document.activeElement.closest('.top-6.right-4')
+      if (inTopRow) {
+        // Top row: explicit toggle between collapse and more_vert
+        const collapseSpan = streamContainer.querySelector('.top-4.left-4 [tabindex="0"]')
+        const moreSpan = streamContainer.querySelector('.top-6.right-4 [tabindex="0"]')
+        if (document.activeElement === collapseSpan && moreSpan) {
+          moreSpan.focus({ preventScroll: true })
+        } else if (document.activeElement === moreSpan && collapseSpan) {
+          collapseSpan.focus({ preventScroll: true })
+        }
+      } else {
+        const next = findHorizontalTarget(key)
+        if (next && streamContainer.contains(next)) {
+          next.focus({ preventScroll: true })
+        }
+      }
+      return true
+    }
+    if (key === 'ArrowUp' || key === 'ArrowDown') {
+      event.preventDefault()
+      const playerControls = document.getElementById('playerControls')
+      const inControls = playerControls?.contains(document.activeElement)
+      const inTopRow = document.activeElement.closest('.top-4.left-4') ||
+        document.activeElement.closest('.top-6.right-4')
+      const inUtility = !inControls && !inTopRow
+
+      if (key === 'ArrowUp') {
+        if (inUtility) {
+          // Utility → Controls: focus play/pause
+          const playBtn = streamContainer.querySelector('.play-btn')
+          if (playBtn) playBtn.focus({ preventScroll: true })
+        } else if (inControls) {
+          // Controls → Top row: focus collapse button
+          const collapseSpan = streamContainer.querySelector('.top-4.left-4 [tabindex="0"]')
+          if (collapseSpan) collapseSpan.focus({ preventScroll: true })
+        }
+        // From top row, Up does nothing
+      } else {
+        // ArrowDown
+        if (inTopRow) {
+          // Top row → Controls: focus play/pause
+          const playBtn = streamContainer.querySelector('.play-btn')
+          if (playBtn) playBtn.focus({ preventScroll: true })
+        } else if (inControls) {
+          // Controls → Utility: focus first utility button
+          const next = findVerticalTarget(key)
+          if (next && streamContainer.contains(next)) {
+            next.focus({ preventScroll: true })
+          }
+        }
+        // From utility, Down does nothing
+      }
+      return true
+    }
+  }
+
+  return false
+}

--- a/plugins/tv/pageHandlers/statsPage.js
+++ b/plugins/tv/pageHandlers/statsPage.js
@@ -1,0 +1,94 @@
+/**
+ * Stats page D-pad handler.
+ *
+ * Scroll-through content like author bio pages — always scroll first,
+ * then transfer focus to elements entering the viewport.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ * Returns true if handled, false to fall through.
+ */
+
+import { getScrollBehavior } from '../scrollHelpers.js'
+import { getAllFocusable } from '../visibility.js'
+import { findHorizontalTarget } from '../spatialNav.js'
+import { focusFirstContentElement } from '../focusEntry.js'
+
+export function handleStatsPage(event, key, activeEl, statsPage) {
+  const focusInStats = activeEl && activeEl !== document.body && statsPage.contains(activeEl)
+  const focusInAppbar = activeEl && activeEl !== document.body && activeEl.closest('#appbar')
+
+  // Only handle keys when focus is in stats page, on body (no focus), or
+  // in appbar (just escaped to nav bar). Let other handlers run otherwise.
+  if (!(focusInStats || focusInAppbar || activeEl === document.body)) return false
+  if (!['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(key)) return false
+
+  // Left/Right in appbar: use generic handler (don't trap) — fall through
+  if (focusInAppbar && (key === 'ArrowLeft' || key === 'ArrowRight')) {
+    return false
+  }
+  // Left/Right in stats: horizontal nav within focused row
+  if (key === 'ArrowLeft' || key === 'ArrowRight') {
+    event.preventDefault()
+    if (focusInStats) {
+      const next = findHorizontalTarget(key)
+      if (next && statsPage.contains(next)) {
+        next.focus({ preventScroll: true })
+      }
+    }
+    return true
+  }
+  // Down from appbar: return to stats page
+  if (focusInAppbar && key === 'ArrowDown') {
+    event.preventDefault()
+    statsPage.scrollTo({ top: 0 })
+    focusFirstContentElement()
+    return true
+  }
+  // Up at top of stats: escape to nav bar
+  if (key === 'ArrowUp' && statsPage.scrollTop < 50 && !focusInAppbar) {
+    event.preventDefault()
+    const appbar = document.getElementById('appbar')
+    if (appbar) {
+      const appbarFocusable = appbar.querySelector('a[tabindex="0"], button, a[href]:not([tabindex="-1"])')
+      if (appbarFocusable) {
+        appbarFocusable.focus({ preventScroll: true })
+        return true
+      }
+    }
+  }
+  if (key === 'ArrowDown' || key === 'ArrowUp') {
+    event.preventDefault()
+    // Blur and scroll
+    if (focusInStats) document.activeElement.blur()
+    statsPage.scrollBy({ top: key === 'ArrowDown' ? 150 : -150, behavior: getScrollBehavior() })
+
+    // After scroll, find focusable elements and pick the best one
+    setTimeout(() => {
+      const cr = statsPage.getBoundingClientRect()
+      const visible = getAllFocusable().filter((c) => {
+        if (!statsPage.contains(c) || c.closest('#appbar')) return false
+        const r = c.getBoundingClientRect()
+        return r.top >= cr.top && r.bottom <= cr.bottom
+      })
+      if (!visible.length) return
+      // Prefer Next button, then any non-show/hide button
+      const nextBtn = visible.find((el) => {
+        const txt = el.textContent?.trim()
+        return txt?.includes('Next') || txt?.includes('chevron_right')
+      })
+      if (nextBtn) { nextBtn.focus({ preventScroll: true }); return }
+      // Pick last visible (down) or first visible (up), but skip
+      // the See Year in Review button if other buttons are available
+      const nonToggle = visible.filter((el) => {
+        const txt = el.textContent?.trim()
+        return !txt?.includes('Year in Review') || visible.length === 1
+      })
+      const pool = nonToggle.length ? nonToggle : visible
+      const target = key === 'ArrowDown' ? pool[pool.length - 1] : pool[0]
+      if (target) target.focus({ preventScroll: true })
+    }, 250)
+    return true
+  }
+
+  return false
+}

--- a/plugins/tv/scrollHelpers.js
+++ b/plugins/tv/scrollHelpers.js
@@ -1,0 +1,124 @@
+/**
+ * TV navigation scroll-helper functions + page-type detection.
+ *
+ * Uses tvContext.lastKeyTime for rapid-keypress detection.
+ * `isGridPage` lives here (not in focusEntry) to avoid a circular
+ * dependency: scrollParentToReveal needs isGridPage, focusEntry needs
+ * both. Having both here keeps the DAG clean.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+import { tvContext } from './context.js'
+
+// ── Page scroll container lookup ──
+// Centralized lookup for the main scrollable container on the current page.
+const pageScrollContainerIds = [
+  'bookshelf-wrapper', 'author-page-wrapper', 'item-page', 'episode-page',
+  'manage-files-page', 'settings-page', 'stats-page', 'account-page', 'logs-container'
+]
+
+export function findPageScrollContainer(fallbackEl) {
+  for (const id of pageScrollContainerIds) {
+    const el = document.getElementById(id)
+    if (el) return el
+  }
+  return fallbackEl ? findScrollableParent(fallbackEl) : null
+}
+
+// Detail-like pages where we suppress snap-to-top scrolling
+export function isDetailScrollContainer(id) {
+  return id === 'item-page' || id === 'episode-page' || id === 'manage-files-page' || id === 'settings-page' || id === 'stats-page' || id === 'account-page'
+}
+
+export function isGridPage() {
+  const path = window.location.pathname
+  return path.startsWith('/bookshelf/') && path !== '/bookshelf'
+}
+
+export function getScrollBehavior() {
+  const now = Date.now()
+  const rapid = (now - tvContext.lastKeyTime) < 250
+  tvContext.lastKeyTime = now
+  return rapid ? 'auto' : 'smooth'
+}
+
+export function findScrollableParent(el) {
+  let parent = el.parentElement
+  while (parent && parent !== document.body) {
+    const style = window.getComputedStyle(parent)
+    if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
+      return parent
+    }
+    parent = parent.parentElement
+  }
+  return null
+}
+
+export function scrollParentToReveal(el) {
+  const behavior = getScrollBehavior()
+
+  // Horizontal: scroll the shelf row to reveal the card
+  let parent = el.parentElement
+  while (parent) {
+    const style = window.getComputedStyle(parent)
+    if (style.overflowX === 'auto' || style.overflowX === 'scroll') {
+      const parentRect = parent.getBoundingClientRect()
+      const elRect = el.getBoundingClientRect()
+
+      if (elRect.right > parentRect.right) {
+        parent.scrollBy({ left: elRect.right - parentRect.right + 20, behavior })
+      } else if (elRect.left < parentRect.left) {
+        parent.scrollBy({ left: elRect.left - parentRect.left - 20, behavior })
+      }
+      break
+    }
+    parent = parent.parentElement
+  }
+
+  // Vertical: find the scrollable container and scroll to show the focused element
+  const scrollContainer = findPageScrollContainer(el)
+  if (scrollContainer) {
+    const elRect = el.getBoundingClientRect()
+    const containerRect = scrollContainer.getBoundingClientRect()
+
+    const gridPage = isGridPage()
+
+    // On non-grid pages (home), if the element is near the top of
+    // the content (within first 300px), scroll to very top for a clean look.
+    // Skip for item detail pages — the cover image occupies the top area and
+    // snapping to it creates erratic scrolling.
+    const isItemPage = isDetailScrollContainer(scrollContainer.id)
+    const elOffsetInContent = elRect.top - containerRect.top + scrollContainer.scrollTop
+    if (!gridPage && !isItemPage && scrollContainer.scrollTop > 0 && elOffsetInContent < 300) {
+      scrollContainer.scrollTo({ top: 0, behavior })
+    } else {
+      // Grid pages snap card rows tight to the top (10px clearance).
+      // Other pages (home, detail, etc.) keep more breathing room for headers.
+      // Item detail pages: only scroll if the element is actually off-screen,
+      // so cover ↔ Play button transitions don't cause unnecessary scrolling.
+      const topMargin = gridPage ? 10 : 60
+      const targetOffset = elRect.top - containerRect.top - topMargin
+      if (isItemPage) {
+        // Only scroll if the element is not fully visible in the container.
+        // This prevents unnecessary scrolling when navigating between elements
+        // that are both on-screen (e.g. cover ↔ Play button at scroll=0).
+        const fullyVisible = elRect.top >= containerRect.top && elRect.bottom <= containerRect.bottom
+        if (!fullyVisible) {
+          scrollContainer.scrollBy({ top: targetOffset, behavior })
+        }
+      } else {
+        const deadZone = gridPage ? 10 : (scrollContainer.scrollTop < 10 ? 80 : 10)
+        if (Math.abs(targetOffset) > deadZone) {
+          scrollContainer.scrollBy({ top: targetOffset, behavior })
+        }
+      }
+    }
+  } else {
+    const elRect = el.getBoundingClientRect()
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight
+    if (elRect.top < 0 || elRect.bottom > viewportHeight) {
+      el.scrollIntoView({ block: 'nearest', behavior })
+    }
+  }
+}

--- a/plugins/tv/selectors.js
+++ b/plugins/tv/selectors.js
@@ -1,0 +1,21 @@
+/**
+ * Shared DOM-target finders for TV navigation.
+ *
+ * Single source of truth for the stable data-* hooks that replaced fragile
+ * Tailwind utility-class selectors (I5). Maintainer-side class renames no
+ * longer break TV nav; the contract is the data-attribute, documented here.
+ *
+ * Contract (set in Vue components):
+ * - [data-tv-target="play-button"]  — the primary Play button on a detail
+ *   page (item / episode / playlist / collection). Static attribute.
+ * - [data-tv-overlay="side-drawer"] — the side-drawer panel, present ONLY
+ *   while the drawer is open (bound to its `show` state in SideDrawer.vue).
+ */
+
+export function findPlayButton() {
+  return document.querySelector('[data-tv-target="play-button"]')
+}
+
+export function findVisibleSideDrawer() {
+  return document.querySelector('[data-tv-overlay="side-drawer"]')
+}

--- a/plugins/tv/spatialNav.js
+++ b/plugins/tv/spatialNav.js
@@ -1,0 +1,235 @@
+/**
+ * Spatial D-pad target finders.
+ *
+ * Beam-model navigation: horizontal stays in row at edges; vertical finds
+ * nearest element in the next row.
+ *
+ * Reads tvContext.lastFocusRect to maintain column when focus is briefly
+ * lost during virtualizer card detach/reattach cycles.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+import { tvContext } from './context.js'
+import { centerOf, isSameRow, getAllFocusable } from './visibility.js'
+import { findPageScrollContainer } from './scrollHelpers.js'
+
+export function findHorizontalTarget(direction) {
+  const current = document.activeElement
+  if (!current) return null
+
+  const currentRect = current.getBoundingClientRect()
+  const goingRight = direction === 'ArrowRight'
+
+  // Exclude player controls from page navigation (player has its own handler)
+  const playerContainer = document.getElementById('streamContainer')
+  const currentInPlayer = playerContainer?.contains(current)
+
+  // Snapshot every candidate's rect ONCE. getBoundingClientRect forces a
+  // synchronous layout; calling it inside the filter + sort comparator below
+  // (once per candidate, O(n log n) in the sort) thrashes layout on every
+  // keypress. Reading from the Map instead collapses that to one reflow per
+  // focusable. The Map is ephemeral per call — no invalidation needed (I4).
+  const focusables = getAllFocusable()
+  const rectMap = new Map()
+  for (const el of focusables) rectMap.set(el, el.getBoundingClientRect())
+
+  const candidates = focusables.filter((el) => {
+    if (el === current) return false
+    // Don't navigate between player and page content via horizontal nav
+    if (!currentInPlayer && playerContainer?.contains(el)) return false
+    if (currentInPlayer && !playerContainer?.contains(el)) return false
+    const rect = rectMap.get(el)
+    if (!isSameRow(currentRect, rect)) return false
+    return goingRight ? rect.left > currentRect.left : rect.right < currentRect.right
+  })
+
+  if (candidates.length === 0) return null
+
+  candidates.sort((a, b) => {
+    const aRect = rectMap.get(a)
+    const bRect = rectMap.get(b)
+    const aDist = goingRight ? aRect.left - currentRect.left : currentRect.right - aRect.right
+    const bDist = goingRight ? bRect.left - currentRect.left : currentRect.right - bRect.right
+    return aDist - bDist
+  })
+
+  return candidates[0]
+}
+
+export function findVerticalTarget(direction) {
+  const current = document.activeElement
+  if (!current) return null
+
+  // When the virtualizer detaches the focused card during rapid scrolling,
+  // focus falls to body. Use the last known card position to maintain column.
+  const focusLost = !current || current === document.body
+  const currentRect = focusLost && tvContext.lastFocusRect ? tvContext.lastFocusRect : current.getBoundingClientRect()
+  const currentCenter = centerOf(currentRect)
+  const goingDown = direction === 'ArrowDown'
+
+  // If focus is lost and we have no saved position, we can't navigate
+  if (focusLost && !tvContext.lastFocusRect) return null
+
+  // Find the scrollable container the current element lives in
+  const scrollContainer = findPageScrollContainer(focusLost ? null : current)
+  const isInScrollable = !focusLost && scrollContainer?.contains(current)
+
+  // Exclude player controls from page navigation (player has its own handler)
+  const playerContainer = document.getElementById('streamContainer')
+  const currentInPlayer = !focusLost && playerContainer?.contains(current)
+
+  // Snapshot every candidate's rect ONCE — see findHorizontalTarget (I4).
+  const focusables = getAllFocusable()
+  const rectMap = new Map()
+  for (const el of focusables) rectMap.set(el, el.getBoundingClientRect())
+
+  const candidates = focusables.filter((el) => {
+    if (el === current) return false
+    // Don't navigate between player and page content via generic vertical nav.
+    // The player entry/exit is handled explicitly in handleKeyDown.
+    if (!currentInPlayer && playerContainer?.contains(el)) return false
+    if (currentInPlayer && !playerContainer?.contains(el)) return false
+    const rect = rectMap.get(el)
+    if (isSameRow(currentRect, rect)) return false
+    const center = centerOf(rect)
+    const isCorrectDirection = goingDown ? center.y > currentCenter.y : center.y < currentCenter.y
+    if (!isCorrectDirection) return false
+
+    // When navigating up from inside a scrollable area, only allow jumping
+    // to elements outside it (e.g. nav bar) if scrolled to the very top
+    if (isInScrollable && !goingDown && !scrollContainer.contains(el)) {
+      if (scrollContainer.scrollTop > 50) return false
+    }
+
+    return true
+  })
+
+  if (candidates.length === 0) return null
+
+  // Find the nearest row, then closest element horizontally
+  candidates.sort((a, b) => {
+    const aDy = Math.abs(centerOf(rectMap.get(a)).y - currentCenter.y)
+    const bDy = Math.abs(centerOf(rectMap.get(b)).y - currentCenter.y)
+    return aDy - bDy
+  })
+
+  const nearestRect = rectMap.get(candidates[0])
+  const nearestRow = candidates.filter((el) => isSameRow(nearestRect, rectMap.get(el)))
+
+  nearestRow.sort((a, b) => {
+    const aDx = Math.abs(centerOf(rectMap.get(a)).x - currentCenter.x)
+    const bDx = Math.abs(centerOf(rectMap.get(b)).x - currentCenter.x)
+    return aDx - bDx
+  })
+
+  return nearestRow[0]
+}
+
+/**
+ * Column-stable grid vertical target — immune to the native TV focus engine.
+ *
+ * Root problem: the LazyBookshelf virtualizer `el.remove()`s the focused card
+ * mid-scroll, and the native Android-TV focus engine then re-homes focus to an
+ * edge column (deterministically the last). Reading the column from wherever
+ * focus currently is (live `activeElement`) therefore drifts to that edge.
+ *
+ * Fix: take the ROW from where focus actually is (so we follow the scroll), but
+ * the COLUMN from tvContext.gridIntendedCol — the user's chosen column, set only
+ * on Left/Right + first focus, never from live focus — and re-assert it every
+ * press. The target is then `(row ± 1) * itemsPerRow + intendedCol`, focused by
+ * id, so a native hijack to the last column is undone on the very next keypress.
+ *
+ * Returns `{ card, index, col, prefix }` on a hit, or null (not a shelf grid /
+ * nothing remembered / past the first row / target not mounted) — caller falls
+ * back to geometry or its scroll-and-retry.
+ */
+export function findShelfVerticalTarget(direction) {
+  const current = document.activeElement
+  const liveCard =
+    current && current !== document.body && current.closest && current.closest('[id^="shelf-"]')
+      ? current
+      : null
+
+  let index
+  let prefix
+  let currentShelf = null
+  if (liveCard) {
+    const m = liveCard.id.match(/^(.*-card-)(\d+)$/)
+    if (!m) return null
+    prefix = m[1]
+    index = parseInt(m[2], 10)
+    currentShelf = liveCard.closest('[id^="shelf-"]')
+  } else if (tvContext.lastGridIndex != null && tvContext.lastGridPrefix) {
+    index = tvContext.lastGridIndex
+    prefix = tvContext.lastGridPrefix
+    const known = document.getElementById(prefix + index)
+    currentShelf = known ? known.closest('[id^="shelf-"]') : null
+  } else {
+    return null
+  }
+  if (Number.isNaN(index) || !prefix) return null
+
+  const itemsPerRow = gridItemsPerRow(currentShelf)
+  if (!itemsPerRow) return null
+
+  // ROW follows where focus actually is (so we track the scroll, even after a
+  // native hijack); COLUMN is the sticky intended column — immune to the
+  // engine's edge-column hijack. Before any Left/Right has set an intended
+  // column, derive it once from the live card.
+  const currentRow = Math.floor(index / itemsPerRow)
+  const intendedCol = tvContext.gridIntendedCol != null ? tvContext.gridIntendedCol : index % itemsPerRow
+
+  const targetRow = direction === 'ArrowDown' ? currentRow + 1 : currentRow - 1
+  if (targetRow < 0) return null
+
+  const targetIndex = targetRow * itemsPerRow + intendedCol
+  const targetCard = document.getElementById(prefix + targetIndex)
+  if (!targetCard) return null // not mounted yet / past the end — caller handles it
+
+  return { card: targetCard, index: targetIndex, col: intendedCol, prefix }
+}
+
+// Record a focused card's column as the INTENDED column (plus index + prefix).
+// Called on Left/Right and first focus — deliberate column choices — so
+// gridIntendedCol tracks user intent and is never set from a native hijack.
+export function rememberGridCol(card) {
+  if (!card || !card.id) return
+  const m = card.id.match(/^(.*-card-)(\d+)$/)
+  if (!m) return
+  const epp = gridItemsPerRow(card.closest ? card.closest('[id^="shelf-"]') : null)
+  if (!epp) return
+  tvContext.lastGridPrefix = m[1]
+  tvContext.lastGridIndex = parseInt(m[2], 10)
+  tvContext.gridIntendedCol = tvContext.lastGridIndex % epp
+}
+
+// Record only a card's index + prefix — the ROW anchor — WITHOUT touching
+// gridIntendedCol. Used on the vertical geometry fallback, where focus may land
+// on the engine's hijacked column: we must follow the row but must NOT let that
+// wrong column overwrite the user's intended column (doing so poisoned the
+// intended column, so the correction poll treated the hijacked column as
+// "correct" and never fired).
+export function rememberGridRow(card) {
+  if (!card || !card.id) return
+  const m = card.id.match(/^(.*-card-)(\d+)$/)
+  if (!m) return
+  tvContext.lastGridPrefix = m[1]
+  tvContext.lastGridIndex = parseInt(m[2], 10)
+}
+
+// Items per grid row (entitiesPerShelf), read off the current in-view shelf —
+// a full row gives the true value, kept as a monotonic max so a short final row
+// never shrinks it. Cached on tvContext; reset on route change.
+function gridItemsPerRow(currentShelf) {
+  const observed = currentShelf ? shelfCards(currentShelf).length : 0
+  if (observed > (tvContext.gridItemsPerRow || 0)) tvContext.gridItemsPerRow = observed
+  return tvContext.gridItemsPerRow || 0
+}
+
+// Focusable card children of a shelf row, in DOM order — which equals visual
+// column order because mountEntityCard appends cards ascending by index. The
+// only other shelf child is the non-focusable .bookshelfDivider.
+function shelfCards(shelfEl) {
+  return Array.from(shelfEl.children).filter((el) => el.getAttribute('tabindex') === '0')
+}

--- a/plugins/tv/visibility.js
+++ b/plugins/tv/visibility.js
@@ -1,0 +1,47 @@
+/**
+ * TV navigation visibility + focusable-discovery helpers.
+ * Pure functions; no module-level state.
+ *
+ * Extracted from plugins/tv-navigation.js during v1.0.10 refactor.
+ */
+
+export function centerOf(rect) {
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+}
+
+export function isVisible(el, options = {}) {
+  const style = window.getComputedStyle(el)
+  if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') return false
+  const rect = el.getBoundingClientRect()
+  if (rect.width <= 0 || rect.height <= 0) return false
+  // Reject elements fully off-screen (e.g. translated drawer items).
+  // In overlay context we skip this check so long scrollable lists (e.g. sort
+  // modal with 13 items in a 70vh-scroll container) stay fully navigable —
+  // scrollIntoView on focus brings off-viewport items into view as they activate.
+  if (!options.ignoreViewport) {
+    if (rect.right < 0 || rect.left > window.innerWidth) return false
+    if (rect.bottom < 0 || rect.top > window.innerHeight) return false
+  }
+  return true
+}
+
+export function isSameRow(rectA, rectB) {
+  return rectA.bottom > rectB.top && rectA.top < rectB.bottom
+}
+
+export function getAllFocusable(container, options = {}) {
+  const root = container || document
+  return Array.from(
+    root.querySelectorAll('[tabindex="0"], button:not([tabindex="-1"]), a[href]:not([tabindex="-1"]):not([aria-hidden="true"]), input, select, textarea, li[tabindex="0"], li[role="option"][tabindex="0"]')
+  ).filter((el) => {
+    if (!isVisible(el, options)) return false
+    // Exclude disabled elements (focus() silently fails on them)
+    if (el.disabled) return false
+    // Exclude elements with tabindex="-1" (not intended for D-pad navigation)
+    if (el.getAttribute('tabindex') === '-1') return false
+    // Exclude links inside podcast episode descriptions (RSS feed content
+    // with random URLs that aren't meaningful navigation targets on TV)
+    if (el.tagName === 'A' && el.closest('.episode-subtitle, .description-container')) return false
+    return true
+  })
+}


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

Heads up: the rest of the series is now open. It was originally paced in waves, each opening after the previous merged, but that just kept the work invisible — so PRs 5-10 and two small companion PRs are all up now. Review and merge in whatever order suits you; the dependency graph is in the plan.

### Scope
The D-pad navigation engine as a **library only** — 17 modules under `plugins/tv/` that export functions and attach to nothing at runtime. Nine utility modules (focus memory, spatial navigation, scroll helpers, visibility, overlay focus, focus entry, focus color, selectors, shared context) and eight per-page handlers. Every file is under 235 LOC.

### Safety
Nothing registers a listener, installs a router hook, or touches the store. This is dead code on every device until the integration PR wires it up — merging it alone changes no behavior anywhere. The split exists so the function library can be reviewed separately from the wiring that turns it on.

### Testing
Inert on its own, so verified by build: `npm run generate` green. The modules are exercised end-to-end by the integration PR and verified on a Google TV Streamer 4K across a 13-batch manual smoke suite.

Depends on the `isAndroidTv` flag from #1983. Required by the integration PR.
