### PR TITLE
Enable password manager autofill on server login form

### DIFF
--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -56,8 +56,8 @@
           </div>
           <div class="w-full h-px bg-fg/10 my-2" />
           <form v-if="isLocalAuthEnabled" @submit.prevent="submitAuth" class="pt-3">
-            <ui-text-input v-model="serverConfig.username" :disabled="processing" :placeholder="$strings.LabelUsername" class="w-full mb-2 text-lg" />
-            <ui-text-input v-model="password" type="password" :disabled="processing" :placeholder="$strings.LabelPassword" class="w-full mb-2 text-lg" />
+            <ui-text-input v-model="serverConfig.username" name="username" autocomplete="username" :disabled="processing" :placeholder="$strings.LabelUsername" class="w-full mb-2 text-lg" />
+            <ui-text-input v-model="password" type="password" name="password" autocomplete="current-password" :disabled="processing" :placeholder="$strings.LabelPassword" class="w-full mb-2 text-lg" />
 
             <div class="flex items-center pt-2">
               <ui-icon-btn v-if="serverConfig.id" bg-color="error" icon="delete" type="button" @click="removeServerConfigClick(serverConfig)" />

--- a/components/ui/TextInput.vue
+++ b/components/ui/TextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative">
-    <input v-model="input" ref="input" :autofocus="autofocus" :type="type" :disabled="disabled" :readonly="readonly" autocorrect="off" autocapitalize="none" autocomplete="off" :placeholder="placeholder" class="py-2 w-full outline-none bg-primary disabled:text-fg-muted" :class="inputClass" @keyup="keyup" />
+    <input v-model="input" ref="input" :autofocus="autofocus" :type="type" :name="name" :disabled="disabled" :readonly="readonly" autocorrect="off" autocapitalize="none" :autocomplete="autocomplete" :placeholder="placeholder" class="py-2 w-full outline-none bg-primary disabled:text-fg-muted" :class="inputClass" @keyup="keyup" />
     <div v-if="prependIcon" class="absolute top-0 left-0 h-full px-2 flex items-center justify-center">
       <span class="material-symbols text-lg">{{ prependIcon }}</span>
     </div>
@@ -19,6 +19,11 @@ export default {
     value: [String, Number],
     placeholder: String,
     type: String,
+    name: String,
+    autocomplete: {
+      type: String,
+      default: 'off'
+    },
     disabled: Boolean,
     readonly: Boolean,
     borderless: Boolean,


### PR DESCRIPTION
## Brief summary

Fixes a bug where password managers (Android GBoard/Google Password Manager, iOS Keychain) never offer to save or fill stored credentials on the server login form. The shared `TextInput` component hardcoded `autocomplete="off"` on every input, which told autofill services to never offer stored credentials, and the username/password fields had no `name` or autofill hints for autofill services to recognize the form as a login form.

## Which issue is fixed?

No issue number — reported directly.

## Pull Request Type

Both Android and iOS — the fix is in the shared Nuxt/Vue code, so it ships identically to both platforms via the single Capacitor web bundle. No native or backend code was touched.

## In-depth Description

- `components/ui/TextInput.vue`: `autocomplete` and `name` are now configurable props (default `autocomplete` stays `"off"`, so all other existing inputs are unaffected).
- `components/connection/ServerConnectForm.vue`: login fields tagged `name="username" autocomplete="username"` and `name="password" autocomplete="current-password"`.

These are the standard `autocomplete` tokens that Android's Autofill framework (GBoard/Google Password Manager) and iOS's Keychain AutoFill (QuickType bar) both key off of in their respective WebViews.

## How have you tested this?

Ran a full production build (`npm run generate`) and confirmed it completes successfully and the new attributes reach the compiled bundle both platforms consume. On-device verification (GBoard save/fill prompt on Android, Keychain QuickType on iOS) is still pending — will confirm after testing on a real device.

## Screenshots

None — no visual changes; only non-visual input attributes were added.