### PR TITLE
Refresh the auth token on a 401 in the download path (follow-up to #1953)

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DownloadItemManager.kt
@@ -9,12 +9,14 @@ import com.audiobookshelf.app.device.DeviceManager
 import com.audiobookshelf.app.device.FolderScanner
 import com.audiobookshelf.app.models.DownloadItem
 import com.audiobookshelf.app.models.DownloadItemPart
+import com.audiobookshelf.app.server.ApiHandler
 import com.fasterxml.jackson.core.json.JsonReadFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.getcapacitor.JSObject
 import java.io.File
 import java.io.FileInputStream
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +35,8 @@ class DownloadItemManager(
   private val tag = "DownloadItemManager"
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
   private val activeCalls = ConcurrentHashMap<String, Call>()
+  private val apiHandler = ApiHandler(context)
+  private val isRefreshingToken = AtomicBoolean(false)
   private val safFolderLocks = ConcurrentHashMap<String, Any>()
   private val reservations = mutableMapOf<String, Long>()
   private val lastPersistTime = mutableMapOf<String, Long>()
@@ -56,6 +60,8 @@ class DownloadItemManager(
   interface InternalProgressCallback {
     fun onProgress(totalBytesWritten: Long, progress: Long)
     fun onComplete(failed: Boolean)
+    /** Transfer returned 401 - the access token expired and needs to be refreshed before retrying. */
+    fun onAuthError()
   }
 
   init {
@@ -123,6 +129,7 @@ class DownloadItemManager(
       part.isMoving = false
       part.downloadId = null
       part.retryCount = 0
+      part.authRetryCount = 0
     }
     persist(item, force = true)
   }
@@ -214,6 +221,13 @@ class DownloadItemManager(
                                   persist(item, force = true)
                                 }
                               }
+
+                              override fun onAuthError() {
+                                synchronized(this@DownloadItemManager) {
+                                  if (part !in currentDownloadItemParts) return
+                                  handleAuthError(item, part)
+                                }
+                              }
                             },
                             { hasAvailableSpace(part) }
                     )
@@ -250,6 +264,12 @@ class DownloadItemManager(
                       removeActivePart(part)
                       return
                     }
