### PR TITLE
Add local network server address switching

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />

--- a/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/MainActivity.kt
@@ -24,6 +24,7 @@ import com.audiobookshelf.app.plugins.AbsDatabase
 import com.audiobookshelf.app.plugins.AbsDownloader
 import com.audiobookshelf.app.plugins.AbsFileSystem
 import com.audiobookshelf.app.plugins.AbsLogger
+import com.audiobookshelf.app.plugins.AbsNetwork
 import com.getcapacitor.BridgeActivity
 
 
@@ -43,12 +44,14 @@ class MainActivity : BridgeActivity() {
 
   public override fun onCreate(savedInstanceState: Bundle?) {
     DbManager.initialize(applicationContext)
+    com.audiobookshelf.app.device.DeviceManager.applicationContext = applicationContext
 
     registerPlugin(AbsAudioPlayer::class.java)
     registerPlugin(AbsDownloader::class.java)
     registerPlugin(AbsFileSystem::class.java)
     registerPlugin(AbsDatabase::class.java)
     registerPlugin(AbsLogger::class.java)
+    registerPlugin(AbsNetwork::class.java)
 
     super.onCreate(savedInstanceState)
     Log.d(tag, "onCreate")

--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -59,7 +59,9 @@ data class ServerConnectionConfig(
         var userId: String,
         var username: String,
         var token: String,
-        var customHeaders: Map<String, String>?
+        var customHeaders: Map<String, String>? = null,
+        var localAddress: String? = null,
+        var localSsidWhitelist: MutableList<String>? = mutableListOf()
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/device/DeviceManager.kt
@@ -5,6 +5,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.net.wifi.WifiManager
 import android.util.Log
 import com.audiobookshelf.app.MediaPlayerWidget
 import com.audiobookshelf.app.data.*
@@ -31,12 +32,13 @@ object DeviceManager {
   val dbManager: DbManager = DbManager()
   var deviceData: DeviceData = dbManager.getDeviceData()
   var serverConnectionConfig: ServerConnectionConfig? = null
+  var applicationContext: Context? = null
 
   val serverConnectionConfigId get() = serverConnectionConfig?.id ?: ""
   val serverConnectionConfigName get() = serverConnectionConfig?.name ?: ""
   val serverConnectionConfigString get() = serverConnectionConfig?.name ?: "No server connection"
   val serverAddress
-    get() = serverConnectionConfig?.address ?: ""
+    get() = getServerAddress(serverConnectionConfig)
   val serverUserId
     get() = serverConnectionConfig?.userId ?: ""
   val token
@@ -110,6 +112,31 @@ object DeviceManager {
    */
   fun getServerConnectionConfig(id: String?): ServerConnectionConfig? {
     return id?.let { deviceData.serverConnectionConfigs.find { it.id == id } }
+  }
+
+  fun getServerAddress(config: ServerConnectionConfig?): String {
+    if (config == null) return ""
+    val localAddress = config.localAddress
+    val localSsids = config.localSsidWhitelist ?: mutableListOf()
+    if (localAddress.isNullOrBlank() || localSsids.isEmpty()) return config.address
+
+    val currentSsid = getCurrentWifiSsid()
+    if (!currentSsid.isNullOrBlank() && localSsids.contains(currentSsid)) {
+      return localAddress
+    }
+
+    return config.address
+  }
+
+  fun getCurrentWifiSsid(): String? {
+    val ctx = applicationContext ?: return null
+    val wifiManager = ctx.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    var ssid = wifiManager.connectionInfo?.ssid ?: return null
+    if (ssid == WifiManager.UNKNOWN_SSID || ssid == "<unknown ssid>") return null
+    if (ssid.length >= 2 && ssid.startsWith("\"") && ssid.endsWith("\"")) {
+      ssid = ssid.substring(1, ssid.length - 1)
+    }
+    return ssid
   }
 
   /**

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -496,7 +496,9 @@ class DownloadItemManager(
 
   private fun serverUrl(item: DownloadItem, part: DownloadItemPart): String {
     val rawCover = if (part.serverPath.endsWith("/cover")) "?raw=1" else ""
-    return "${item.serverAddress}${part.serverPath}$rawCover"
+    val config = DeviceManager.getServerConnectionConfig(item.serverConnectionConfigId)
+    val activeAddress = DeviceManager.getServerAddress(config).ifEmpty { item.serverAddress }
+    return "$activeAddress${part.serverPath}$rawCover"
   }
 
   private companion object {

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDatabase.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDatabase.kt
@@ -30,7 +30,7 @@ class AbsDatabase : Plugin() {
   data class LocalMediaProgressPayload(val value:List<LocalMediaProgress>)
   data class LocalLibraryItemsPayload(val value:List<LocalLibraryItem>)
   data class LocalFoldersPayload(val value:List<LocalFolder>)
-  data class ServerConnConfigPayload(val id:String?, val index:Int, val name:String?, val userId:String, val username:String, var version:String, val token:String, val refreshToken:String?, val address:String?, val customHeaders:Map<String,String>?)
+  data class ServerConnConfigPayload(val id:String?, val index:Int, val name:String?, val userId:String, val username:String, var version:String, val token:String, val refreshToken:String?, val address:String?, val customHeaders:Map<String,String>?, val localAddress:String?, val localSsidWhitelist:MutableList<String>?)
 
   override fun load() {
     mainActivity = (activity as MainActivity)
@@ -145,7 +145,7 @@ class AbsDatabase : Plugin() {
         }
         Log.d(tag, "Refresh token secured = $hasRefreshToken")
 
-        serverConnectionConfig = ServerConnectionConfig(sscId, sscIndex, "$serverAddress ($username)", serverAddress, serverVersion, userId, username, accessToken, serverConfigPayload.customHeaders)
+        serverConnectionConfig = ServerConnectionConfig(sscId, sscIndex, "$serverAddress ($username)", serverAddress, serverVersion, userId, username, accessToken, serverConfigPayload.customHeaders, serverConfigPayload.localAddress, serverConfigPayload.localSsidWhitelist ?: mutableListOf())
 
         // Add and save
         DeviceManager.deviceData.serverConnectionConfigs.add(serverConnectionConfig!!)
@@ -153,12 +153,14 @@ class AbsDatabase : Plugin() {
         DeviceManager.dbManager.saveDeviceData(DeviceManager.deviceData)
       } else {
         var shouldSave = false
-        if (serverConnectionConfig?.username != username || serverConnectionConfig?.token != accessToken || serverConnectionConfig?.version != serverVersion) {
+        if (serverConnectionConfig?.username != username || serverConnectionConfig?.token != accessToken || serverConnectionConfig?.version != serverVersion || serverConnectionConfig?.localAddress != serverConfigPayload.localAddress || serverConnectionConfig?.localSsidWhitelist != serverConfigPayload.localSsidWhitelist) {
           serverConnectionConfig?.userId = userId
           serverConnectionConfig?.username = username
           serverConnectionConfig?.name = "${serverConnectionConfig?.address} (${serverConnectionConfig?.username})"
           serverConnectionConfig?.version = serverVersion
           serverConnectionConfig?.token = accessToken
+          serverConnectionConfig?.localAddress = serverConfigPayload.localAddress
+          serverConnectionConfig?.localSsidWhitelist = serverConfigPayload.localSsidWhitelist ?: mutableListOf()
           shouldSave = true
         }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsDownloader.kt
@@ -176,7 +176,7 @@ class AbsDownloader : Plugin() {
       Log.d(tag, "Starting library item download with ${tracks.size} tracks")
       val itemSubfolder = "$bookAuthor/$bookTitle"
       val itemFolderPath = if (isInternal) finalInternalFolderPath else "${localFolder.absolutePath}/$itemSubfolder"
-      val downloadItem = DownloadItem(libraryItem.id, libraryItem.id, null, libraryItem.userMediaProgress,DeviceManager.serverConnectionConfig?.id ?: "", DeviceManager.serverAddress, DeviceManager.serverUserId, libraryItem.mediaType, itemFolderPath, localFolder, bookTitle, itemSubfolder, libraryItem.media, mutableListOf())
+      val downloadItem = DownloadItem(libraryItem.id, libraryItem.id, null, libraryItem.userMediaProgress,DeviceManager.serverConnectionConfig?.id ?: "", DeviceManager.serverConnectionConfig?.address ?: "", DeviceManager.serverUserId, libraryItem.mediaType, itemFolderPath, localFolder, bookTitle, itemSubfolder, libraryItem.media, mutableListOf())
 
       val book = libraryItem.media as Book
       book.ebookFile?.let { ebookFile ->
@@ -237,7 +237,7 @@ class AbsDownloader : Plugin() {
       Log.d(tag, "Starting podcast episode download")
       val itemFolderPath = if (isInternal) finalInternalFolderPath else "${localFolder.absolutePath}/$podcastTitle"
       val downloadItemId = "${libraryItem.id}-${episode?.id}"
-      val downloadItem = DownloadItem(downloadItemId, libraryItem.id, episode?.id, libraryItem.userMediaProgress, DeviceManager.serverConnectionConfig?.id ?: "", DeviceManager.serverAddress, DeviceManager.serverUserId, libraryItem.mediaType, itemFolderPath, localFolder, podcastTitle, podcastTitle, libraryItem.media, mutableListOf())
+      val downloadItem = DownloadItem(downloadItemId, libraryItem.id, episode?.id, libraryItem.userMediaProgress, DeviceManager.serverConnectionConfig?.id ?: "", DeviceManager.serverConnectionConfig?.address ?: "", DeviceManager.serverUserId, libraryItem.mediaType, itemFolderPath, localFolder, podcastTitle, podcastTitle, libraryItem.media, mutableListOf())
 
       var serverPath = "/api/items/${libraryItem.id}/file/${audioFileIno}/download"
       var destinationFilename = getFilenameFromRelPath(audioTrack?.relPath ?: "")

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsNetwork.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsNetwork.kt
@@ -1,0 +1,56 @@
+package com.audiobookshelf.app.plugins
+
+import android.Manifest
+import android.content.Context
+import android.net.wifi.WifiManager
+import com.getcapacitor.JSObject
+import com.getcapacitor.PermissionState
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.getcapacitor.annotation.Permission
+import com.getcapacitor.annotation.PermissionCallback
+
+@CapacitorPlugin(
+  name = "AbsNetwork",
+  permissions = [
+    Permission(strings = [Manifest.permission.ACCESS_FINE_LOCATION], alias = "location")
+  ]
+)
+class AbsNetwork : Plugin() {
+  @PluginMethod
+  fun getCurrentWifiSsid(call: PluginCall) {
+    if (getPermissionState("location") != PermissionState.GRANTED) {
+      requestPermissionForAlias("location", call, "locationPermsCallback")
+      return
+    }
+
+    resolveCurrentWifiSsid(call)
+  }
+
+  @PermissionCallback
+  private fun locationPermsCallback(call: PluginCall) {
+    if (getPermissionState("location") == PermissionState.GRANTED) {
+      resolveCurrentWifiSsid(call)
+    } else {
+      call.resolve(JSObject().put("ssid", null))
+    }
+  }
+
+  private fun resolveCurrentWifiSsid(call: PluginCall) {
+    val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+    val wifiInfo = wifiManager.connectionInfo
+    var ssid: String? = wifiInfo?.ssid
+
+    if (ssid == null || ssid == WifiManager.UNKNOWN_SSID || ssid == "<unknown ssid>") {
+      ssid = null
+    }
+
+    if (ssid != null && ssid.length >= 2 && ssid.startsWith("\"") && ssid.endsWith("\"")) {
+      ssid = ssid.substring(1, ssid.length - 1)
+    }
+
+    call.resolve(JSObject().put("ssid", ssid))
+  }
+}

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -54,7 +54,7 @@ class ApiHandler(var ctx:Context) {
   data class LocalSessionsSyncResponsePayload(val results:List<LocalSessionSyncResult>)
 
   private fun getRequest(endpoint:String, httpClient:OkHttpClient?, config:ServerConnectionConfig?, cb: (JSObject) -> Unit) {
-    val address = config?.address ?: DeviceManager.serverAddress
+    val address = if (config != null) DeviceManager.getServerAddress(config) else DeviceManager.serverAddress
     val token = config?.token ?: DeviceManager.token
 
     try {
@@ -71,7 +71,7 @@ class ApiHandler(var ctx:Context) {
   }
 
   private fun postRequest(endpoint:String, payload: JSObject?, config:ServerConnectionConfig?, cb: (JSObject) -> Unit) {
-    val address = config?.address ?: DeviceManager.serverAddress
+    val address = if (config != null) DeviceManager.getServerAddress(config) else DeviceManager.serverAddress
     val token = config?.token ?: DeviceManager.token
     val mediaType = "application/json; charset=utf-8".toMediaType()
     val requestBody = payload?.toString()?.toRequestBody(mediaType) ?: EMPTY_REQUEST

--- a/components/app/SideDrawer.vue
+++ b/components/app/SideDrawer.vue
@@ -19,8 +19,12 @@
         </template>
       </div>
       <div class="absolute bottom-0 left-0 w-full py-6 px-6 text-fg">
-        <div v-if="serverConnectionConfig" class="mb-4 flex justify-center">
-          <p class="text-xs text-fg-muted" style="word-break: break-word">{{ serverConnectionConfig.address }} (v{{ serverSettings.version }})</p>
+        <div v-if="serverConnectionConfig" class="mb-4">
+          <div class="flex items-center justify-center gap-1 mb-1">
+            <span class="material-symbols text-sm" :class="isUsingLocalConnection ? 'text-success' : 'text-fg-muted'">{{ isUsingLocalConnection ? 'home_wifi' : 'public' }}</span>
+            <p class="text-xs" :class="isUsingLocalConnection ? 'text-success' : 'text-fg-muted'">{{ connectionModeLabel }}</p>
+          </div>
+          <p class="text-xs text-fg-muted text-center" style="word-break: break-word">{{ shownServerAddress }} (v{{ serverSettings.version }})</p>
         </div>
         <div class="flex items-center">
           <p class="text-xs">{{ $config.version }}</p>
@@ -51,9 +55,13 @@ export default {
       }
     },
     show: {
-      handler(newVal) {
-        if (newVal) this.registerListener()
-        else this.removeListener()
+      async handler(newVal) {
+        if (newVal) {
+          await this.refreshActiveServerAddress()
+          this.registerListener()
+        } else {
+          this.removeListener()
+        }
       }
     }
   },
@@ -74,6 +82,19 @@ export default {
     },
     serverSettings() {
       return this.$store.state.serverSettings || {}
+    },
+    activeServerAddress() {
+      return this.$store.getters['user/getActiveServerAddress']
+    },
+    shownServerAddress() {
+      return this.activeServerAddress || this.serverConnectionConfig?.address || ''
+    },
+    isUsingLocalConnection() {
+      if (!this.serverConnectionConfig?.localAddress || !this.activeServerAddress) return false
+      return this.$serverAddress.normalizeAddress(this.activeServerAddress) === this.$serverAddress.normalizeAddress(this.serverConnectionConfig.localAddress)
+    },
+    connectionModeLabel() {
+      return this.isUsingLocalConnection ? 'Local connection' : 'External connection'
     },
     username() {
       return this.user?.username || ''
@@ -192,6 +213,10 @@ export default {
 
       // Close side drawer
       this.show = false
+    },
+    async refreshActiveServerAddress() {
+      if (!this.serverConnectionConfig) return
+      await this.$serverAddress.resolve(this.serverConnectionConfig, { forceRefresh: true })
     },
     touchstart(e) {
       this.touchEvent = new TouchEvent(e)

--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -39,6 +39,17 @@
           </div>
           <h2 class="text-lg leading-7 mb-2">{{ $strings.LabelServerAddress }}</h2>
           <ui-text-input v-model="serverConfig.address" :disabled="processing || !networkConnected || !!serverConfig.id" placeholder="http://55.55.55.55:13378" type="url" class="w-full h-10" />
+          <div class="mt-4">
+            <p class="text-sm text-fg-muted mb-1">Local network address</p>
+            <ui-text-input v-model="serverConfig.localAddress" :disabled="processing || !networkConnected" placeholder="http://192.168.1.20:13378" type="url" class="w-full h-10" />
+          </div>
+          <div class="mt-4">
+            <div class="flex items-center justify-between mb-1 gap-2">
+              <p class="text-sm text-fg-muted">Local Wi-Fi SSIDs</p>
+              <ui-btn type="button" :disabled="processing || !networkConnected" :padding-x="2" :padding-y="1" class="text-xs" @click="addCurrentWifiSsid">Use current Wi-Fi</ui-btn>
+            </div>
+            <textarea v-model="localSsidText" :disabled="processing || !networkConnected" placeholder="Home WiFi&#10;Office WiFi" class="w-full min-h-[5rem] rounded bg-bg border border-fg/20 px-3 py-2 text-sm outline-none focus:border-fg/60"></textarea>
+          </div>
           <div class="flex justify-end items-center mt-6">
             <ui-btn :disabled="processing || !networkConnected" type="submit" :padding-x="3" class="h-10">{{ networkConnected ? $strings.ButtonSubmit : $strings.MessageNoNetworkConnection }}</ui-btn>
           </div>
@@ -109,8 +120,11 @@ export default {
         address: null,
         version: null,
         username: null,
-        customHeaders: null
+        customHeaders: null,
+        localAddress: null,
+        localSsidWhitelist: []
       },
+      localSsidText: '',
       password: null,
       error: null,
       showForm: false,
@@ -440,11 +454,14 @@ export default {
       this.showForm = false
       this.showAuth = false
       this.error = null
-      this.serverConfig = {
-        address: null,
-        userId: null,
-        username: null
-      }
+        this.serverConfig = {
+          address: null,
+          userId: null,
+          username: null,
+          localAddress: null,
+          localSsidWhitelist: []
+        }
+        this.localSsidText = ''
     },
     async connectToServer(config) {
       await this.$hapticsImpact()
@@ -453,6 +470,7 @@ export default {
       this.serverConfig = {
         ...config
       }
+      this.localSsidText = (config.localSsidWhitelist || []).join('\n')
       this.showForm = true
       var success = await this.pingServerAddress(config.address)
       this.processing = false
@@ -493,11 +511,14 @@ export default {
         updatedDeviceData.serverConnectionConfigs = this.deviceData.serverConnectionConfigs.filter((scc) => scc.id != serverConfig.id)
         this.$store.commit('setDeviceData', updatedDeviceData)
 
-        this.serverConfig = {
-          address: null,
-          userId: null,
-          username: null
-        }
+      this.serverConfig = {
+        address: null,
+        userId: null,
+        username: null,
+        localAddress: null,
+        localSsidWhitelist: []
+      }
+      this.localSsidText = ''
         this.password = null
         this.processing = false
         this.showAuth = false
@@ -509,6 +530,7 @@ export default {
       this.serverConfig = {
         ...serverConfig
       }
+      this.localSsidText = (serverConfig.localSsidWhitelist || []).join('\n')
 
       if (await this.submit(true)) {
         this.showForm = true
@@ -519,8 +541,11 @@ export default {
       this.serverConfig = {
         address: '',
         userId: '',
-        username: ''
+        username: '',
+        localAddress: null,
+        localSsidWhitelist: []
       }
+      this.localSsidText = ''
       this.showForm = true
       this.showAuth = false
       this.error = null
@@ -528,6 +553,29 @@ export default {
     editServerAddress() {
       this.error = null
       this.showAuth = false
+    },
+    syncLocalConnectionSettings() {
+      this.serverConfig.localAddress = this.$serverAddress.normalizeAddress(this.serverConfig.localAddress) || null
+      this.serverConfig.localSsidWhitelist = this.localSsidText
+        .split('\n')
+        .map((ssid) => ssid.trim())
+        .filter(Boolean)
+    },
+    async addCurrentWifiSsid() {
+      const ssid = await this.$serverAddress.getCurrentWifiSsid()
+      if (!ssid) {
+        this.$toast.error('Current Wi-Fi SSID is unavailable')
+        return
+      }
+
+      const ssids = this.localSsidText
+        .split('\n')
+        .map((value) => value.trim())
+        .filter(Boolean)
+      if (!ssids.includes(ssid)) {
+        ssids.push(ssid)
+      }
+      this.localSsidText = ssids.join('\n')
     },
     /**
      * Validates a URL and reconstructs it with an optional protocol override.
@@ -662,6 +710,7 @@ export default {
       if (!this.networkConnected || !this.serverConfig.address) return false
 
       const initialAddress = this.serverConfig.address
+      this.syncLocalConnectionSettings()
       // Did the user specify a protocol?
       const protocolProvided = initialAddress.startsWith('http://') || initialAddress.startsWith('https://')
       // Add https:// if not provided
@@ -873,6 +922,7 @@ export default {
       }
 
       this.serverConfig.version = serverSettings.version
+      this.syncLocalConnectionSettings()
 
       var serverConnectionConfig = await this.$db.setServerConnectionConfig(this.serverConfig)
 
@@ -901,7 +951,8 @@ export default {
       this.$store.commit('user/setAccessToken', serverConnectionConfig.token)
       this.$store.commit('user/setServerConnectionConfig', serverConnectionConfig)
 
-      this.$socket.connect(this.serverConfig.address, this.serverConfig.token)
+      const activeServerAddress = await this.$serverAddress.resolve(serverConnectionConfig, { forceRefresh: true })
+      this.$socket.connect(activeServerAddress || this.serverConfig.address, this.serverConfig.token)
       this.$router.replace('/bookshelf')
     },
     async authenticateToken() {

--- a/components/modals/ItemMoreMenuModal.vue
+++ b/components/modals/ItemMoreMenuModal.vue
@@ -164,6 +164,8 @@ export default {
     },
     isConnectedToServer() {
       if (!this.isLocal) return true
+      const currentConfigId = this.$store.getters['user/getServerConnectionConfigId']
+      if (this.libraryItem?.serverConnectionConfigId && currentConfigId === this.libraryItem.serverConnectionConfigId) return true
       if (!this.libraryItem?.serverAddress) return false
       return this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress
     },

--- a/components/readers/ComicReader.vue
+++ b/components/readers/ComicReader.vue
@@ -90,8 +90,12 @@ export default {
     serverLibraryItemId() {
       if (!this.isLocal) return this.libraryItem.id
       // Check if local library item is connected to the current server
-      if (!this.libraryItem.serverAddress || !this.libraryItem.libraryItemId) return null
-      if (this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress) {
+      if (!this.libraryItem.libraryItemId) return null
+      const currentConfigId = this.$store.getters['user/getServerConnectionConfigId']
+      if (this.libraryItem.serverConnectionConfigId && currentConfigId === this.libraryItem.serverConnectionConfigId) {
+        return this.libraryItem.libraryItemId
+      }
+      if (this.libraryItem.serverAddress && this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress) {
         return this.libraryItem.libraryItemId
       }
       return null

--- a/components/readers/EpubReader.vue
+++ b/components/readers/EpubReader.vue
@@ -64,8 +64,12 @@ export default {
     serverLibraryItemId() {
       if (!this.isLocal) return this.libraryItem.id
       // Check if local library item is connected to the current server
-      if (!this.libraryItem.serverAddress || !this.libraryItem.libraryItemId) return null
-      if (this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress) {
+      if (!this.libraryItem.libraryItemId) return null
+      const currentConfigId = this.$store.getters['user/getServerConnectionConfigId']
+      if (this.libraryItem.serverConnectionConfigId && currentConfigId === this.libraryItem.serverConnectionConfigId) {
+        return this.libraryItem.libraryItemId
+      }
+      if (this.libraryItem.serverAddress && this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress) {
         return this.libraryItem.libraryItemId
       }
       return null

--- a/components/readers/PdfReader.vue
+++ b/components/readers/PdfReader.vue
@@ -67,8 +67,12 @@ export default {
     serverLibraryItemId() {
       if (!this.isLocal) return this.libraryItem.id
       // Check if local library item is connected to the current server
-      if (!this.libraryItem.serverAddress || !this.libraryItem.libraryItemId) return null
-      if (this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress) {
+      if (!this.libraryItem.libraryItemId) return null
+      const currentConfigId = this.$store.getters['user/getServerConnectionConfigId']
+      if (this.libraryItem.serverConnectionConfigId && currentConfigId === this.libraryItem.serverConnectionConfigId) {
+        return this.libraryItem.libraryItemId
+      }
+      if (this.libraryItem.serverAddress && this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress) {
         return this.libraryItem.libraryItemId
       }
       return null

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -12,7 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
 
         let configuration = Realm.Configuration(
-            schemaVersion: 20,
+            schemaVersion: 21,
             migrationBlock: { [weak self] migration, oldSchemaVersion in
                 if (oldSchemaVersion < 1) {
                     AbsLogger.info(message: "Realm schema version was \(oldSchemaVersion)")
@@ -71,6 +71,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                         newObject?["version"] = ""
                     }
                 }
+                if (oldSchemaVersion < 21) {
+                    AbsLogger.info(message: "Realm schema version was \(oldSchemaVersion)... Adding local address settings to ServerConnectionConfigs")
+                    migration.enumerateObjects(ofType: ServerConnectionConfig.className()) { oldObject, newObject in
+                        newObject?["localAddress"] = nil
+                    }
+                }
             }
         )
         Realm.Configuration.defaultConfiguration = configuration
@@ -125,4 +131,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
 }
-

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -69,6 +69,8 @@ public class AbsDatabase: CAPPlugin, CAPBridgedPlugin {
         let username = call.getString("username", "")
         let token = call.getString("token", "")
         let refreshToken = call.getString("refreshToken", "") // Refresh only sent after login or refresh
+        let localAddress = call.getString("localAddress")
+        let localSsidWhitelist = call.getArray("localSsidWhitelist", String.self) ?? []
 
         let name = "\(address) (\(username))"
         
@@ -91,6 +93,8 @@ public class AbsDatabase: CAPPlugin, CAPBridgedPlugin {
         config.userId = userId
         config.username = username
         config.token = token
+        config.localAddress = localAddress
+        config.localSsidWhitelist.append(objectsIn: localSsidWhitelist)
 
         Store.serverConfig = config
         let savedConfig = Store.serverConfig // Fetch the latest value

--- a/ios/App/App/plugins/AbsDownloader.swift
+++ b/ios/App/App/plugins/AbsDownloader.swift
@@ -449,7 +449,7 @@ public class AbsDownloader: CAPPlugin, CAPBridgedPlugin, URLSessionDownloadDeleg
             audioFileIno = matchingAudioFile?.ino ?? ""
         }
 
-        let urlstr = "\(Store.serverConfig!.address)/api/items/\(item.id)/file/\(audioFileIno)/download?token=\(Store.serverConfig!.token)"
+        let urlstr = "\(Store.serverConfig!.resolvedAddress)/api/items/\(item.id)/file/\(audioFileIno)/download?token=\(Store.serverConfig!.token)"
         return URL(string: urlstr)!
     }
     

--- a/ios/App/App/plugins/AbsNetwork.swift
+++ b/ios/App/App/plugins/AbsNetwork.swift
@@ -1,0 +1,31 @@
+//
+//  AbsNetwork.swift
+//  App
+//
+
+import Foundation
+import Capacitor
+import NetworkExtension
+
+@objc(AbsNetwork)
+public class AbsNetwork: CAPPlugin, CAPBridgedPlugin {
+    public var identifier = "AbsNetworkPlugin"
+    public var jsName = "AbsNetwork"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getCurrentWifiSsid", returnType: CAPPluginReturnPromise)
+    ]
+
+    @objc func getCurrentWifiSsid(_ call: CAPPluginCall) {
+        if #available(iOS 14.0, *) {
+            NEHotspotNetwork.fetchCurrent { network in
+                call.resolve([
+                    "ssid": network?.ssid ?? NSNull()
+                ])
+            }
+        } else {
+            call.resolve([
+                "ssid": NSNull()
+            ])
+        }
+    }
+}

--- a/ios/App/Shared/models/ServerConnectionConfig.swift
+++ b/ios/App/Shared/models/ServerConnectionConfig.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RealmSwift
+import SystemConfiguration.CaptiveNetwork
 
 class ServerConnectionConfig: Object {
     @Persisted(primaryKey: true) var id: String = UUID().uuidString
@@ -17,6 +18,32 @@ class ServerConnectionConfig: Object {
     @Persisted var userId: String = ""
     @Persisted var username: String = ""
     @Persisted var token: String = ""
+    @Persisted var localAddress: String?
+    @Persisted var localSsidWhitelist = List<String>()
+
+    var resolvedAddress: String {
+        guard let localAddress = localAddress, !localAddress.isEmpty, !localSsidWhitelist.isEmpty else {
+            return address
+        }
+        guard let currentSsid = Self.currentWifiSsid(), localSsidWhitelist.contains(currentSsid) else {
+            return address
+        }
+        return localAddress
+    }
+
+    static func currentWifiSsid() -> String? {
+        guard let interfaces = CNCopySupportedInterfaces() as? [String] else {
+            return nil
+        }
+        for interface in interfaces {
+            guard let info = CNCopyCurrentNetworkInfo(interface as CFString) as? [String: AnyObject],
+                  let ssid = info[kCNNetworkInfoKeySSID as String] as? String else {
+                continue
+            }
+            return ssid
+        }
+        return nil
+    }
 }
 
 class ServerConnectionConfigActiveIndex: Object {
@@ -34,5 +61,7 @@ func convertServerConnectionConfigToJSON(config: ServerConnectionConfig) -> Dict
         "userId": config.userId,
         "username": config.username,
         "token": config.token,
+        "localAddress": config.localAddress ?? NSNull(),
+        "localSsidWhitelist": Array(config.localSsidWhitelist),
     ]
 }

--- a/ios/App/Shared/models/download/DownloadItemPart.swift
+++ b/ios/App/Shared/models/download/DownloadItemPart.swift
@@ -78,7 +78,7 @@ extension DownloadItemPart {
         self.ebookFile = EBookFile.detachCopy(of: ebookFile)
         
         let config = Store.serverConfig!
-        var downloadUrl = "\(config.address)\(serverPath)?token=\(config.token)"
+        var downloadUrl = "\(config.resolvedAddress)\(serverPath)?token=\(config.token)"
         if (serverPath.hasSuffix("/cover")) {
             downloadUrl += "&format=jpeg" // For cover images force to jpeg
         }

--- a/ios/App/Shared/player/AudioPlayer.swift
+++ b/ios/App/Shared/player/AudioPlayer.swift
@@ -563,9 +563,9 @@ class AudioPlayer: NSObject {
             // See: https://github.com/advplyr/audiobookshelf/pull/4263
             let contentUrl: String
             if Store.isServerVersionGreaterThanOrEqualTo("2.22.0") {
-                contentUrl = "\(Store.serverConfig!.address)/public/session/\(playbackSession.id)/track/\(track.index ?? 1)"
+                contentUrl = "\(Store.serverConfig!.resolvedAddress)/public/session/\(playbackSession.id)/track/\(track.index ?? 1)"
             } else {
-                contentUrl = "\(Store.serverConfig!.address)/api/items/\(itemId)/file/\(ino)?token=\(Store.serverConfig!.token)"
+                contentUrl = "\(Store.serverConfig!.resolvedAddress)/api/items/\(itemId)/file/\(ino)?token=\(Store.serverConfig!.token)"
             }
             let url = URL(string: contentUrl)!
             return AVURLAsset(url: url)
@@ -573,7 +573,7 @@ class AudioPlayer: NSObject {
             guard let localFile = track.getLocalFile() else {
                 // Worst case we can stream the file
                 AbsLogger.info(message:"Unable to play local file. Resulting to streaming \(track.localFileId ?? "Unknown")")
-                let urlstr = "\(Store.serverConfig!.address)/api/items/\(itemId)/file/\(ino)?token=\(Store.serverConfig!.token)"
+                let urlstr = "\(Store.serverConfig!.resolvedAddress)/api/items/\(itemId)/file/\(ino)?token=\(Store.serverConfig!.token)"
                 let url = URL(string: urlstr)!
                 return AVURLAsset(url: url)
             }
@@ -583,7 +583,7 @@ class AudioPlayer: NSObject {
                 "Authorization": "Bearer \(Store.serverConfig!.token)"
             ]
             
-            let contentUrl = "\(Store.serverConfig!.address)\(track.contentUrl ?? "")"
+            let contentUrl = "\(Store.serverConfig!.resolvedAddress)\(track.contentUrl ?? "")"
             return AVURLAsset(url: URL(string: contentUrl)!, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
         }
     }

--- a/ios/App/Shared/util/ApiClient.swift
+++ b/ios/App/Shared/util/ApiClient.swift
@@ -29,7 +29,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers).responseDecodable(of: decodable) { response in
+        AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers).responseDecodable(of: decodable) { response in
             switch response.result {
             case .success(let obj):
                 callback?(obj)
@@ -50,7 +50,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers).responseDecodable(of: decodable) { response in
+        AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers).responseDecodable(of: decodable) { response in
             switch response.result {
             case .success(let obj):
                 callback?(obj)
@@ -80,7 +80,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers).response { response in
+        AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers).response { response in
             switch response.result {
             case .success(_):
                 callback?(true)
@@ -104,7 +104,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .patch, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers).response { response in
+        AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .patch, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers).response { response in
             switch response.result {
             case .success(_):
                 callback?(true)
@@ -135,7 +135,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .get, encoding: JSONEncoding.default, headers: headers).responseDecodable(of: decodable) { response in
+        AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .get, encoding: JSONEncoding.default, headers: headers).responseDecodable(of: decodable) { response in
             switch response.result {
                 case .success(let obj):
                     callback?(obj)
@@ -182,7 +182,7 @@ class ApiClient {
             "Content-Type": "application/json"
         ]
         
-        let refreshRequest = AF.request("\(serverConfig.address)/auth/refresh", method: .post, headers: refreshHeaders)
+        let refreshRequest = AF.request("\(serverConfig.resolvedAddress)/auth/refresh", method: .post, headers: refreshHeaders)
         
         refreshRequest.responseDecodable(of: RefreshResponse.self) { response in
             switch response.result {
@@ -253,20 +253,20 @@ class ApiClient {
         
         switch method {
         case .get:
-            retryRequest = AF.request("\(serverConfig.address)/\(endpoint)", method: .get, headers: headers)
+            retryRequest = AF.request("\(serverConfig.resolvedAddress)/\(endpoint)", method: .get, headers: headers)
         case .post:
             if let parameters = parameters as? [String: Any] {
-                retryRequest = AF.request("\(serverConfig.address)/\(endpoint)", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
+                retryRequest = AF.request("\(serverConfig.resolvedAddress)/\(endpoint)", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
             } else if let encodableParams = parameters as? Encodable {
-                retryRequest = AF.request("\(serverConfig.address)/\(endpoint)", method: .post, parameters: encodableParams, encoder: JSONParameterEncoder.default, headers: headers)
+                retryRequest = AF.request("\(serverConfig.resolvedAddress)/\(endpoint)", method: .post, parameters: encodableParams, encoder: JSONParameterEncoder.default, headers: headers)
             } else {
-                retryRequest = AF.request("\(serverConfig.address)/\(endpoint)", method: .post, headers: headers)
+                retryRequest = AF.request("\(serverConfig.resolvedAddress)/\(endpoint)", method: .post, headers: headers)
             }
         case .patch:
             if let encodableParams = parameters as? Encodable {
-                retryRequest = AF.request("\(serverConfig.address)/\(endpoint)", method: .patch, parameters: encodableParams, encoder: JSONParameterEncoder.default, headers: headers)
+                retryRequest = AF.request("\(serverConfig.resolvedAddress)/\(endpoint)", method: .patch, parameters: encodableParams, encoder: JSONParameterEncoder.default, headers: headers)
             } else {
-                retryRequest = AF.request("\(serverConfig.address)/\(endpoint)", method: .patch, headers: headers)
+                retryRequest = AF.request("\(serverConfig.resolvedAddress)/\(endpoint)", method: .patch, headers: headers)
             }
         default:
             AbsLogger.error(message: "retryOriginalRequest: Unsupported method \(method)")
@@ -340,7 +340,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        let request = AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .get, headers: headers)
+        let request = AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .get, headers: headers)
         
         request.responseDecodable(of: decodable) { response in
             if let statusCode = response.response?.statusCode, statusCode == 401 {
@@ -370,7 +370,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        let request = AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
+        let request = AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
         
         request.responseDecodable(of: decodable) { response in
             if let statusCode = response.response?.statusCode, statusCode == 401 {
@@ -403,7 +403,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        let request = AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
+        let request = AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .post, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
         
         request.response { response in
             if let statusCode = response.response?.statusCode, statusCode == 401 {
@@ -435,7 +435,7 @@ class ApiClient {
             "Authorization": "Bearer \(Store.serverConfig!.token)"
         ]
         
-        let request = AF.request("\(Store.serverConfig!.address)/\(endpoint)", method: .patch, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
+        let request = AF.request("\(Store.serverConfig!.resolvedAddress)/\(endpoint)", method: .patch, parameters: parameters, encoder: JSONParameterEncoder.default, headers: headers)
         
         request.response { response in
             if let statusCode = response.response?.statusCode, statusCode == 401 {
@@ -495,7 +495,7 @@ class ApiClient {
             
             // Set server connection info on the session
             session.serverConnectionConfigId = Store.serverConfig!.id
-            session.serverAddress = Store.serverConfig!.address
+            session.serverAddress = Store.serverConfig!.resolvedAddress
             
             callback(session)
         }
@@ -631,7 +631,7 @@ class ApiClient {
     
     public static func pingServer() async -> Bool {
         var status = true
-        AF.request("\(Store.serverConfig!.address)/ping", method: .get).responseDecodable(of: PingResponsePayload.self) { response in
+        AF.request("\(Store.serverConfig!.resolvedAddress)/ping", method: .get).responseDecodable(of: PingResponsePayload.self) { response in
             switch response.result {
                 case .success:
                     status = true

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -78,6 +78,18 @@ export default {
           this.socketDisconnectedTime = Date.now()
         }
       }
+    },
+    activeServerAddress: {
+      async handler(newVal, oldVal) {
+        if (!this.hasMounted || !newVal || newVal === oldVal) return
+        await this.ensureSocketConnectedToActiveServer()
+      }
+    },
+    networkStatusChangeId: {
+      async handler() {
+        if (!this.hasMounted) return
+        await this.refreshActiveServerAddress()
+      }
     }
   },
   computed: {
@@ -92,6 +104,15 @@ export default {
     },
     socketConnected() {
       return this.$store.state.socketConnected
+    },
+    networkStatusChangeId() {
+      return this.$store.state.networkStatusChangeId
+    },
+    activeServerAddress() {
+      return this.$store.getters['user/getActiveServerAddress']
+    },
+    serverConnectionConfig() {
+      return this.$store.state.user.serverConnectionConfig
     },
     user() {
       return this.$store.state.user.user
@@ -207,11 +228,22 @@ export default {
       this.$store.commit('user/setAccessToken', serverConnectionConfig.token)
       this.$store.commit('user/setServerConnectionConfig', serverConnectionConfig)
 
-      this.$socket.connect(serverConnectionConfig.address, serverConnectionConfig.token)
+      const activeServerAddress = await this.$serverAddress.resolve(serverConnectionConfig, { forceRefresh: true })
+      this.$socket.connect(activeServerAddress || serverConnectionConfig.address, serverConnectionConfig.token)
 
       AbsLogger.info({ tag: 'default', message: `attemptConnection: Successful connection to last saved server config (${serverConnectionConfig.name})` })
       await this.initLibraries()
       this.attemptingConnection = false
+    },
+    async refreshActiveServerAddress() {
+      if (!this.user || !this.serverConnectionConfig || !this.networkConnected) return
+      const activeServerAddress = await this.$serverAddress.resolve(this.serverConnectionConfig, { forceRefresh: true })
+      await this.ensureSocketConnectedToActiveServer(activeServerAddress)
+    },
+    async ensureSocketConnectedToActiveServer(activeServerAddress = this.activeServerAddress) {
+      if (!this.user || !this.serverConnectionConfig || !activeServerAddress) return
+      if (this.$socket.isConnectedTo(activeServerAddress)) return
+      this.$socket.connect(activeServerAddress, this.serverConnectionConfig.token)
     },
     itemRemoved(libraryItem) {
       if (this.$route.name.startsWith('item')) {
@@ -327,6 +359,7 @@ export default {
       if (document.visibilityState === 'visible') {
         const elapsedTimeOutOfFocus = Date.now() - this.timeLostFocus
         console.log(`✅ [default] device visibility: has focus (${elapsedTimeOutOfFocus}ms out of focus)`)
+        await this.refreshActiveServerAddress()
         // If device out of focus for more than 30s then reload local media progress
         if (elapsedTimeOutOfFocus > 30000) {
           console.log(`✅ [default] device visibility: reloading local media progress`)

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,7 +30,7 @@ export default {
 
   css: ['@/assets/tailwind.css', '@/assets/app.css'],
 
-  plugins: ['@/plugins/server.js', '@/plugins/db.js', '@/plugins/localStore.js', '@/plugins/init.client.js', '@/plugins/axios.js', '@/plugins/capacitor/index.js', '@/plugins/capacitor/AbsAudioPlayer.js', '@/plugins/nativeHttp.js', '@/plugins/toast.js', '@/plugins/constants.js', '@/plugins/haptics.js', '@/plugins/i18n.js'],
+  plugins: ['@/plugins/server.js', '@/plugins/db.js', '@/plugins/localStore.js', '@/plugins/init.client.js', '@/plugins/capacitor/index.js', '@/plugins/serverAddress.js', '@/plugins/axios.js', '@/plugins/capacitor/AbsAudioPlayer.js', '@/plugins/nativeHttp.js', '@/plugins/toast.js', '@/plugins/constants.js', '@/plugins/haptics.js', '@/plugins/i18n.js'],
 
   components: true,
 

--- a/pages/account.vue
+++ b/pages/account.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full p-4">
+  <div class="w-full h-full p-4 overflow-y-auto">
     <ui-text-input-with-label :value="serverAddress" :label="$strings.LabelHost" disabled class="my-2" />
 
     <ui-text-input-with-label :value="username" :label="$strings.LabelUsername" disabled class="my-2" />
@@ -8,9 +8,27 @@
       <p>Server version: v{{ serverVersion }}</p>
     </div>
 
+    <div class="mt-8">
+      <p class="uppercase text-xs font-semibold text-fg-muted mb-2">Local Connection</p>
+      <div class="my-2">
+        <p class="text-sm text-fg-muted mb-1">Local network address</p>
+        <ui-text-input v-model="localAddress" placeholder="http://192.168.1.20:13378" type="url" class="w-full h-10" />
+      </div>
+      <div class="my-4">
+        <div class="flex items-center justify-between mb-1 gap-2">
+          <p class="text-sm text-fg-muted">Local Wi-Fi SSIDs</p>
+          <ui-btn type="button" :disabled="processing" :padding-x="2" :padding-y="1" class="text-xs" @click="addCurrentWifiSsid">Use current Wi-Fi</ui-btn>
+        </div>
+        <textarea v-model="localSsidText" placeholder="Home WiFi&#10;Office WiFi" class="w-full min-h-[5rem] rounded bg-bg border border-fg/20 px-3 py-2 text-sm outline-none focus:border-fg/60"></textarea>
+      </div>
+      <div class="flex justify-end">
+        <ui-btn :disabled="processing || !hasLocalConnectionChanges" @click="saveLocalConnectionSettings">{{ processing ? 'Saving...' : $strings.ButtonSave }}</ui-btn>
+      </div>
+    </div>
+
     <ui-btn color="primary flex items-center justify-between gap-2 ml-auto text-base mt-8" @click="logout">{{ $strings.ButtonSwitchServerUser }}<span class="material-symbols" style="font-size: 1.1rem">logout</span></ui-btn>
 
-    <div class="flex justify-center items-center my-4 left-0 right-0 bottom-0 absolute">
+    <div class="flex justify-center items-center my-4 left-0 right-0">
       <p class="text-sm text-fg">{{ $strings.MessageReportBugsAndContribute }} <a class="underline" href="https://github.com/advplyr/audiobookshelf-app" target="_blank">GitHub</a></p>
       <a href="https://github.com/advplyr/audiobookshelf-app" target="_blank" class="text-fg hover:scale-150 hover:rotate-6 transform duration-500 ml-2">
         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="24" height="24" viewBox="0 0 24 24">
@@ -32,7 +50,11 @@ export default {
     return {}
   },
   data() {
-    return {}
+    return {
+      processing: false,
+      localAddress: null,
+      localSsidText: ''
+    }
   },
   computed: {
     username() {
@@ -51,15 +73,82 @@ export default {
     serverVersion() {
       // Saved in server connection config after 0.9.81
       return this.serverConnectionConfig.version
+    },
+    normalizedLocalAddress() {
+      return this.$serverAddress.normalizeAddress(this.localAddress) || null
+    },
+    localSsidWhitelist() {
+      return this.localSsidText
+        .split('\n')
+        .map((ssid) => ssid.trim())
+        .filter(Boolean)
+    },
+    hasLocalConnectionChanges() {
+      const savedLocalAddress = this.serverConnectionConfig.localAddress || null
+      const savedSsids = this.serverConnectionConfig.localSsidWhitelist || []
+      return this.normalizedLocalAddress !== savedLocalAddress || JSON.stringify(this.localSsidWhitelist) !== JSON.stringify(savedSsids)
     }
   },
   methods: {
+    loadLocalConnectionSettings() {
+      this.localAddress = this.serverConnectionConfig.localAddress || ''
+      this.localSsidText = (this.serverConnectionConfig.localSsidWhitelist || []).join('\n')
+    },
+    async addCurrentWifiSsid() {
+      const ssid = await this.$serverAddress.getCurrentWifiSsid()
+      if (!ssid) {
+        this.$toast.error('Current Wi-Fi SSID is unavailable')
+        return
+      }
+
+      const ssids = [...this.localSsidWhitelist]
+      if (!ssids.includes(ssid)) {
+        ssids.push(ssid)
+      }
+      this.localSsidText = ssids.join('\n')
+    },
+    async saveLocalConnectionSettings() {
+      if (!this.serverConnectionConfig.id) return
+      this.processing = true
+      try {
+        const updatedConfig = {
+          ...this.serverConnectionConfig,
+          localAddress: this.normalizedLocalAddress,
+          localSsidWhitelist: this.localSsidWhitelist
+        }
+        const savedConfig = await this.$db.setServerConnectionConfig(updatedConfig)
+        this.$store.commit('user/setServerConnectionConfig', savedConfig)
+        this.$store.commit('setActiveServerAddress', null)
+
+        const deviceData = this.$store.state.deviceData
+        if (deviceData?.serverConnectionConfigs) {
+          const updatedDeviceData = {
+            ...deviceData,
+            serverConnectionConfigs: deviceData.serverConnectionConfigs.map((config) => (config.id === savedConfig.id ? savedConfig : config))
+          }
+          this.$store.commit('setDeviceData', updatedDeviceData)
+        }
+
+        const activeServerAddress = await this.$serverAddress.resolve(savedConfig, { forceRefresh: true })
+        this.$socket.logout()
+        this.$socket.connect(activeServerAddress || savedConfig.address, savedConfig.token)
+        this.loadLocalConnectionSettings()
+        this.$toast.success('Local connection settings saved')
+      } catch (error) {
+        console.error('Failed to save local connection settings', error)
+        this.$toast.error('Failed to save local connection settings')
+      } finally {
+        this.processing = false
+      }
+    },
     async logout() {
       await this.$hapticsImpact()
       await this.$store.dispatch('user/logout')
       this.$router.push('/connect')
     }
   },
-  mounted() {}
+  mounted() {
+    this.loadLocalConnectionSettings()
+  }
 }
 </script>

--- a/pages/item/_id/_episode/index.vue
+++ b/pages/item/_id/_episode/index.vue
@@ -148,6 +148,8 @@ export default {
     },
     isConnectedToServer() {
       if (!this.isLocal) return true
+      const currentConfigId = this.$store.getters['user/getServerConnectionConfigId']
+      if (this.libraryItem.serverConnectionConfigId && currentConfigId === this.libraryItem.serverConnectionConfigId) return true
       if (!this.libraryItem.serverAddress) return false
       return this.$store.getters['user/getServerAddress'] === this.libraryItem.serverAddress
     },

--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -190,7 +190,7 @@ export default {
       if (libraryItem?.libraryItemId?.startsWith('li_')) {
         // Detect old library item id
         console.error('Local library item has old server library item id', libraryItem.libraryItemId)
-      } else if (query.noredirect !== '1' && libraryItem?.libraryItemId && libraryItem?.serverAddress === store.getters['user/getServerAddress'] && store.state.socketConnected) {
+      } else if (query.noredirect !== '1' && libraryItem?.libraryItemId && ((libraryItem?.serverConnectionConfigId && libraryItem.serverConnectionConfigId === store.getters['user/getServerConnectionConfigId']) || libraryItem?.serverAddress === store.getters['user/getServerAddress']) && store.state.socketConnected) {
         const queryParams = new URLSearchParams()
         queryParams.set('localLibraryItemId', libraryItemId)
         if (libraryItem.mediaType === 'podcast') {
@@ -257,8 +257,11 @@ export default {
     serverLibraryItemId() {
       if (!this.isLocal) return this.libraryItem.id
       // Check if local library item is connected to the current server
-      if (!this.libraryItem.serverAddress || !this.libraryItem.libraryItemId) return null
-      if (this.currentServerAddress === this.libraryItem.serverAddress) {
+      if (!this.libraryItem.libraryItemId) return null
+      if (this.libraryItem.serverConnectionConfigId && this.currentServerConnectionConfigId === this.libraryItem.serverConnectionConfigId) {
+        return this.libraryItem.libraryItemId
+      }
+      if (this.libraryItem.serverAddress && this.currentServerAddress === this.libraryItem.serverAddress) {
         return this.libraryItem.libraryItemId
       }
       return null
@@ -276,7 +279,9 @@ export default {
      * User is currently connected to a server and this local library item has the same server address
      */
     isLocalMatchingServerAddress() {
-      if (!this.localLibraryItem || !this.currentServerAddress) return false
+      if (!this.localLibraryItem) return false
+      if (this.localLibraryItem.serverConnectionConfigId && this.currentServerConnectionConfigId === this.localLibraryItem.serverConnectionConfigId) return true
+      if (!this.currentServerAddress) return false
       return this.localLibraryItem.serverAddress === this.currentServerAddress
     },
     /**

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -1,4 +1,4 @@
-export default function ({ $axios, store, $db }) {
+export default function ({ $axios, store, $db, $serverAddress }) {
   // Track if we're currently refreshing to prevent multiple refresh attempts
   let isRefreshing = false
   let failedQueue = []
@@ -39,7 +39,7 @@ export default function ({ $axios, store, $db }) {
     }
   }
 
-  $axios.onRequest((config) => {
+  $axios.onRequest(async (config) => {
     console.log('[Axios] Making request to ' + config.url)
     if (config.url.startsWith('http:') || config.url.startsWith('https:') || config.url.startsWith('capacitor:')) {
       return
@@ -52,7 +52,7 @@ export default function ({ $axios, store, $db }) {
       console.warn('[Axios] No Bearer Token for request')
     }
 
-    const serverUrl = store.getters['user/getServerAddress']
+    const serverUrl = await $serverAddress.resolve()
     if (serverUrl) {
       config.url = `${serverUrl}${config.url}`
     }

--- a/plugins/capacitor/AbsDatabase.js
+++ b/plugins/capacitor/AbsDatabase.js
@@ -10,6 +10,8 @@ import { registerPlugin, Capacitor, WebPlugin } from '@capacitor/core'
  * @property {string} userId
  * @property {string} username
  * @property {string} token
+ * @property {string} [localAddress]
+ * @property {string[]} [localSsidWhitelist]
  * @property {string} [refreshToken] - Only passed in when setting config, then stored in secure storage
  */
 
@@ -49,6 +51,8 @@ class AbsDatabaseWeb extends WebPlugin {
       ssc.username = serverConnectionConfig.username
       ssc.version = serverConnectionConfig.version
       ssc.customHeaders = serverConnectionConfig.customHeaders || {}
+      ssc.localAddress = serverConnectionConfig.localAddress || null
+      ssc.localSsidWhitelist = serverConnectionConfig.localSsidWhitelist || []
 
       if (serverConnectionConfig.refreshToken) {
         console.log('[AbsDatabase] Updating refresh token...')
@@ -67,7 +71,9 @@ class AbsDatabaseWeb extends WebPlugin {
         address: serverConnectionConfig.address,
         token: serverConnectionConfig.token,
         version: serverConnectionConfig.version,
-        customHeaders: serverConnectionConfig.customHeaders || {}
+        customHeaders: serverConnectionConfig.customHeaders || {},
+        localAddress: serverConnectionConfig.localAddress || null,
+        localSsidWhitelist: serverConnectionConfig.localSsidWhitelist || []
       }
 
       if (serverConnectionConfig.refreshToken) {

--- a/plugins/capacitor/AbsNetwork.js
+++ b/plugins/capacitor/AbsNetwork.js
@@ -1,0 +1,13 @@
+import { registerPlugin, WebPlugin } from '@capacitor/core'
+
+class AbsNetworkWeb extends WebPlugin {
+  async getCurrentWifiSsid() {
+    return { ssid: null }
+  }
+}
+
+const AbsNetwork = registerPlugin('AbsNetwork', {
+  web: () => new AbsNetworkWeb()
+})
+
+export { AbsNetwork }

--- a/plugins/capacitor/index.js
+++ b/plugins/capacitor/index.js
@@ -4,8 +4,9 @@ import { AbsDownloader } from './AbsDownloader'
 import { AbsFileSystem } from './AbsFileSystem'
 import { AbsDatabase } from './AbsDatabase'
 import { AbsLogger } from './AbsLogger'
+import { AbsNetwork } from './AbsNetwork'
 import { Capacitor } from '@capacitor/core'
 
 Vue.prototype.$platform = Capacitor.getPlatform()
 
-export { AbsAudioPlayer, AbsDownloader, AbsFileSystem, AbsLogger, AbsDatabase }
+export { AbsAudioPlayer, AbsDownloader, AbsFileSystem, AbsLogger, AbsDatabase, AbsNetwork }

--- a/plugins/nativeHttp.js
+++ b/plugins/nativeHttp.js
@@ -1,6 +1,6 @@
 import { CapacitorHttp } from '@capacitor/core'
 
-export default function ({ store, $db, $socket }, inject) {
+export default function ({ store, $db, $socket, $serverAddress }, inject) {
   const nativeHttp = {
     async request(method, _url, data, options = {}) {
       // When authorizing before a config is set, server config gets passed in as an option
@@ -16,8 +16,9 @@ export default function ({ store, $db, $socket }, inject) {
         } else {
           console.warn('[nativeHttp] No Bearer Token for request')
         }
-        if (serverConnectionConfig?.address) {
-          url = `${serverConnectionConfig.address}${url}`
+        const activeServerAddress = await $serverAddress.resolve(serverConnectionConfig)
+        if (activeServerAddress) {
+          url = `${activeServerAddress}${url}`
         }
       }
       if (data) {
@@ -77,7 +78,8 @@ export default function ({ store, $db, $socket }, inject) {
         }
 
         // Attempt to refresh the token
-        const newTokens = await this.refreshAccessToken(refreshToken, serverConnectionConfig.address)
+        const refreshAddress = await $serverAddress.resolve(serverConnectionConfig, { forceRefresh: true })
+        const newTokens = await this.refreshAccessToken(refreshToken, refreshAddress)
         if (!newTokens?.accessToken) {
           console.error('[nativeHttp] Failed to refresh access token')
           throw new Error('Failed to refresh access token')

--- a/plugins/server.js
+++ b/plugins/server.js
@@ -14,6 +14,15 @@ class ServerSocket extends EventEmitter {
     this.lastReconnectAttemptTime = 0
   }
 
+  normalizeAddress(address) {
+    if (!address) return null
+    try {
+      return new URL(address).href.replace(/\/$/, '')
+    } catch (error) {
+      return address
+    }
+  }
+
   $on(evt, callback) {
     if (this.socket) this.socket.on(evt, callback)
     else console.error('$on Socket not initialized')
@@ -25,9 +34,21 @@ class ServerSocket extends EventEmitter {
   }
 
   connect(serverAddress, token) {
-    this.serverAddress = serverAddress
+    const normalizedServerAddress = this.normalizeAddress(serverAddress)
+    if (this.socket && this.normalizeAddress(this.serverAddress) === normalizedServerAddress) {
+      if (this.connected && !this.isAuthenticated) {
+        this.sendAuthenticate()
+      }
+      return
+    }
 
-    const serverUrl = new URL(serverAddress)
+    this.closeCurrentSocket()
+    this.serverAddress = normalizedServerAddress
+    this.connected = false
+    this.isAuthenticated = false
+    this.$store.commit('setSocketConnected', false)
+
+    const serverUrl = new URL(normalizedServerAddress)
     const serverHost = `${serverUrl.protocol}//${serverUrl.host}`
     const serverPath = serverUrl.pathname === '/' ? '' : serverUrl.pathname
 
@@ -40,92 +61,120 @@ class ServerSocket extends EventEmitter {
       reconnectionDelayMax: 15000
     }
     this.socket = io(serverHost, socketOptions)
-    this.setSocketListeners()
+    this.setSocketListeners(this.socket)
   }
 
   logout() {
-    if (this.socket) this.socket.disconnect()
-    this.removeListeners()
+    this.closeCurrentSocket()
+    this.serverAddress = null
   }
 
-  setSocketListeners() {
-    this.socket.on('connect', this.onConnect.bind(this))
-    this.socket.on('disconnect', this.onDisconnect.bind(this))
-    this.socket.on('init', this.onInit.bind(this))
-    this.socket.on('auth_failed', this.onAuthFailed.bind(this))
-    this.socket.on('user_updated', this.onUserUpdated.bind(this))
-    this.socket.on('user_item_progress_updated', this.onUserItemProgressUpdated.bind(this))
-    this.socket.on('playlist_added', this.onPlaylistAdded.bind(this))
-    this.socket.io.on('reconnect_attempt', this.onReconnectAttempt.bind(this))
-    this.socket.io.on('reconnect_error', this.onReconnectError.bind(this))
-    this.socket.io.on('reconnect_failed', this.onReconnectFailed.bind(this))
+  isConnectedTo(serverAddress) {
+    return this.connected && this.normalizeAddress(this.serverAddress) === this.normalizeAddress(serverAddress)
+  }
+
+  setSocketListeners(socket) {
+    socket.on('connect', () => this.onConnect(socket))
+    socket.on('disconnect', (reason) => this.onDisconnect(socket, reason))
+    socket.on('init', (data) => this.onInit(socket, data))
+    socket.on('auth_failed', (data) => this.onAuthFailed(socket, data))
+    socket.on('user_updated', (data) => this.onUserUpdated(socket, data))
+    socket.on('user_item_progress_updated', (payload) => this.onUserItemProgressUpdated(socket, payload))
+    socket.on('playlist_added', () => this.onPlaylistAdded(socket))
+    socket.io.on('reconnect_attempt', (attemptNumber) => this.onReconnectAttempt(socket, attemptNumber))
+    socket.io.on('reconnect_error', (error) => this.onReconnectError(socket, error))
+    socket.io.on('reconnect_failed', (error) => this.onReconnectFailed(socket, error))
   }
 
   sendAuthenticate() {
     // Required to connect a socket to a user
+    if (!this.socket) return
     this.socket.emit('auth', this.$store.getters['user/getToken'])
   }
 
-  removeListeners() {
-    if (!this.socket) return
-    this.socket.removeAllListeners()
-    if (this.socket.io && this.socket.io.removeAllListeners) {
-      this.socket.io.removeAllListeners()
+  closeCurrentSocket() {
+    const socket = this.socket
+    if (!socket) return
+
+    socket.removeAllListeners()
+    if (socket.io && socket.io.removeAllListeners) {
+      socket.io.removeAllListeners()
     }
+    socket.disconnect()
+    this.socket = null
+    this.connected = false
+    this.isAuthenticated = false
+    this.$store.commit('setSocketConnected', false)
+    this.emit('connection-update', false)
   }
 
-  onConnect() {
-    console.log('[SOCKET] Socket Connected ' + this.socket.id)
+  isCurrentSocket(socket) {
+    return socket && socket === this.socket
+  }
+
+  onConnect(socket) {
+    if (!this.isCurrentSocket(socket)) return
+    console.log('[SOCKET] Socket Connected ' + socket.id)
     this.connected = true
     this.$store.commit('setSocketConnected', true)
     this.emit('connection-update', true)
     this.sendAuthenticate()
   }
 
-  onReconnectAttempt(attemptNumber) {
+  onReconnectAttempt(socket, attemptNumber) {
+    if (!this.isCurrentSocket(socket)) return
     const timeSinceLastReconnectAttempt = this.lastReconnectAttemptTime ? Date.now() - this.lastReconnectAttemptTime : 0
     this.lastReconnectAttemptTime = Date.now()
     console.log(`[SOCKET] Reconnect attempt ${attemptNumber} ${timeSinceLastReconnectAttempt > 0 ? `after ${timeSinceLastReconnectAttempt}ms` : ''}`)
   }
 
-  onReconnectError(error) {
+  onReconnectError(socket, error) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] Reconnect error', error)
   }
 
-  onReconnectFailed(error) {
+  onReconnectFailed(socket, error) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] Reconnect failed', error)
   }
 
-  onDisconnect(reason) {
+  onDisconnect(socket, reason) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] Socket Disconnected: ' + reason)
     this.connected = false
+    this.isAuthenticated = false
     this.$store.commit('setSocketConnected', false)
     this.emit('connection-update', false)
   }
 
-  onInit(data) {
+  onInit(socket, data) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] Initial socket data received', data)
     this.emit('initialized', true)
     this.isAuthenticated = true
   }
 
-  onAuthFailed(data) {
+  onAuthFailed(socket, data) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] Auth failed: ' + (data?.message || 'Unknown reason'))
     this.isAuthenticated = false
   }
 
-  onUserUpdated(data) {
+  onUserUpdated(socket, data) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] User updated', data)
     this.emit('user_updated', data)
   }
 
-  onUserItemProgressUpdated(payload) {
+  onUserItemProgressUpdated(socket, payload) {
+    if (!this.isCurrentSocket(socket)) return
     console.log('[SOCKET] User Item Progress Updated', JSON.stringify(payload))
     this.$store.commit('user/updateUserMediaProgress', payload.data)
     this.emit('user_media_progress_updated', payload)
   }
 
-  onPlaylistAdded() {
+  onPlaylistAdded(socket) {
+    if (!this.isCurrentSocket(socket)) return
     // Currently numUserPlaylists is only used for showing the playlist tab or not. Precise number is not necessary
     if (!this.$store.state.libraries.numUserPlaylists) {
       this.$store.commit('libraries/setNumUserPlaylists', 1)

--- a/plugins/serverAddress.js
+++ b/plugins/serverAddress.js
@@ -1,0 +1,96 @@
+import { CapacitorHttp } from '@capacitor/core'
+import { AbsNetwork } from '@/plugins/capacitor'
+
+const CACHE_TTL_MS = 30000
+
+function normalizeAddress(address) {
+  if (!address) return null
+  try {
+    return new URL(address).href.replace(/\/$/, '')
+  } catch (error) {
+    console.error('[serverAddress] Invalid address', address, error)
+    return null
+  }
+}
+
+function normalizeSsid(ssid) {
+  return (ssid || '').replace(/^"(.*)"$/, '$1').trim()
+}
+
+function getLocalSsids(config) {
+  if (!config) return []
+  if (Array.isArray(config.localSsidWhitelist)) return config.localSsidWhitelist
+  if (Array.isArray(config.localSsids)) return config.localSsids
+  return []
+}
+
+export default function ({ store }, inject) {
+  const cache = new Map()
+
+  const serverAddress = {
+    normalizeAddress,
+    async getCurrentWifiSsid() {
+      try {
+        const result = await AbsNetwork.getCurrentWifiSsid()
+        return normalizeSsid(result?.ssid)
+      } catch (error) {
+        console.warn('[serverAddress] Failed to get current Wi-Fi SSID', error)
+        return null
+      }
+    },
+    isSameServerConfig(configOrId, localServerConnectionConfigId) {
+      const configId = typeof configOrId === 'string' ? configOrId : configOrId?.id
+      return !!configId && !!localServerConnectionConfigId && configId === localServerConnectionConfigId
+    },
+    async canReach(address, customHeaders = {}, timeout = 2500) {
+      const normalizedAddress = normalizeAddress(address)
+      if (!normalizedAddress) return false
+      try {
+        const response = await CapacitorHttp.get({
+          url: `${normalizedAddress}/ping`,
+          headers: customHeaders || {},
+          connectTimeout: timeout,
+          readTimeout: timeout
+        })
+        return response.status === 200 && response.data?.success !== false
+      } catch (error) {
+        console.warn('[serverAddress] Ping failed', normalizedAddress, error?.message || error)
+        return false
+      }
+    },
+    async resolve(config = store.state.user.serverConnectionConfig, options = {}) {
+      const primaryAddress = normalizeAddress(config?.address)
+      const localAddress = normalizeAddress(config?.localAddress)
+      if (!primaryAddress) return null
+
+      if (!localAddress) {
+        store.commit('setActiveServerAddress', primaryAddress)
+        return primaryAddress
+      }
+
+      const currentSsid = await this.getCurrentWifiSsid()
+      const allowedSsids = getLocalSsids(config).map(normalizeSsid).filter(Boolean)
+      const ssidAllowed = !!currentSsid && allowedSsids.includes(currentSsid)
+
+      if (!ssidAllowed) {
+        store.commit('setActiveServerAddress', primaryAddress)
+        return primaryAddress
+      }
+
+      const cacheKey = `${config.id || primaryAddress}|${currentSsid}|${localAddress}`
+      const cached = cache.get(cacheKey)
+      if (!options.forceRefresh && cached && Date.now() - cached.time < CACHE_TTL_MS) {
+        store.commit('setActiveServerAddress', cached.address)
+        return cached.address
+      }
+
+      const canUseLocal = options.skipPing || (await this.canReach(localAddress, config.customHeaders))
+      const resolvedAddress = canUseLocal ? localAddress : primaryAddress
+      cache.set(cacheKey, { address: resolvedAddress, time: Date.now() })
+      store.commit('setActiveServerAddress', resolvedAddress)
+      return resolvedAddress
+    }
+  }
+
+  inject('serverAddress', serverAddress)
+}

--- a/store/index.js
+++ b/store/index.js
@@ -15,7 +15,9 @@ export const state = () => ({
   socketConnected: false,
   networkConnected: false,
   networkConnectionType: null,
+  networkStatusChangeId: 0,
   isNetworkUnmetered: true,
+  activeServerAddress: null,
   isFirstLoad: true,
   isFirstAudioLoad: true,
   hasStoragePermission: false,
@@ -190,9 +192,16 @@ export const mutations = {
       state.networkConnected = true
     }
     state.networkConnectionType = val.connectionType
+    state.networkStatusChangeId += 1
   },
   setIsNetworkUnmetered(state, val) {
     state.isNetworkUnmetered = val
+  },
+  setActiveServerAddress(state, val) {
+    if (state.activeServerAddress && val && state.activeServerAddress !== val) {
+      state.socketConnected = false
+    }
+    state.activeServerAddress = val
   },
   showReader(state, { libraryItem, keepProgress, fileId }) {
     state.selectedLibraryItem = libraryItem

--- a/store/user.js
+++ b/store/user.js
@@ -31,6 +31,9 @@ export const getters = {
   getServerAddress: (state) => {
     return state.serverConnectionConfig?.address || null
   },
+  getActiveServerAddress: (state, getters, rootState) => {
+    return rootState.activeServerAddress || state.serverConnectionConfig?.address || null
+  },
   getServerConfigName: (state) => {
     return state.serverConnectionConfig?.name || null
   },
@@ -127,7 +130,7 @@ export const actions = {
     }
   },
   async openWebClient({ getters }, path = null) {
-    const serverAddress = getters.getServerAddress
+    const serverAddress = await this.$serverAddress.resolve(state.serverConnectionConfig)
     if (!serverAddress) {
       console.error('openWebClient: No server address')
       return
@@ -164,6 +167,7 @@ export const actions = {
     this.$socket.logout()
     this.$localStore.removeLastLibraryId()
     commit('logout')
+    commit('setActiveServerAddress', null, { root: true })
     commit('libraries/setCurrentLibrary', null, { root: true })
     await AbsLogger.info({ tag: 'user', message: `Logged out from server ${state.serverConnectionConfig?.name || 'Not connected'}` })
   },
@@ -174,7 +178,7 @@ export const actions = {
       return null
     }
 
-    const serverAddress = getters.getServerAddress
+    const serverAddress = await this.$serverAddress.resolve(state.serverConnectionConfig, { forceRefresh: true })
 
     const response = await CapacitorHttp.post({
       url: `${serverAddress}/auth/refresh`,


### PR DESCRIPTION
## Brief summary

Adds local network server address switching for saved Audiobookshelf servers.

Users can configure a local server URL and a list of Wi-Fi SSIDs. When the app is connected to one of those SSIDs and the local server responds, requests use the local URL. Otherwise, the app falls back to the canonical external URL.

## Which issue is fixed?

Fixes #209.

Related to #1401.

## Pull Request Type

Affects both Android and iOS, plus shared frontend/native request handling.

This changes mobile app client behavior only. It does not require Audiobookshelf server changes.

## In-depth Description

This adds local connection switching for server connection configs, matching the dual-address setup requested in #209.

The app now stores optional local connection fields on each server config:

- `localAddress`
- `localSsidWhitelist`

A new shared address resolver chooses the active server address by checking the current Wi-Fi SSID, validating that the local address responds, and falling back to the canonical external address when local access is unavailable.

The canonical server address remains the stable identity for saved configs, downloads, and local media matching. This avoids treating the same server as different servers just because it was reached through a local URL sometimes and an external URL other times.

The feature includes:

- Android and iOS SSID lookup plugins.
- Local URL and SSID settings in the connection/account UI.
- "Use current Wi-Fi" button for filling the SSID list.
- Axios/native HTTP/socket routing through the resolved active address.
- Socket reconnect when the resolved address changes.
- Side drawer indicator showing whether the app is using the local or external connection.
- Reader/local media checks updated to prefer `serverConnectionConfigId`.
- Android download transfer URLs now resolve the active address at transfer time while keeping canonical server identity.

This should help users who access the same Audiobookshelf server through a fast LAN address at home and a public/reverse-proxy URL elsewhere.

## How have you tested this?

- `git diff --check`
- `node --check plugins/server.js`
- `node --check plugins/serverAddress.js`
- `npm run generate`
- `npx cap sync android`
- `./gradlew :app:assembleDebug`
- `./gradlew :app:compileDebugKotlin`

Also installed and launched the debug APK on an Android device.

iOS code was updated but not locally compiled.
