### PR TITLE
Android TV (8/10): TV settings section + focus-ring color picker

### DIFF
--- a/components/ui/TvFocusColorPicker.vue
+++ b/components/ui/TvFocusColorPicker.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="tv-focus-color-picker flex items-center gap-3">
+    <button
+      v-for="preset in PRESETS"
+      :key="preset.hex"
+      type="button"
+      tabindex="0"
+      class="swatch"
+      :style="{ backgroundColor: preset.hex }"
+      :aria-label="`Focus ring color: ${preset.name}${preset.hex === value ? ' (selected)' : ''}`"
+      @click="select(preset.hex)"
+      @keydown.enter.prevent="select(preset.hex)"
+    >
+      <span v-if="preset.hex === value" class="selected-marker" aria-hidden="true">★</span>
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: String,
+      default: '#1ad691'
+    }
+  },
+  data() {
+    return {
+      PRESETS: [
+        { hex: '#1ad691', name: 'ABS Green' },
+        { hex: '#3ea6ff', name: 'Sky' },
+        { hex: '#ffb74d', name: 'Amber' },
+        { hex: '#ff5252', name: 'Red' },
+        { hex: '#e040fb', name: 'Violet' },
+        { hex: '#ffeb3b', name: 'Yellow' },
+        { hex: '#ffffff', name: 'White' }
+      ]
+    }
+  },
+  methods: {
+    select(hex) {
+      if (hex !== this.value) {
+        this.$emit('input', hex)
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.swatch {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* TV D-pad focus indicator. The global .android-tv button:focus rule paints
+   in var(--tv-focus-color), which blends invisibly into a same-colored
+   swatch fill. Override with a black inner separator + outer ring in the
+   current focus color — the black band keeps the ring readable even when
+   the focused swatch is the same color as the focus ring itself.
+   box-shadow takes no layout space, so swatches don't shift when focused. */
+.swatch:focus,
+.swatch:focus-visible {
+  outline: 2px solid transparent !important;
+  box-shadow: 0 0 0 2px #000, 0 0 0 4px var(--tv-focus-color, #1ad691);
+}
+
+/* In-use marker, top-right corner. White glyph + black halo reads on every
+   swatch fill including white (the halo provides the silhouette there). */
+.selected-marker {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 12px;
+  color: #ffffff;
+  text-shadow: 0 0 2px #000, 0 0 3px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+}
+</style>

--- a/docs/pr-08-settings-focus-color.md
+++ b/docs/pr-08-settings-focus-color.md
@@ -1,0 +1,52 @@
+# PR 08 — TV settings section + focus-ring color picker
+
+Part of a 10-PR series adding Android TV support to audiobookshelf-app,
+replacing the original PR #1843.
+
+## Full series plan
+
+See **[bilbospocketses/abs-app — PR_DECOMPOSITION_PLAN.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/PR_DECOMPOSITION_PLAN.md)**
+for the complete 10-PR breakdown, dependency graph, and rationale.
+
+## This PR's scope
+
+Adds a "TV Settings" section to `pages/settings.vue`, shown only when
+`isAndroidTv` is set, containing a single control: a focus-ring color picker.
+
+- `components/ui/TvFocusColorPicker.vue` — a new swatch-row component with a
+  default marker and a white-outline selection state. It is D-pad navigable
+  and emits the chosen hex.
+- `pages/settings.vue` — the TV-only section plus an `isAndroidTv` computed, a
+  `tvFocusColor` computed, and a `setTvFocusColor` method that dispatches
+  `user/updateUserSettings`. The `mt-10` spacer on the next section header is
+  TV-gated, so the phone layout is byte-identical to before.
+
+The chosen color is written into the `--tv-focus-color` CSS variable that
+`assets/css/tv-focus.css` (PR4) consumes for every focus ring. Focus rings are
+the only way to tell where you are on a TV, and the default green does not read
+well against every cover art or theme — hence making it configurable.
+
+**On i18n:** the section header and row label are hardcoded English here rather
+than routed through `$strings`, to avoid touching `strings/en-us.json` and the
+translation workflow in a TV PR. Happy to move them into the string catalog if
+you would prefer that before merge.
+
+## Architecture context (fork-hosted)
+
+- [TV_FOCUS_SYSTEM.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_FOCUS_SYSTEM.md) — how the focus color propagates to the CSS variable.
+- [TV_USER_GUIDE.md](https://github.com/bilbospocketses/abs-app/blob/android-tv-dpad-navigation/docs/TV_USER_GUIDE.md) — end-user TV feature documentation.
+
+## Testing
+
+Verified on a Google TV Streamer 4K: the section appears only on TV, each
+swatch is reachable with the D-pad, and the selected color applies to focus
+rings immediately and survives an app restart. Verified on an Android phone
+that the settings page is unchanged.
+
+## Relationship to the series
+
+- **Depends on:** PR4 (the `tvFocusColor` settings key and `tv-focus.css`) and
+  PR6 (live engine to apply the color and to navigate the picker).
+- **Note:** also edits `pages/settings.vue`, which PR2 touches in different
+  regions; whichever merges second may need a trivial rebase.
+- **Layer:** 3 of 3

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -1,7 +1,16 @@
 <template>
   <div class="w-full h-full px-4 py-8 overflow-y-auto">
+    <!-- TV settings (Android TV only) -->
+    <template v-if="isAndroidTv">
+      <p class="uppercase text-xs font-semibold text-fg-muted mb-2">TV Settings</p>
+      <div class="py-3 flex items-center">
+        <p class="pr-4 w-36">Focus Ring Color</p>
+        <TvFocusColorPicker :value="tvFocusColor" @input="setTvFocusColor" />
+      </div>
+    </template>
+
     <!-- Display settings -->
-    <p class="uppercase text-xs font-semibold text-fg-muted mb-2">{{ $strings.HeaderUserInterfaceSettings }}</p>
+    <p class="uppercase text-xs font-semibold text-fg-muted mb-2" :class="{ 'mt-10': isAndroidTv }">{{ $strings.HeaderUserInterfaceSettings }}</p>
     <div class="flex items-center py-3">
       <div class="w-10 flex justify-center" @click="toggleEnableAltView">
         <ui-toggle-switch v-model="enableBookshelfView" @input="saveSettings" />
@@ -188,9 +197,13 @@
 <script>
 import { Dialog } from '@capacitor/dialog'
 import jumpLabelMixin from '@/mixins/jumpLabel'
+import TvFocusColorPicker from '@/components/ui/TvFocusColorPicker.vue'
 
 export default {
   mixins: [jumpLabelMixin],
+  components: {
+    TvFocusColorPicker
+  },
   data() {
     return {
       loading: false,
@@ -354,6 +367,12 @@ export default {
     isiOS() {
       return this.$platform === 'ios'
     },
+    isAndroidTv() {
+      return this.$store.state.isAndroidTv
+    },
+    tvFocusColor() {
+      return this.$store.state.user.settings.tvFocusColor || '#1ad691'
+    },
     jumpForwardSecondsOptions() {
       return this.$store.state.globals.jumpForwardSecondsOptions || []
     },
@@ -454,6 +473,9 @@ export default {
     }
   },
   methods: {
+    setTvFocusColor(hex) {
+      this.$store.dispatch('user/updateUserSettings', { tvFocusColor: hex })
+    },
     sleepTimerLengthModalSelection(value) {
       this.settings.sleepTimerLength = value
       this.saveSettings()


### PR DESCRIPTION
Part of the Android TV support work, replacing #1843 (split into smaller PRs per the review-volume feedback).

### Scope
A "TV Settings" section at the top of `pages/settings.vue`, shown only on Android TV, containing one control: a focus-ring color picker.
- `components/ui/TvFocusColorPicker.vue` — new D-pad-navigable swatch row with a default marker and a white-outline selection state.
- `pages/settings.vue` — the TV-only section plus `isAndroidTv` / `tvFocusColor` computeds and a `setTvFocusColor` method dispatching `user/updateUserSettings`.

The chosen color feeds the `--tv-focus-color` CSS variable that `tv-focus.css` (#1986) consumes for every focus ring. Focus rings are the only way to tell where you are on a TV, and the default green does not read well against every cover or theme — hence making it configurable.

### On i18n
The section header and row label are hardcoded English rather than routed through `$strings`, to keep the translation catalog out of a TV PR. Happy to move them into `strings/en-us.json` before merge if you would prefer that.

### Safety
The section is behind `v-if="isAndroidTv"`, and the `mt-10` spacer on the next header is TV-gated, so the phone layout is byte-identical.

### Testing
GTV Streamer 4K: section appears only on TV, every swatch reachable by D-pad, selection applies immediately and survives a restart. Phone: settings page unchanged.

Depends on the `tvFocusColor` key and `tv-focus.css` from #1986, and on the live engine. Also edits `pages/settings.vue`, which #1984 touches in different regions — whichever merges second may need a trivial rebase.