+    // Item already latched a terminal failure (e.g. unrecoverable auth) - ignore stale updates for
+    // parts that a watcher iteration captured before the latch.
+    if (item.terminalFailureAt != null) {
+      removeActivePart(part)
+      return
+    }
     if (!part.completed && !part.failed) {
       val lastUpdate = part.lastUpdateTime ?: return
       if (System.currentTimeMillis() - lastUpdate > STALL_TIMEOUT_MS) {
@@ -272,14 +292,7 @@ class DownloadItemManager(
     part.retryCount += 1
     reservations.remove(part.destinationPath)
     if (part.retryCount > MAX_RETRIES) {
-      Log.e(tag, "$reason after $MAX_RETRIES retries: ${part.filename}")
-      part.failed = true
-      part.completed = false
-      part.downloadId = null
-      item.terminalFailureAt = item.terminalFailureAt ?: System.currentTimeMillis()
-      persist(item, force = true)
-      IncompleteDownloadCleanup.schedule(context, item)
-      notifyQueueChanged()
+      markTerminalFailure(item, part, "$reason after $MAX_RETRIES retries")
       return
     }
     part.failed = false
@@ -287,6 +300,86 @@ class DownloadItemManager(
     part.downloadId = null
     part.isMoving = false
     persist(item, force = true)
+  }
+
+  /**
+   * Handles a 401 from the file download endpoint. Unlike [failOrRetry] this does not consume a
+   * transfer retry - the access token simply expired while the item sat in the queue. The part is
+   * parked (downloadId=null, not failed) and a single token refresh is kicked off; on success
+   * [checkUpdateDownloadQueue] restarts the parked part(s) with the fresh token.
+   */
+  @Synchronized
+  private fun handleAuthError(item: DownloadItem, part: DownloadItemPart) {
+    removeActivePart(part)
+    reservations.remove(part.destinationPath)
+    part.downloadId = null
+    part.isMoving = false
+    part.failed = false
+    part.completed = false
+    part.authRetryCount += 1
+
+    if (part.authRetryCount > MAX_AUTH_RETRIES) {
+      markTerminalFailure(item, part, "Download unauthorized - token refresh did not resolve after $MAX_AUTH_RETRIES attempts")
+      return
+    }
+
+    part.lastUpdateTime = System.currentTimeMillis()
+    persist(item, force = true)
+    Log.w(tag, "Download unauthorized (401): ${part.filename} - refreshing auth token (attempt ${part.authRetryCount})")
+    clientEventEmitter.onDownloadItemPartUpdate(part)
+    refreshTokenThenResume()
+  }
+
+  /** Kicks off a single (deduplicated) token refresh and resumes or fails parked parts on the result. */
+  private fun refreshTokenThenResume() {
+    if (!isRefreshingToken.compareAndSet(false, true)) {
+      Log.d(tag, "Auth token refresh already in progress for downloads")
+      return
+    }
+    Log.d(tag, "Requesting auth token refresh for downloads")
+    apiHandler.refreshAuthTokens { newAccessToken ->
+      isRefreshingToken.set(false)
+      synchronized(this@DownloadItemManager) {
+        if (newAccessToken.isNullOrEmpty()) {
+          Log.e(tag, "Auth token refresh for downloads failed - failing parked downloads")
+          failParkedAuthParts()
+        } else {
+          Log.d(tag, "Auth token refresh for downloads succeeded - resuming queue")
+          checkUpdateDownloadQueue()
+        }
+      }
+    }
+  }
+
+  /** Fails parts that were parked awaiting a token refresh which ultimately failed. */
+  @Synchronized
+  private fun failParkedAuthParts() {
+    downloadItemQueue.toList().forEach { item ->
+      item.downloadItemParts
+              .filter {
+                it.authRetryCount > 0 &&
+                        !it.completed &&
+                        !it.failed &&
+                        it.downloadId == null &&
+                        it !in currentDownloadItemParts
+              }
+              .forEach { part -> markTerminalFailure(item, part, "Download unauthorized - auth token refresh failed") }
+    }
+  }
+
+  @Synchronized
+  private fun markTerminalFailure(item: DownloadItem, part: DownloadItemPart, reason: String) {
+    Log.e(tag, "$reason: ${part.filename}")
+    removeActivePart(part)
+    reservations.remove(part.destinationPath)
+    part.failed = true
+    part.completed = false
+    part.downloadId = null
+    part.isMoving = false
+    item.terminalFailureAt = item.terminalFailureAt ?: System.currentTimeMillis()
+    persist(item, force = true)
+    IncompleteDownloadCleanup.schedule(context, item)
+    notifyQueueChanged()
   }
 
   private fun finalizeInternalFile(item: DownloadItem, part: DownloadItemPart) {
@@ -505,6 +598,7 @@ class DownloadItemManager(
     const val WATCH_INTERVAL_MS = 1_000L
     const val STALL_TIMEOUT_MS = 60_000L
     const val MAX_RETRIES = 5
+    const val MAX_AUTH_RETRIES = 2
     const val PERSIST_INTERVAL_MS = 2_000L
     const val MIN_FREE_SPACE_BYTES = 100L * 1024L * 1024L
     const val UNKNOWN_PART_RESERVATION_BYTES = 100L * 1024L * 1024L

--- a/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/InternalDownloadManager.kt
@@ -47,6 +47,11 @@ class InternalDownloadManager(
               override fun onResponse(call: Call, response: Response) {
                 response.use {
                   try {
+                    if (response.code == 401) {
+                      Log.e(tag, "Download unauthorized (401) - access token likely expired for $url")
+                      progressCallback.onAuthError()
+                      return
+                    }
                     if (response.code == 416 && expectedSize > 0L && existingBytes == expectedSize
                     ) {
                       progressCallback.onProgress(existingBytes, 100L)

--- a/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/models/DownloadItemPart.kt
@@ -38,6 +38,7 @@ data class DownloadItemPart(
   var progress: Long,
   var bytesDownloaded: Long,
   @JsonIgnore var retryCount: Int = 0,
+  @JsonIgnore var authRetryCount: Int = 0,
   @JsonIgnore var waitingForSpace: Boolean = false
 ) {
   companion object {

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -161,68 +161,82 @@ class ApiHandler(var ctx:Context) {
   }
 
   /**
-   * Handles token refresh when a 401 Unauthorized response is received
-   * This function will:
-   * 1. Get the refresh token from secure storage for the current server connection
-   * 2. Make a request to /auth/refresh endpoint with the refresh token
-   * 3. Update the stored tokens with the new access token
-   * 4. Retry the original request with the new access token
-   * 5. If refresh fails, handle logout
+   * Handles token refresh when a 401 Unauthorized response is received for an API request.
+   * Refreshes the auth tokens (see [refreshAuthTokens]) and, on success, retries the original
+   * request with the new access token. On failure the caller's [callback] receives an error.
    *
    * @param originalRequest The original request that failed with 401
    * @param httpClient The HTTP client to use for the request
    * @param callback The callback to return the response
    */
   private fun handleTokenRefresh(originalRequest: Request, httpClient: OkHttpClient?, callback: (JSObject) -> Unit) {
-    try {
-      AbsLogger.info(tag, "handleTokenRefresh: Attempting to refresh auth tokens for server ${DeviceManager.serverConnectionConfigString}")
+    AbsLogger.info(tag, "handleTokenRefresh: Attempting to refresh auth tokens for server ${DeviceManager.serverConnectionConfigString}")
+    refreshAuthTokens(httpClient) { newAccessToken ->
+      if (newAccessToken.isNullOrEmpty()) {
+        val errorObj = JSObject()
+        errorObj.put("error", "Authentication failed - please login again")
+        callback(errorObj)
+      } else {
+        Log.d(tag, "handleTokenRefresh: Retrying original request with new token")
+        retryOriginalRequest(originalRequest, newAccessToken, httpClient, callback)
+      }
+    }
+  }
 
-      // Get current server connection config ID
+  /**
+   * Refreshes the access + refresh tokens for the current server connection.
+   *
+   * This function will:
+   * 1. Get the refresh token from secure storage for the current server connection
+   * 2. Make a request to the /auth/refresh endpoint with the refresh token
+   * 3. Update the stored tokens (secure storage + [DeviceManager] + webview) with the new tokens
+   *
+   * Shared by [handleTokenRefresh] (API 401 handling) and the download manager, which has no other
+   * way to recover an access token that expired while items sat in the download queue.
+   *
+   * @param httpClient Optional HTTP client to use for the refresh request
+   * @param onResult Receives the new access token on success, or null on failure. On an auth
+   *   failure the session is cleared via [handleRefreshFailure]; a missing connection/refresh token
+   *   resolves to null without clearing the session.
+   */
+  fun refreshAuthTokens(httpClient: OkHttpClient? = null, onResult: (String?) -> Unit) {
+    try {
       val serverConnectionConfigId = DeviceManager.serverConnectionConfigId
       if (serverConnectionConfigId.isEmpty()) {
-        AbsLogger.error(tag, "handleTokenRefresh: Unable to refresh auth tokens. No server connection config ID")
-        val errorObj = JSObject()
-        errorObj.put("error", "No server connection available")
-        callback(errorObj)
-        return
+        AbsLogger.error(tag, "refreshAuthTokens: Unable to refresh auth tokens. No server connection config ID")
+        return onResult(null)
       }
 
-      // Get refresh token from secure storage
       val refreshToken = secureStorage.getRefreshToken(serverConnectionConfigId)
       if (refreshToken.isNullOrEmpty()) {
-        AbsLogger.error(tag, "handleTokenRefresh: Unable to refresh auth tokens. No refresh token available for server ${DeviceManager.serverConnectionConfigString}")
-        val errorObj = JSObject()
-        errorObj.put("error", "No refresh token available")
-        callback(errorObj)
-        return
+        AbsLogger.error(tag, "refreshAuthTokens: Unable to refresh auth tokens. No refresh token available for server ${DeviceManager.serverConnectionConfigString}")
+        return onResult(null)
       }
 
-      Log.d(tag, "handleTokenRefresh: Retrieved refresh token, attempting to refresh access token")
+      Log.d(tag, "refreshAuthTokens: Retrieved refresh token, attempting to refresh access token")
 
-      // Create refresh token request
-      val refreshEndpoint = "${DeviceManager.serverAddress}/auth/refresh"
       val refreshRequest = Request.Builder()
-        .url(refreshEndpoint)
+        .url("${DeviceManager.serverAddress}/auth/refresh")
         .addHeader("x-refresh-token", refreshToken)
         .addHeader("Content-Type", "application/json")
         .post(EMPTY_REQUEST)
         .build()
 
-      // Make the refresh request
       val client = httpClient ?: defaultClient
       client.newCall(refreshRequest).enqueue(object : Callback {
         override fun onFailure(call: Call, e: IOException) {
-          Log.e(tag, "handleTokenRefresh: Failed to connect to refresh endpoint", e)
-          AbsLogger.error(tag, "handleTokenRefresh: Failed to connect to refresh endpoint for server ${DeviceManager.serverConnectionConfigString} (error: ${e.message})")
-          handleRefreshFailure(callback)
+          Log.e(tag, "refreshAuthTokens: Failed to connect to refresh endpoint", e)
+          AbsLogger.error(tag, "refreshAuthTokens: Failed to connect to refresh endpoint for server ${DeviceManager.serverConnectionConfigString} (error: ${e.message})")
+          handleRefreshFailure { _ -> }
+          onResult(null)
         }
 
         override fun onResponse(call: Call, response: Response) {
           response.use {
             if (!it.isSuccessful) {
-              AbsLogger.error(tag, "handleTokenRefresh: Refresh request failed with status ${it.code} for server ${DeviceManager.serverConnectionConfigString}")
-              handleRefreshFailure(callback)
-              return
+              AbsLogger.error(tag, "refreshAuthTokens: Refresh request failed with status ${it.code} for server ${DeviceManager.serverConnectionConfigString}")
+              handleRefreshFailure { _ -> }
+              return onResult(null)
             }
 
             val bodyString = it.body!!.string()
@@ -231,41 +245,38 @@ class ApiHandler(var ctx:Context) {
               val userObj = responseJson.optJSONObject("user")
 
               if (userObj == null) {
-                AbsLogger.error(tag, "handleTokenRefresh: No user object in refresh response for server ${DeviceManager.serverConnectionConfigString}")
-                handleRefreshFailure(callback)
-                return
+                AbsLogger.error(tag, "refreshAuthTokens: No user object in refresh response for server ${DeviceManager.serverConnectionConfigString}")
+                handleRefreshFailure { _ -> }
+                return onResult(null)
               }
 
               val newAccessToken = userObj.optString("accessToken")
               val newRefreshToken = userObj.optString("refreshToken")
 
               if (newAccessToken.isEmpty()) {
-                AbsLogger.error(tag, "handleTokenRefresh: No access token in refresh response for server ${DeviceManager.serverConnectionConfigString}")
-                handleRefreshFailure(callback)
-                return
+                AbsLogger.error(tag, "refreshAuthTokens: No access token in refresh response for server ${DeviceManager.serverConnectionConfigString}")
+                handleRefreshFailure { _ -> }
+                return onResult(null)
               }
 
-              Log.d(tag, "handleTokenRefresh: Successfully obtained new access token")
+              Log.d(tag, "refreshAuthTokens: Successfully obtained new access token")
 
               // Update tokens in secure storage and device manager
               updateTokens(newAccessToken, newRefreshToken.ifEmpty { refreshToken }, serverConnectionConfigId)
-
-              // Retry the original request with the new access token
-              Log.d(tag, "handleTokenRefresh: Retrying original request with new token")
-              retryOriginalRequest(originalRequest, newAccessToken, httpClient, callback)
-
+              onResult(newAccessToken)
             } catch (e: Exception) {
-              Log.e(tag, "handleTokenRefresh: Failed to parse refresh response", e)
-              AbsLogger.error(tag, "handleTokenRefresh: Failed to parse refresh response for server ${DeviceManager.serverConnectionConfigString} (error: ${e.message})")
-              handleRefreshFailure(callback)
+              Log.e(tag, "refreshAuthTokens: Failed to parse refresh response", e)
+              AbsLogger.error(tag, "refreshAuthTokens: Failed to parse refresh response for server ${DeviceManager.serverConnectionConfigString} (error: ${e.message})")
+              handleRefreshFailure { _ -> }
+              onResult(null)
             }
           }
         }
       })
-
     } catch (e: Exception) {
-      Log.e(tag, "handleTokenRefresh: Unexpected error during token refresh", e)
-      handleRefreshFailure(callback)
+      Log.e(tag, "refreshAuthTokens: Unexpected error during token refresh", e)
+      handleRefreshFailure { _ -> }
+      onResult(null)
     }
   }
 


### PR DESCRIPTION
## Brief summary

Follow-up to #1953, as discussed there. That PR recovers 416 / interrupted transfers; this one handles a **401** on the file download request, which wedges a download into the same "stuck at 100% / Download already started" state by a different route.

## Which issue is fixed?

Follow-up to #1953. Also relevant to the non-Range-bug reports in #1970 / #1963 where "kill the app and reopen" is the only recovery.

## Pull Request Type

Android, native (Kotlin).

## In-depth Description

`InternalDownloadManager.download()` sends `Authorization: Bearer <token>` using the access token read once in `DownloadItemManager.startDownload()`. Every other network path in the app refreshes on 401 (`ApiHandler.makeRequest` → `handleTokenRefresh`, and the JS `nativeHttp`), but the file downloader has no 401 handling — a 401 falls through to the generic failure path. When the access token expires while items sit in the queue, or mid-transfer on a large book, each part fails, burns its transfer retries against the dead token, and latches `terminalFailureAt`. It only clears once something else in the app refreshes the token.

Changes:

- **`ApiHandler`**: extract the `/auth/refresh` core out of the private `handleTokenRefresh` into a reusable `refreshAuthTokens(httpClient?, onResult: (String?) -> Unit)`. `handleTokenRefresh` now delegates to it; behavior for the existing API 401 path (including `handleRefreshFailure` session-clear semantics) is unchanged.
- **`InternalDownloadManager`**: detect HTTP 401 and report it distinctly via a new `InternalProgressCallback.onAuthError()` instead of a generic failure.
- **`DownloadItemManager`**: on `onAuthError`, park the part (`downloadId = null`, not failed — **no transfer retry consumed**), bump a separate `authRetryCount` (bound `MAX_AUTH_RETRIES = 2`), and fire a single de-duplicated `refreshAuthTokens()`. On success, `checkUpdateDownloadQueue()` restarts the parked part(s) with the freshly stored token. On failure, the parked parts go to terminal failure (and the session is cleared by the refresh path, as elsewhere). Also refactored the terminal-failure block out of `failOrRetry` into a shared `markTerminalFailure`, and added a `terminalFailureAt != null` guard in `handlePartUpdate` so a stale watcher iteration can't un-latch a terminal auth failure.
- **`DownloadItemPart`**: add `@JsonIgnore var authRetryCount: Int = 0`.

Layered so it sits alongside #1953's 416 branch (my `onAuthError` path vs their `416` path; my `handleAuthError` vs their `retryDownloadItem`). If #1953 lands first this will need a small rebase in the same three files, and vice versa — happy to do whichever.

## How have you tested this?

- `./android/gradlew -p android assembleDebug` builds cleanly.
- Not yet exercised on a device against a live token expiry — the logic is a mirror of the app's existing `handleTokenRefresh` retry, scoped to the download path.
