### PR TITLE
Reset cover error state when the resolved cover url changes

### DIFF
--- a/components/covers/BookCover.vue
+++ b/components/covers/BookCover.vue
@@ -60,7 +60,10 @@ export default {
     }
   },
   watch: {
-    cover() {
+    // Watch the resolved image url rather than the cover path. The url includes a
+    // cache busting timestamp, so it changes when the server cover is fixed or
+    // replaced even though the cover path stays the same.
+    fullCoverUrl() {
       this.imageFailed = false
     }
   },
@@ -151,6 +154,7 @@ export default {
     },
     imageLoaded() {
       this.loading = false
+      this.imageFailed = false
       this.$nextTick(() => {
         this.imageReady = true
       })


### PR DESCRIPTION
## Brief summary

Fixes the "Invalid Cover" overlay persisting after a book's cover is fixed or replaced on the server. The cover actually reloads correctly, but the red error overlay is never cleared and keeps covering it, so the item looks permanently broken until the app is force-stopped and its cache cleared.

## Which issue is fixed?

Fixes #1962

## Pull Request Type

Both Android and iOS — the change is in shared frontend Vue code (`components/covers/BookCover.vue`). No native or backend code was touched.

## In-depth Description

`BookCover.vue` clears `imageFailed` from a watcher, but that watcher keyed off `cover`, which is just `media.coverPath`. The `<img>` src actually comes from `fullCoverUrl` → `getLibraryItemCoverSrc` (`store/globals.js`), which appends a cache busting `ts` param derived from `libraryItem.updatedAt`.

So when a cover is corrected on the server, `updatedAt` changes and the url changes, the image refetches and loads successfully — but `coverPath` never changed, so the watcher never fired and `imageFailed` stayed `true`. The result is a correctly loaded cover sitting underneath a stale "Invalid Cover" overlay, which matches the reported symptom of needing a force-stop and cache clear to recover.

Two changes:

- Watch `fullCoverUrl` instead of `cover`, so the error state resets whenever the url actually bound to `:src` changes. This matches what `PreviewCover.vue` already does — there the watched `cover` *is* the value bound to `:src`, so this brings `BookCover` in line with the existing correct pattern.
- Also clear `imageFailed` in `imageLoaded()`, so a successful load always dismisses the error overlay regardless of how the state was reached.

## How have you tested this?

Ran a full production build (`npm run generate`) and confirmed it completes successfully. I also checked the sibling cover components for the same mismatch: `PreviewCover.vue` is already correct, and `CollectionCover.vue` declares `imageFailed` but never uses it, so neither needed changes.

Device testing of the full cycle is still pending: view a library item whose cover 404s on the server, confirm the "Invalid Cover" overlay appears, fix or replace the cover on the server, then reload the library and confirm the cover appears without needing to force-stop the app.

## Screenshots

None yet — the visible change is the absence of a stale error overlay, best captured during the device test described above.