### PR TITLE
Fix playback session bug

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -228,6 +228,7 @@ class PlaybackSession(
                     .putString(MediaMetadataCompat.METADATA_KEY_ALBUM_ARTIST, displayAuthor)
                     .putString(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION, displayAuthor)
                     .putString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID, id)
+                      .putLong(MediaMetadataCompat.METADATA_KEY_DURATION, totalDurationMs)
                     .putString(
                             MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON_URI,
                             coverUri.toString()


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Android media notification lost the duration.

## Which issue is fixed?

Fixes #1965 

## Pull Request Type

Fixes android media player notification

<!--
Does this affect only Android, only iOS, or both?
Does this change the frontend or the backend of the apps?
-->

## In-depth Description

Android media notification lost the duration. This is a regression caused by #1917, which replaced the explicit setMetaData with a custom object. However the METADATA_KEY_DURATION was omitted.

## How have you tested this?

Yes, built the android app following the guidelines and tested on my android device.

## Screenshots

This PR:

<img width="341" height="178" alt="afbeelding" src="https://github.com/user-attachments/assets/a1af536e-492a-4273-97a9-ee17b0754d3c" />

0.14.0-beta:
<img width="337" height="174" alt="afbeelding" src="https://github.com/user-attachments/assets/f61801c9-5e3a-44ad-8112-7bf991aa1705" />
