### PR TITLE
Leave playlist/collection detail pages when the library changes (#1711, #1712)

### DIFF
--- a/pages/collection/_id.vue
+++ b/pages/collection/_id.vue
@@ -135,8 +135,20 @@ export default {
           this.$eventBus.$emit('play-item', { libraryItemId: nextBookNotRead.id })
         }
       }
+    },
+    libraryChanged(libraryId) {
+      // A collection belongs to a single library, so leave this page when a different library is
+      // selected rather than showing a collection that is not in the current library
+      if (!libraryId || libraryId !== this.collection.libraryId) {
+        this.$router.replace('/bookshelf/collections')
+      }
     }
   },
-  mounted() {}
+  mounted() {
+    this.$eventBus.$on('library-changed', this.libraryChanged)
+  },
+  beforeDestroy() {
+    this.$eventBus.$off('library-changed', this.libraryChanged)
+  }
 }
 </script>

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -162,13 +162,20 @@ export default {
       if (this.playlist.id === playlist.id) {
         this.$router.replace('/bookshelf/playlists')
       }
+    },
+    libraryChanged() {
+      // Playlist contents are shown in the context of the selected library, so leave this page
+      // when the library changes rather than showing stale items
+      this.$router.replace('/bookshelf/playlists')
     }
   },
   mounted() {
+    this.$eventBus.$on('library-changed', this.libraryChanged)
     this.$socket.$on('playlist_updated', this.playlistUpdated)
     this.$socket.$on('playlist_removed', this.playlistRemoved)
   },
   beforeDestroy() {
+    this.$eventBus.$off('library-changed', this.libraryChanged)
     this.$socket.$off('playlist_updated', this.playlistUpdated)
     this.$socket.$off('playlist_removed', this.playlistRemoved)
   }


### PR DESCRIPTION
## Brief summary

The playlist and collection detail pages don't react when the selected library changes, so switching libraries leaves them showing stale content with no path back to the list. This adds the same `library-changed` handling the item detail page already has.

## Which issue is fixed?

Fixes #1711
Fixes #1712

## Pull Request Type

Frontend only (Vue), both platforms.

## In-depth Description

`pages/item/_id/index.vue` listens for the app-wide `library-changed` event and calls `$router.replace()` when the item is not in the newly selected library. `pages/playlist/_id.vue` and `pages/collection/_id.vue` never subscribed to that event.

- `playlist/_id.vue` — routes to `/bookshelf/playlists` on `library-changed` (playlist contents are shown in the context of the selected library).
- `collection/_id.vue` — routes to `/bookshelf/collections` unless the event's library id matches the collection's own `libraryId` (a collection belongs to one library).

Both register the listener in `mounted()` and remove it in `beforeDestroy()`, matching the existing pattern.

## How have you tested this?

- `npm run generate` builds cleanly.
- Logic mirrors the item detail page's existing `libraryChanged` handler and the `playlistRemoved` handler already in `playlist/_id.vue`.

## Screenshots

No visual change — navigation behavior only.
