### PR TITLE
Fix ~1 minute Android startup block with many downloaded files

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -73,6 +73,13 @@ data class LocalFile(
         var mimeType: String?,
         var size: Long
 ) {
+  /**
+   * Full check: does the file exist and can this app actually open it?
+   *
+   * Costs a ContentResolver round-trip per file, so callers holding many files should prefer
+   * [exists] with a folder listing, or [existsOnDisk] when access to the folder is already known
+   * to be intact.
+   */
   @JsonIgnore
   fun exists(ctx: Context): Boolean {
     if (contentUrl.startsWith("content:")) {
@@ -87,26 +94,34 @@ data class LocalFile(
   }
 
   /**
-   * Existence check backed by a pre-fetched set of sibling document ids.
-   *
-   * Opening a file descriptor per file (see [exists]) costs a ContentResolver IPC round-trip
-   * (~15ms each), which adds up to minutes on libraries with thousands of downloaded files.
-   * When the caller already listed the parent folder once, this only does a set lookup.
-   * Falls back to the per-file check when no sibling set is available.
+   * Same check as [exists], but backed by the document ids of the parent folder, so a whole
+   * folder costs one query instead of a round-trip per file. Falls back to the per-file check
+   * when the folder cannot be listed (permission lost, non-tree uri).
    */
   @JsonIgnore
-  fun exists(ctx: Context, siblingDocumentIds: Set<String>?): Boolean {
-    if (siblingDocumentIds != null && contentUrl.startsWith("content:")) {
-      val documentId =
-              try {
-                DocumentsContract.getDocumentId(Uri.parse(contentUrl))
-              } catch (e: Exception) {
-                null
-              }
-      if (documentId != null) return siblingDocumentIds.contains(documentId)
+  fun exists(ctx: Context, siblingDocumentIds: () -> Set<String>?): Boolean {
+    if (contentUrl.startsWith("content:")) {
+      val documentIds = siblingDocumentIds()
+      if (documentIds != null) {
+        val documentId =
+                try {
+                  DocumentsContract.getDocumentId(Uri.parse(contentUrl))
+                } catch (e: Exception) {
+                  null
+                }
+        if (documentId != null) return documentIds.contains(documentId)
+      }
     }
     return exists(ctx)
   }
+
+  /**
+   * Is the file still on disk? Costs a stat, so it is orders of magnitude cheaper than the SAF
+   * checks above, but it only answers presence: under scoped storage a path can be visible while
+   * the file is not openable. Only use it when access to the containing folder has been
+   * established separately.
+   */
+  @JsonIgnore fun existsOnDisk(): Boolean = absolutePath.isNotEmpty() && File(absolutePath).exists()
 
   @JsonIgnore
   fun isAudioFile(): Boolean {

--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -2,6 +2,7 @@ package com.audiobookshelf.app.data
 
 import android.content.Context
 import android.net.Uri
+import android.provider.DocumentsContract
 import android.support.v4.media.MediaDescriptionCompat
 import android.util.Log
 import com.fasterxml.jackson.annotation.JsonIgnore
@@ -83,6 +84,28 @@ data class LocalFile(
       }
     }
     return File(absolutePath).exists()
+  }
+
+  /**
+   * Existence check backed by a pre-fetched set of sibling document ids.
+   *
+   * Opening a file descriptor per file (see [exists]) costs a ContentResolver IPC round-trip
+   * (~15ms each), which adds up to minutes on libraries with thousands of downloaded files.
+   * When the caller already listed the parent folder once, this only does a set lookup.
+   * Falls back to the per-file check when no sibling set is available.
+   */
+  @JsonIgnore
+  fun exists(ctx: Context, siblingDocumentIds: Set<String>?): Boolean {
+    if (siblingDocumentIds != null && contentUrl.startsWith("content:")) {
+      val documentId =
+              try {
+                DocumentsContract.getDocumentId(Uri.parse(contentUrl))
+              } catch (e: Exception) {
+                null
+              }
+      if (documentId != null) return siblingDocumentIds.contains(documentId)
+    }
+    return exists(ctx)
   }
 
   @JsonIgnore

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
@@ -1,6 +1,8 @@
 package com.audiobookshelf.app.managers
 
 import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
 import android.util.Log
 import com.audiobookshelf.app.data.*
 import com.audiobookshelf.app.models.DownloadItem
@@ -147,16 +149,52 @@ class DbManager {
   }
 
   // Make sure all local file ids still exist
+  /**
+   * Lists the document ids of all children of the given SAF folder with a single
+   * ContentResolver query. Returns null when the folder cannot be listed (e.g. not a
+   * tree-based uri or permission lost) so callers can fall back to per-file checks.
+   */
+  private fun listFolderDocumentIds(context: Context, folderContentUrl: String?): Set<String>? {
+    if (folderContentUrl.isNullOrEmpty() || !folderContentUrl.startsWith("content:")) return null
+    return try {
+      val folderUri = Uri.parse(folderContentUrl)
+      val folderDocumentId =
+              if (DocumentsContract.isDocumentUri(context, folderUri)) {
+                DocumentsContract.getDocumentId(folderUri)
+              } else {
+                DocumentsContract.getTreeDocumentId(folderUri)
+              }
+      val childrenUri =
+              DocumentsContract.buildChildDocumentsUriUsingTree(folderUri, folderDocumentId)
+      val documentIds = mutableSetOf<String>()
+      context.contentResolver.query(
+              childrenUri,
+              arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID),
+              null,
+              null,
+              null
+      )?.use { cursor -> while (cursor.moveToNext()) documentIds.add(cursor.getString(0)) }
+              ?: return null
+      documentIds
+    } catch (e: Exception) {
+      Log.w(tag, "listFolderDocumentIds: Failed to list children of $folderContentUrl", e)
+      null
+    }
+  }
+
   fun cleanLocalLibraryItems(context: Context) {
     val localLibraryItems = getLocalLibraryItems()
 
     localLibraryItems.forEach { lli ->
       var hasUpdates = false
 
+      // One folder listing per item instead of one ContentResolver round-trip per file
+      val folderDocumentIds = listFolderDocumentIds(context, lli.contentUrl)
+
       // Check local files
       lli.localFiles =
               lli.localFiles.filter { localFile ->
-                val exists = localFile.exists(context)
+                val exists = localFile.exists(context, folderDocumentIds)
                 if (!exists) {
                   Log.d(
                           tag,
@@ -204,7 +242,7 @@ class DbManager {
       lli.coverAbsolutePath?.let {
         val coverExists =
                 lli.localFiles.any { localFile ->
-                  localFile.absolutePath == it && localFile.exists(context)
+                  localFile.absolutePath == it && localFile.exists(context, folderDocumentIds)
                 }
         if (!coverExists) {
           Log.d(

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
@@ -148,7 +148,32 @@ class DbManager {
     Paper.book("localMediaProgress").destroy()
   }
 
-  // Make sure all local file ids still exist
+  /**
+   * Does this app still hold read access to the document tree the given uri belongs to?
+   *
+   * Access is granted per tree, not per document, so asking once per folder answers it for every
+   * file inside. When it holds, presence on disk is enough to consider a file intact; when it does
+   * not, the caller has to fall back to checking each document through the provider.
+   */
+  private fun hasPersistedTreeAccess(context: Context, contentUrl: String?): Boolean {
+    if (contentUrl.isNullOrEmpty() || !contentUrl.startsWith("content:")) return false
+    return try {
+      val uri = Uri.parse(contentUrl)
+      val treeDocumentId = DocumentsContract.getTreeDocumentId(uri)
+      context.contentResolver.persistedUriPermissions.any { permission ->
+        permission.isReadPermission &&
+                permission.uri.authority == uri.authority &&
+                try {
+                  DocumentsContract.getTreeDocumentId(permission.uri)
+                } catch (e: Exception) {
+                  null
+                } == treeDocumentId
+      }
+    } catch (e: Exception) {
+      false
+    }
+  }
+
   /**
    * Lists the document ids of all children of the given SAF folder with a single
    * ContentResolver query. Returns null when the folder cannot be listed (e.g. not a
@@ -182,19 +207,28 @@ class DbManager {
     }
   }
 
+  // Make sure all local file ids still exist
   fun cleanLocalLibraryItems(context: Context) {
     val localLibraryItems = getLocalLibraryItems()
 
     localLibraryItems.forEach { lli ->
       var hasUpdates = false
 
-      // One folder listing per item instead of one ContentResolver round-trip per file
-      val folderDocumentIds = listFolderDocumentIds(context, lli.contentUrl)
+      // Read access is granted per document tree, so establish it once for the whole item. While
+      // it holds, a file that is still on disk is intact, and checking that costs a stat instead
+      // of a round-trip to the storage provider. Without it, fall back to the full check, using
+      // one folder listing rather than a round-trip per file.
+      val folderAccessible = hasPersistedTreeAccess(context, lli.contentUrl)
+      val folderDocumentIds by lazy { listFolderDocumentIds(context, lli.contentUrl) }
+      val fileExists = { localFile: LocalFile ->
+        if (folderAccessible) localFile.existsOnDisk()
+        else localFile.exists(context) { folderDocumentIds }
+      }
 
       // Check local files
       lli.localFiles =
               lli.localFiles.filter { localFile ->
-                val exists = localFile.exists(context, folderDocumentIds)
+                val exists = fileExists(localFile)
                 if (!exists) {
                   Log.d(
                           tag,
@@ -242,7 +276,7 @@ class DbManager {
       lli.coverAbsolutePath?.let {
         val coverExists =
                 lli.localFiles.any { localFile ->
-                  localFile.absolutePath == it && localFile.exists(context, folderDocumentIds)
+                  localFile.absolutePath == it && fileExists(localFile)
                 }
         if (!coverExists) {
           Log.d(

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
@@ -240,34 +240,37 @@ class DbManager {
               } as
                       MutableList<LocalFile>
 
-      // Check audio tracks and episodes
+      // Check audio tracks and episodes. Scanning the file list per track is quadratic and
+      // dominates the cleanup on items with hundreds of files, so look ids up in a set.
+      val localFileIds = lli.localFiles.mapTo(HashSet()) { it.id }
       if (lli.isPodcast) {
         val podcast = lli.media as Podcast
         podcast.episodes =
                 podcast.episodes?.filter { ep ->
-                  if (lli.localFiles.find { lf -> lf.id == ep.audioTrack?.localFileId } == null) {
+                  val hasLocalFile = ep.audioTrack?.localFileId?.let(localFileIds::contains) == true
+                  if (!hasLocalFile) {
                     Log.d(
                             tag,
                             "cleanLocalLibraryItems: Podcast episode ${ep.title} was removed from library item ${lli.media.metadata.title}"
                     )
                     hasUpdates = true
                   }
-                  ep.audioTrack != null &&
-                          lli.localFiles.find { lf -> lf.id == ep.audioTrack?.localFileId } != null
+                  ep.audioTrack != null && hasLocalFile
                 } as
                         MutableList<PodcastEpisode>
       } else {
         val book = lli.media as Book
         book.tracks =
                 book.tracks?.filter { track ->
-                  if (lli.localFiles.find { lf -> lf.id == track.localFileId } == null) {
+                  val hasLocalFile = track.localFileId?.let(localFileIds::contains) == true
+                  if (!hasLocalFile) {
                     Log.d(
                             tag,
                             "cleanLocalLibraryItems: Audio track ${track.title} was removed from library item ${lli.media.metadata.title}"
                     )
                     hasUpdates = true
                   }
-                  lli.localFiles.find { lf -> lf.id == track.localFileId } != null
+                  hasLocalFile
                 } as
                         MutableList<AudioTrack>
       }

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -58,10 +58,6 @@ class DownloadItemManager(
     fun onComplete(failed: Boolean)
   }
 
-  init {
-    IncompleteDownloadCleanup.cleanupExpired(context)
-  }
-
   @Synchronized
   fun setEventEmitter(eventEmitter: DownloadEventEmitter) {
     clientEventEmitter = eventEmitter
@@ -69,10 +65,16 @@ class DownloadItemManager(
     notifyQueueChanged()
   }
 
+  /**
+   * Restores the persisted queue. Deserializes the download db and probes shared storage for
+   * files that are already in place, so this must not be called from the main thread.
+   */
   @Synchronized
   fun restoreQueue() {
     if (downloadItemQueue.isNotEmpty()) return
-    DeviceManager.dbManager.getDownloadItems().forEach { item ->
+    val persistedItems = DeviceManager.dbManager.getDownloadItems()
+    val expiredIds = IncompleteDownloadCleanup.cleanupExpired(context, persistedItems)
+    persistedItems.filterNot { expiredIds.contains(it.id) }.forEach { item ->
       if (item.isDownloadFinished) {
         downloadItemQueue.add(item)
         checkDownloadItemFinished(item)

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/IncompleteDownloadCleanup.kt
@@ -36,12 +36,18 @@ object IncompleteDownloadCleanup {
 
   /** Removes failures retained longer than 24 hours when scheduled work did not run. */
   fun cleanupExpired(context: Context) {
+    cleanupExpired(context, DeviceManager.dbManager.getDownloadItems())
+  }
+
+  /**
+   * Same, for callers that already hold the persisted items. Returns the ids that were deleted so
+   * the caller can drop them from its own copy of the list.
+   */
+  fun cleanupExpired(context: Context, items: List<DownloadItem>): Set<String> {
     val now = System.currentTimeMillis()
-    DeviceManager.dbManager.getDownloadItems()
-            .filter { item -> isEligible(item, now) }
-            .forEach { item ->
-              deleteItem(context, item)
-            }
+    val expired = items.filter { item -> isEligible(item, now) }
+    expired.forEach { item -> deleteItem(context, item) }
+    return expired.map { it.id }.toSet()
   }
 
   private fun isEligible(item: DownloadItem, now: Long): Boolean {

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDatabase.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDatabase.kt
@@ -39,9 +39,14 @@ class AbsDatabase : Plugin() {
 
     secureStorage = SecureStorage(mainActivity)
 
-    DeviceManager.dbManager.cleanLocalMediaProgress()
-    DeviceManager.dbManager.cleanLocalLibraryItems(mainActivity)
-    DeviceManager.dbManager.cleanLogs()
+    // Run db cleanup off the main thread. Capacitor calls load() synchronously during
+    // Activity.onCreate, and with many downloaded files these scans block app startup
+    // (deserializing the local library alone can take seconds).
+    GlobalScope.launch(Dispatchers.IO) {
+      DeviceManager.dbManager.cleanLocalMediaProgress()
+      DeviceManager.dbManager.cleanLocalLibraryItems(mainActivity)
+      DeviceManager.dbManager.cleanLogs()
+    }
   }
 
   @PluginMethod

--- a/android/app/src/main/java/com/audiobookshelf/app/services/DownloadServiceHost.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/services/DownloadServiceHost.kt
@@ -1,6 +1,7 @@
 package com.audiobookshelf.app.services
 
 import android.content.Context
+import android.util.Log
 import androidx.core.content.ContextCompat
 import com.audiobookshelf.app.device.FolderScanner
 import com.audiobookshelf.app.managers.DbManager
@@ -8,6 +9,11 @@ import com.audiobookshelf.app.managers.DownloadItemManager
 import com.audiobookshelf.app.models.DownloadItem
 import com.getcapacitor.JSObject
 import java.util.Collections
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 /** Shared process owner used by the foreground service and the Capacitor bridge. */
 object DownloadServiceHost {
@@ -19,10 +25,14 @@ object DownloadServiceHost {
           val cancel: String
   )
 
+  private const val tag = "DownloadServiceHost"
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
   private var manager: DownloadItemManager? = null
   private var bridgeEmitter: DownloadItemManager.DownloadEventEmitter = NoopEmitter
   private var service: DownloadService? = null
   @Volatile private var bridgeReady = false
+  @Volatile private var restoreJob: Job? = null
   private val deferredCompletions = Collections.synchronizedList(mutableListOf<JSObject>())
 
   @Synchronized
@@ -30,8 +40,14 @@ object DownloadServiceHost {
     if (manager == null) {
       val appContext = context.applicationContext
       DbManager.initialize(appContext)
-      manager = DownloadItemManager(FolderScanner(appContext), appContext, ForwardingEmitter)
-      manager!!.restoreQueue()
+      val created = DownloadItemManager(FolderScanner(appContext), appContext, ForwardingEmitter)
+      manager = created
+      // Restoring deserializes the download db and probes shared storage. That is far too slow
+      // for the main thread, which is where the Capacitor plugin load calls this from.
+      restoreJob = scope.launch {
+        created.restoreQueue()
+        if (created.hasWork()) startService(appContext)
+      }
     }
     return manager!!
   }
@@ -42,13 +58,17 @@ object DownloadServiceHost {
     bridgeReady = false
     bridgeEmitter = emitter
     val queue = ensure(context)
-    queue.setEventEmitter(ForwardingEmitter)
-    bridgeReady = true
-    val completions = synchronized(deferredCompletions) {
-      deferredCompletions.toList().also { deferredCompletions.clear() }
+    val appContext = context.applicationContext
+    scope.launch {
+      restoreJob?.join()
+      queue.setEventEmitter(ForwardingEmitter)
+      bridgeReady = true
+      val completions = synchronized(deferredCompletions) {
+        deferredCompletions.toList().also { deferredCompletions.clear() }
+      }
+      completions.forEach(bridgeEmitter::onDownloadItemComplete)
+      if (queue.hasWork()) startService(appContext)
     }
-    completions.forEach(bridgeEmitter::onDownloadItemComplete)
-    if (queue.hasWork()) startService(context)
   }
 
   @Synchronized
@@ -99,7 +119,11 @@ object DownloadServiceHost {
   @Synchronized
   fun attachService(downloadService: DownloadService) {
     service = downloadService
-    service?.onQueueChanged(ensure(downloadService).hasWork())
+    val queue = ensure(downloadService)
+    scope.launch {
+      restoreJob?.join()
+      downloadService.onQueueChanged(queue.hasWork())
+    }
   }
 
   @Synchronized
@@ -108,7 +132,13 @@ object DownloadServiceHost {
   }
 
   private fun startService(context: Context) {
-    ContextCompat.startForegroundService(context, DownloadService.intent(context))
+    // The queue can be restored while the app sits in the background, where starting a
+    // foreground service is not permitted. The in-process watcher keeps the queue moving.
+    try {
+      ContextCompat.startForegroundService(context, DownloadService.intent(context))
+    } catch (e: Exception) {
+      Log.w(tag, "Could not start the download foreground service", e)
+    }
   }
 
   private object ForwardingEmitter : DownloadItemManager.DownloadEventEmitter {


### PR DESCRIPTION
## Brief summary

Cold start on Android took about a minute with many downloaded files, because two Capacitor plugins do heavy storage I/O in `load()`, which runs synchronously on the main thread. This moves that work off the main thread and makes it cheap: **75.4 s blocked → 0.3–0.8 s**, and the library cleanup itself from ~69 s → 1.6 s.

## Which issue is fixed?

Fixes #1997

## Pull Request Type

Android only, native side. No frontend changes.

## In-depth Description

Four commits, each doing one thing.

**1. `Fix slow app startup with many downloaded files`** — `AbsDatabase.load()` ran `cleanLocalMediaProgress`, `cleanLocalLibraryItems` and `cleanLogs` synchronously. Capacitor calls `load()` from `BridgeActivity.onCreate`, so this blocked the first frame. Wrapped in `GlobalScope.launch(Dispatchers.IO)`, matching how the other methods of the same plugin already work.

**2. `Restore the download queue off the main thread`** — `AbsDownloader.load()` called `DownloadServiceHost.ensure()`, which deserializes the download db and probes shared storage. `DownloadServiceHost` now creates the manager synchronously, so `ensure()` still returns a usable instance to every caller, but runs `restoreQueue()` in a coroutine and defers the bridge attach until that job completes, which preserves the existing event and `bridgeReady` ordering. The persisted items were also read twice, once in `DownloadItemManager`'s constructor via `IncompleteDownloadCleanup.cleanupExpired()` and once in `restoreQueue()`; the loaded list is now passed to the cleanup so the db is read once.

This commit also guards `startForegroundService`. With the queue restored in the background it can be called while the app is in the background, where it throws `ForegroundServiceStartNotAllowedException`. That exception already escapes `load()` on v0.14.0-beta today — it is reproducible by launching the app while the screen is locked with work in the queue — and Capacitor then drops the whole plugin with `PluginLoadException: Unable to load plugin instance`, leaving downloads dead until the app is restarted. That may be what #1970 is seeing, though I have not confirmed it.

**3. `Establish folder access once instead of once per file`** — the expensive part of `cleanLocalLibraryItems`. Checking each file with `openFileDescriptor` costs a round-trip per file; listing the parent folder instead only helps by about 3x, because the provider stats every entry it returns.

Read access, however, is granted per document tree, not per document, so `contentResolver.persistedUriPermissions` answers it for a whole item at once. While that grant holds, a file that is still on disk is intact, and checking that costs a `stat`.

The full per-document check is kept and is used whenever the grant is not confirmed, so nothing is dropped from the local library on the basis of the cheap check alone. In that case every file is verified through the provider as before, except that the item's folder is listed once via `buildChildDocumentsUriUsingTree`, falling back to the per-file check when the folder cannot be listed. The three checks are now separate, named methods on `LocalFile` (`exists(ctx)`, `exists(ctx) { siblingIds }`, `existsOnDisk()`) with the constraint documented on the cheap one.

Worth flagging for review: a plain `File.exists()` is *not* a substitute for the provider check. Measured on Android 15, the app can `stat` files it holds no grant for, and cannot open even its own downloaded files through the `File` api (`exists=true`, `canRead=false`). Presence and accessibility are separate questions, which is why access is established separately rather than inferred from a path.

**4. `Match audio tracks to local files with a set lookup`** — not a regression, but it dominates the cleanup once the storage access is fixed. Every track scanned the whole local file list, twice. Collecting the ids into a set once per item is ~150x faster for a book with 370 files.

## How have you tested this?

On a Fairphone 4 / Android 15 with a library of 1557 downloaded files in a SAF folder on internal storage, using a debug build side by side with unmodified v0.14.0-beta. Cold start measured from logcat: `Starting BridgeActivity` → `load: AbsLogger plugin initialized`, and the plugin attribution comes from the `Registering plugin instance:` lines in between. Absolute values are higher than a release build would give; the ratios are what matters.

| Phase | v0.14.0-beta | this PR |
| --- | --- | --- |
| `AbsDownloader.load()` | 16.6 s | 0.06 s |
| `AbsDatabase.load()` | 58.1 s | 0.02 s |
| **main thread blocked** | **75.4 s** | **0.3–0.8 s** |
| until `mounted` | 77.7 s | 2.3–4.7 s |

The cleanup itself, instrumented, now on a background thread:

| | existence checks | track matching | whole cleanup |
| --- | --- | --- | --- |
| v0.14.0-beta | 53.8 s | 15.0 s | ~69 s |
| one folder listing per item | 18.2 s | 15.0 s | 33.5 s |
| + access established per folder | 1.3 s | 15.0 s | 16.3 s |
| + set lookup for tracks | 1.3 s | 0.11 s | **1.6 s** |

The 53.8 s vs 18.2 s comparison is an A/B on the same device and the same files, with only the checking strategy swapped.

Behaviour checks on the same device: all queued download items are still restored and forwarded to the frontend (visible as `DownloadProgressIndicator onDownloadItem` in the web console); no local library item lost files or tracks during the cleanup across every run; `persistedUriPermissions` correctly resolved to the granted tree for all items, including books in nested subfolders, so the cheap path is the one actually taken; and `AbsDownloader` now loads without the `PluginLoadException` described above.

Both intermediate commits build on their own.

## Screenshots

No frontend changes.
