### PR TITLE
Push isFinished/ebookLocation to the server on reconnect when offline (#1397)

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -849,26 +849,24 @@ class ApiHandler(var ctx:Context) {
               DeviceManager.dbManager.saveLocalMediaProgress(localMediaProgress)
               numLocalMediaProgressUpdated++
             } else if (localMediaProgress.lastUpdate > mediaProgress.lastUpdate) {
-              // Local progress is more recent than the server's - e.g. the user listened, or marked
-              // the item finished, while offline. Push the local values up so the server (the source
-              // of truth that other devices read, and that would otherwise overwrite this local
-              // progress on the next sync) is not left behind.
+              // Local progress is more recent than the server's. currentTime/progress from actual
+              // playback is already covered: AbsDatabase.syncLocalSessionsWithServer calls this
+              // function first, then replays saved local PlaybackSessions to the server via
+              // sendSyncLocalSessions, which is what advances server currentTime/progress. Pushing
+              // those fields here too would sync the same activity twice through two paths.
               //
-              // Local lastUpdate is only advanced to "now" when something actually happened locally
-              // (playback save, mark finished, ebook progress); updateFromServerMediaProgress copies
-              // the server timestamp. So a newer local timestamp reliably means real local activity,
-              // and the position values are correct even if the device clock is skewed.
+              // isFinished (and ebookLocation) have no PlaybackSession behind them - toggling
+              // finished, or moving an ebook location, doesn't record a session. updateLocalMediaProgressFinished
+              // / updateLocalEbookProgress already try to push those to the server immediately when
+              // they happen, but that push is lost if the device was offline at the time, and nothing
+              // else retries it. This is the gap this branch closes on reconnect, mirroring exactly
+              // what those immediate pushes send.
               val pushLogs = mutableListOf<String>()
-              if (mediaProgress.progress != localMediaProgress.progress) {
-                pushLogs.add("progress ${mediaProgress.progress} -> ${localMediaProgress.progress}")
-              }
-              if (mediaProgress.currentTime != localMediaProgress.currentTime) {
-                pushLogs.add("currentTime ${mediaProgress.currentTime} -> ${localMediaProgress.currentTime}")
-              }
               if (mediaProgress.isFinished != localMediaProgress.isFinished) {
                 pushLogs.add("isFinished ${mediaProgress.isFinished} -> ${localMediaProgress.isFinished}")
               }
-              if (localMediaProgress.ebookLocation != null && localMediaProgress.ebookLocation != mediaProgress.ebookLocation) {
+              val ebookLocationChanged = localMediaProgress.ebookLocation != null && localMediaProgress.ebookLocation != mediaProgress.ebookLocation
+              if (ebookLocationChanged) {
                 pushLogs.add("ebookLocation ${mediaProgress.ebookLocation} -> ${localMediaProgress.ebookLocation}")
               }
 
@@ -879,12 +877,13 @@ class ApiHandler(var ctx:Context) {
 
                 val endpoint = if (localMediaProgress.episodeId.isNullOrEmpty()) "/api/me/progress/${localMediaProgress.libraryItemId}" else "/api/me/progress/${localMediaProgress.libraryItemId}/${localMediaProgress.episodeId}"
                 val updatePayload = JSObject()
-                updatePayload.put("currentTime", localMediaProgress.currentTime)
-                updatePayload.put("progress", localMediaProgress.progress)
-                updatePayload.put("isFinished", localMediaProgress.isFinished)
-                updatePayload.put("duration", localMediaProgress.duration)
-                localMediaProgress.ebookLocation?.let { updatePayload.put("ebookLocation", it) }
-                localMediaProgress.ebookProgress?.let { updatePayload.put("ebookProgress", it) }
+                if (mediaProgress.isFinished != localMediaProgress.isFinished) {
+                  updatePayload.put("isFinished", localMediaProgress.isFinished)
+                }
+                if (ebookLocationChanged) {
+                  updatePayload.put("ebookLocation", localMediaProgress.ebookLocation)
+                  updatePayload.put("ebookProgress", localMediaProgress.ebookProgress)
+                }
                 updatePayload.put("lastUpdate", localMediaProgress.lastUpdate)
                 patchRequest(endpoint, updatePayload) {
                   AbsLogger.info("ApiHandler", "syncLocalMediaProgressForUser: Successfully pushed local progress to server for item \"${mediaProgress.mediaItemId}\"")

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -834,7 +834,7 @@ class ApiHandler(var ctx:Context) {
                 updateLogs.add("Updated isFinished from ${localMediaProgress.isFinished} to ${mediaProgress.isFinished}")
               }
               if (mediaProgress.ebookProgress != localMediaProgress.ebookProgress) {
-                updateLogs.add("Updated ebookProgress from ${localMediaProgress.isFinished} to ${mediaProgress.isFinished}")
+                updateLogs.add("Updated ebookProgress from ${localMediaProgress.ebookProgress} to ${mediaProgress.ebookProgress}")
               }
               if (updateLogs.isNotEmpty()) {
                 AbsLogger.info("ApiHandler", "syncLocalMediaProgressForUser: Server progress for item \"${mediaProgress.mediaItemId}\" is more recent than local (server lastUpdate=${mediaProgress.lastUpdate}, local lastUpdate=${localMediaProgress.lastUpdate}). ${updateLogs.joinToString()}")
@@ -848,16 +848,50 @@ class ApiHandler(var ctx:Context) {
               }
               DeviceManager.dbManager.saveLocalMediaProgress(localMediaProgress)
               numLocalMediaProgressUpdated++
-            } else if (localMediaProgress.lastUpdate > mediaProgress.lastUpdate && localMediaProgress.ebookLocation != null && localMediaProgress.ebookLocation != mediaProgress.ebookLocation) {
-              // Patch ebook progress to server
-              AbsLogger.info("ApiHandler", "syncLocalMediaProgressForUser: Local progress for ebook item \"${mediaProgress.mediaItemId}\" is more recent than server progress. Local progress last updated ${localMediaProgress.lastUpdate}, server progress last updated ${mediaProgress.lastUpdate}. Sending server request to update ebook progress from ${mediaProgress.ebookProgress} to ${localMediaProgress.ebookProgress}")
-              val endpoint = "/api/me/progress/${localMediaProgress.libraryItemId}"
-              val updatePayload = JSObject()
-              updatePayload.put("ebookLocation", localMediaProgress.ebookLocation)
-              updatePayload.put("ebookProgress", localMediaProgress.ebookProgress)
-              updatePayload.put("lastUpdate", localMediaProgress.lastUpdate)
-              patchRequest(endpoint,updatePayload) {
-                AbsLogger.info("ApiHandler", "syncLocalMediaProgressForUser: Successfully updated server ebook progress for item item \"${mediaProgress.mediaItemId}\"")
+            } else if (localMediaProgress.lastUpdate > mediaProgress.lastUpdate) {
+              // Local progress is more recent than the server's - e.g. the user listened, or marked
+              // the item finished, while offline. Push the local values up so the server (the source
+              // of truth that other devices read, and that would otherwise overwrite this local
+              // progress on the next sync) is not left behind.
+              //
+              // Local lastUpdate is only advanced to "now" when something actually happened locally
+              // (playback save, mark finished, ebook progress); updateFromServerMediaProgress copies
+              // the server timestamp. So a newer local timestamp reliably means real local activity,
+              // and the position values are correct even if the device clock is skewed.
+              val pushLogs = mutableListOf<String>()
+              if (mediaProgress.progress != localMediaProgress.progress) {
+                pushLogs.add("progress ${mediaProgress.progress} -> ${localMediaProgress.progress}")
+              }
+              if (mediaProgress.currentTime != localMediaProgress.currentTime) {
+                pushLogs.add("currentTime ${mediaProgress.currentTime} -> ${localMediaProgress.currentTime}")
+              }
+              if (mediaProgress.isFinished != localMediaProgress.isFinished) {
+                pushLogs.add("isFinished ${mediaProgress.isFinished} -> ${localMediaProgress.isFinished}")
+              }
+              if (localMediaProgress.ebookLocation != null && localMediaProgress.ebookLocation != mediaProgress.ebookLocation) {
+                pushLogs.add("ebookLocation ${mediaProgress.ebookLocation} -> ${localMediaProgress.ebookLocation}")
+              }
+
+              if (pushLogs.isEmpty()) {
+                numLocalMediaProgressUptToDate++
+              } else {
+                AbsLogger.info("ApiHandler", "syncLocalMediaProgressForUser: Local progress for item \"${mediaProgress.mediaItemId}\" is more recent than server (local lastUpdate=${localMediaProgress.lastUpdate}, server lastUpdate=${mediaProgress.lastUpdate}). Sending server update: ${pushLogs.joinToString()}")
+
+                val endpoint = if (localMediaProgress.episodeId.isNullOrEmpty()) "/api/me/progress/${localMediaProgress.libraryItemId}" else "/api/me/progress/${localMediaProgress.libraryItemId}/${localMediaProgress.episodeId}"
+                val updatePayload = JSObject()
+                updatePayload.put("currentTime", localMediaProgress.currentTime)
+                updatePayload.put("progress", localMediaProgress.progress)
+                updatePayload.put("isFinished", localMediaProgress.isFinished)
+                updatePayload.put("duration", localMediaProgress.duration)
+                localMediaProgress.ebookLocation?.let { updatePayload.put("ebookLocation", it) }
+                localMediaProgress.ebookProgress?.let { updatePayload.put("ebookProgress", it) }
+                updatePayload.put("lastUpdate", localMediaProgress.lastUpdate)
+                patchRequest(endpoint, updatePayload) {
+                  AbsLogger.info("ApiHandler", "syncLocalMediaProgressForUser: Successfully pushed local progress to server for item \"${mediaProgress.mediaItemId}\"")
+                }
+
+                MediaEventManager.syncEvent(mediaProgress, "Pushed local progress to server on connection")
+                numLocalMediaProgressUpdated++
               }
             } else {
               numLocalMediaProgressUptToDate++


### PR DESCRIPTION
## Brief summary

`syncLocalMediaProgressForUser` reconciles local and server media progress on every server connection, but its "local is newer than server" branch only ever patched ebook fields. `isFinished` toggled while offline (including "mark finished" on a downloaded book) is never sent up if the immediate push in `updateLocalMediaProgressFinished` failed because the device was offline - so the server stays behind and can overwrite the local state on a later sync.

This broadens that branch to also PATCH `isFinished` when local `lastUpdate` is newer and it actually differs from the server - mirroring the existing ebookLocation handling right next to it.

## Which issue is fixed?

Fixes #1397. Should also help the "server overwrites my newer progress" reports where the item was marked finished offline: #1338, #1442, #1510, #1852, #1945 (to the extent those are about `isFinished`, not currentTime drift).

## Pull Request Type

Android, native (Kotlin). Touches `ApiHandler.syncLocalMediaProgressForUser` only.

## In-depth Description

Before, the reconciliation loop over `user.mediaProgress` was:

- `server.lastUpdate > local.lastUpdate` → overwrite local from server (all fields)
- `local.lastUpdate > server.lastUpdate` **and `local.ebookLocation != null`** → patch `ebookLocation`/`ebookProgress` to the server
- otherwise → count as up-to-date

**Note this PR does *not* touch `currentTime`/`progress`.** Those are already synced to the server through a different path: `AbsDatabase.syncLocalSessionsWithServer` calls this function first, then calls `sendSyncLocalSessions`, which replays saved local `PlaybackSession`s to `/api/session/local-all` and is what actually advances server `currentTime`/`progress`. An earlier version of this PR also pushed `currentTime`/`progress` directly from `syncLocalMediaProgressForUser`, which would have double-synced that data through both paths - thanks @advplyr for flagging that.

`isFinished` (like `ebookLocation`) has no `PlaybackSession` behind it - toggling finished doesn't record one. `updateLocalMediaProgressFinished` already tries to PATCH `isFinished` to the server immediately when the user toggles it, but if the device is offline at that moment the push is just lost, and nothing retries it later. This change makes `syncLocalMediaProgressForUser`'s "local is newer" branch catch that up on the next connect, sending only `isFinished` (plus `lastUpdate`) - the same shape `updateLocalMediaProgressFinished` already sends.

Also fixed a copy/paste bug in the `ebookProgress` change-log line (it logged `isFinished` values), and made the PATCH endpoint episode-aware (`/api/me/progress/:libraryItemId/:episodeId`) so this works for podcast episodes, not just books.

## How have you tested this?

- `./android/gradlew -p android assembleDebug` builds cleanly.
- Not yet exercised on a device against a real offline scenario - see note below.

## Notes / open questions for a maintainer

- **This runs on every server connection and writes to the server**, so I'd still like real device testing before merge (mark finished while offline → reconnect) and a second look at the scope now that it's narrowed to just `isFinished`.
- The webview-liveness gap @advplyr flagged (this whole sync only runs while `default.vue` is mounted, so it doesn't help if the app is never reopened between connections) is real but out of scope here - happy to discuss moving the trigger into native separately.
- **Known remaining gap, not addressed here:** local progress for an item the server has *no* record of at all (downloaded, then played entirely offline) is still skipped, because the loop only iterates `user.mediaProgress`. iOS has an analogous path that this PR does not touch.
