### PR TITLE
chore: add .gitattributes for LF normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Force LF line endings on text files for cross-platform consistency.
+# Without this, Windows checkouts can introduce CRLF on commit, which
+# produces noisy diffs and partial-normalization commits like the
+# original 5b02ba1d "chore: normalize line endings to LF" that left
+# some files (plugins/tv-navigation.js, .github/ISSUE_TEMPLATE/*.yml,
+# etc.) on CRLF.
+
+* text=auto eol=lf
+
+# Windows-specific text files keep CRLF
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.ps1   text eol=crlf
+
+# Unix-specific text files force LF
+*.sh        text eol=lf
+gradlew     text eol=lf
+
+# Binary files — never normalize
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.webp      binary
+*.ico       binary
+*.icns      binary
+*.pdf       binary
+*.apk       binary
+*.aar       binary
+*.jar       binary
+*.zip       binary
+*.gz        binary
+*.tar       binary
+*.7z        binary
+*.so        binary
+*.dll       binary
+*.dylib     binary
+*.keystore  binary
+*.ttf       binary
+*.otf       binary
+*.woff      binary
+*.woff2     binary
+*.eot       binary
+*.mp3       binary
+*.mp4       binary
+*.mov       binary
+*.webm      binary


### PR DESCRIPTION
A small repo-hygiene chore, opened alongside the Android TV series replacing #1843. Entirely independent of that work — it touches one file and no source code.

### Scope
Adds a `.gitattributes` normalizing line endings to LF in the repository.

### Why
Without it, contributors on Windows can produce diffs where whole files appear rewritten purely from CRLF conversion, which makes review noisy and can hide real changes. Normalizing at the repo level means a working tree can still be CRLF locally while what gets committed stays consistent.

### Heads up before merging
**Merging this triggers a one-time repo-wide renormalization.** Files currently stored with CRLF get rewritten to LF in that commit, so it touches a lot of paths at once and can complicate blame across the boundary. It is probably worth merging on its own at a quiet moment rather than alongside feature work — or not at all, if you would rather not take the churn. No hard feelings either way; it came up as a papercut from another contributor, so I built it rather than just mentioning it.

### Testing
No code change. Verified that a fresh clone checks out cleanly and `npm run generate` is unaffected.
