### PR TITLE
Survive a database entry that cannot be read

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/managers/DbManager.kt
@@ -22,8 +22,32 @@ class DbManager {
     }
   }
 
+  /**
+   * Reads one entry, dropping it when it cannot be read.
+   *
+   * A file left half written - the app was killed mid write, the device ran out of storage - makes
+   * kryo throw, and an unhandled throw here takes the app down on every start. The only way out for
+   * a user would be clearing the app's storage, which takes their downloads and progress with it.
+   */
+  private inline fun <reified T> readEntry(bookName: String, key: String): T? {
+    val book = Paper.book(bookName)
+
+    return try {
+      book.read<T>(key)
+    } catch (e: Exception) {
+      Log.e(tag, "readEntry: Dropping unreadable $bookName entry $key", e)
+      book.delete(key)
+      null
+    }
+  }
+
+  /** Reads every entry of a book, dropping the ones that cannot be read. See [readEntry]. */
+  private inline fun <reified T> readBook(bookName: String): List<T> {
+    return Paper.book(bookName).allKeys.mapNotNull { readEntry<T>(bookName, it) }
+  }
+
   fun getDeviceData(): DeviceData {
-    return Paper.book("device").read("data")
+    return readEntry<DeviceData>("device", "data")
             ?: DeviceData(mutableListOf(), null, DeviceSettings.default(), null)
   }
   fun saveDeviceData(deviceData: DeviceData) {
@@ -31,16 +55,9 @@ class DbManager {
   }
 
   fun getLocalLibraryItems(mediaType: String? = null): MutableList<LocalLibraryItem> {
-    val localLibraryItems: MutableList<LocalLibraryItem> = mutableListOf()
-    Paper.book("localLibraryItems").allKeys.forEach {
-      val localLibraryItem: LocalLibraryItem? = Paper.book("localLibraryItems").read(it)
-      if (localLibraryItem != null &&
-                      (mediaType.isNullOrEmpty() || mediaType == localLibraryItem.mediaType)
-      ) {
-        localLibraryItems.add(localLibraryItem)
-      }
-    }
-    return localLibraryItems
+    return readBook<LocalLibraryItem>("localLibraryItems")
+            .filter { mediaType.isNullOrEmpty() || mediaType == it.mediaType }
+            .toMutableList()
   }
 
   fun getLocalLibraryItemsInFolder(folderId: String): List<LocalLibraryItem> {
@@ -53,7 +70,7 @@ class DbManager {
   }
 
   fun getLocalLibraryItem(localLibraryItemId: String): LocalLibraryItem? {
-    return Paper.book("localLibraryItems").read(localLibraryItemId)
+    return readEntry("localLibraryItems", localLibraryItemId)
   }
 
   fun getLocalLibraryItemWithEpisode(podcastEpisodeId: String): LibraryItemWithEpisode? {
@@ -88,15 +105,11 @@ class DbManager {
   }
 
   fun getLocalFolder(folderId: String): LocalFolder? {
-    return Paper.book("localFolders").read(folderId)
+    return readEntry("localFolders", folderId)
   }
 
   fun getAllLocalFolders(): List<LocalFolder> {
-    val localFolders: MutableList<LocalFolder> = mutableListOf()
-    Paper.book("localFolders").allKeys.forEach { localFolderId ->
-      Paper.book("localFolders").read<LocalFolder>(localFolderId)?.let { localFolders.add(it) }
-    }
-    return localFolders
+    return readBook("localFolders")
   }
 
   fun removeLocalFolder(folderId: String) {
@@ -114,11 +127,7 @@ class DbManager {
   }
 
   fun getDownloadItems(): List<DownloadItem> {
-    val downloadItems: MutableList<DownloadItem> = mutableListOf()
-    Paper.book("downloadItems").allKeys.forEach { downloadItemId ->
-      Paper.book("downloadItems").read<DownloadItem>(downloadItemId)?.let { downloadItems.add(it) }
-    }
-    return downloadItems
+    return readBook("downloadItems")
   }
 
   fun saveLocalMediaProgress(mediaProgress: LocalMediaProgress) {
@@ -127,16 +136,10 @@ class DbManager {
   // For books this will just be the localLibraryItemId for podcast episodes this will be
   // "{localLibraryItemId}-{episodeId}"
   fun getLocalMediaProgress(localMediaProgressId: String): LocalMediaProgress? {
-    return Paper.book("localMediaProgress").read(localMediaProgressId)
+    return readEntry("localMediaProgress", localMediaProgressId)
   }
   fun getAllLocalMediaProgress(): List<LocalMediaProgress> {
-    val mediaProgress: MutableList<LocalMediaProgress> = mutableListOf()
-    Paper.book("localMediaProgress").allKeys.forEach { localMediaProgressId ->
-      Paper.book("localMediaProgress").read<LocalMediaProgress>(localMediaProgressId)?.let {
-        mediaProgress.add(it)
-      }
-    }
-    return mediaProgress
+    return readBook("localMediaProgress")
   }
   fun removeLocalMediaProgress(localMediaProgressId: String) {
     Paper.book("localMediaProgress").delete(localMediaProgressId)
@@ -272,7 +275,7 @@ class DbManager {
     Paper.book("mediaItemHistory").write(mediaItemHistory.id, mediaItemHistory)
   }
   fun getMediaItemHistory(id: String): MediaItemHistory? {
-    return Paper.book("mediaItemHistory").read(id)
+    return readEntry("mediaItemHistory", id)
   }
 
   fun savePlaybackSession(playbackSession: PlaybackSession) {
@@ -282,23 +285,14 @@ class DbManager {
     Paper.book("playbackSession").delete(playbackSessionId)
   }
   fun getPlaybackSessions(): List<PlaybackSession> {
-    val sessions: MutableList<PlaybackSession> = mutableListOf()
-    Paper.book("playbackSession").allKeys.forEach { playbackSessionId ->
-      Paper.book("playbackSession").read<PlaybackSession>(playbackSessionId)?.let {
-        sessions.add(it)
-      }
-    }
-    return sessions
+    return readBook("playbackSession")
   }
 
   fun saveLog(log: AbsLog) {
     Paper.book("log").write(log.id, log)
   }
   fun getAllLogs(): List<AbsLog> {
-    val logs: MutableList<AbsLog> = mutableListOf()
-    Paper.book("log").allKeys.forEach { logId ->
-      Paper.book("log").read<AbsLog>(logId)?.let { logs.add(it) }
-    }
+    val logs: MutableList<AbsLog> = readBook<AbsLog>("log").toMutableList()
     return logs.sortedBy { it.timestamp }
   }
   fun removeAllLogs() {


### PR DESCRIPTION
## Brief summary

A single database entry that cannot be deserialized crashes the app on every
launch, and the only way out for a user is clearing the app's storage. Reads now
skip and delete what they cannot read, so one damaged entry costs that one entry.

## Which issue is fixed?

No existing issue found. Encountered while testing an unrelated change: the app
was killed while it was writing a playback session, and from then on it would not
start at all.

## Pull Request Type

Android only, native side. No frontend changes.

## In-depth Description

A file left half written - the app killed mid write, the device out of storage -
makes kryo throw when paper reads it back. Nothing caught that:

```
FATAL EXCEPTION: CapacitorPlugins
  io.paperdb.PaperDbException: Couldn't read/deserialize file
      .../files/playbackSession/<id>.pt
  Caused by: com.esotericsoftware.kryo.KryoException: Buffer underflow
  Serialization trace: chapters (PlaybackSession)
      at DbManager.getPlaybackSessions(DbManager.kt:287)
      at AbsDatabase.syncLocalSessionsWithServer(AbsDatabase.kt:291)
```

`getPlaybackSessions` runs during the startup sync, so the throw travels straight
out and the app dies before it is usable. There is no way back from that for a
user: clearing the cache does not help, because the paper db lives in the app's
files directory, not its cache. The only remedy is clearing the app's storage -
which takes the server login, the downloads and the local progress with it.

The same shape was in every other read: six hand written "read all keys" loops
and five single reads, including `device`, which holds the server connection and
the settings, so a damaged entry there is just as fatal.

Two helpers, `readEntry` and `readBook`, drop what they cannot deserialize and
delete the damaged entry. Every read in `DbManager` goes through them, and
`Paper.book` is used nowhere else in the app, so the coverage is complete rather
than spot fixed. They replace the six loops as well, which is why this removes
more lines than it adds.

Deleting rather than only skipping is deliberate: the entry is provably
unreadable and would otherwise throw on every start for the life of the install.

## How have you tested this?

Reproduced with the exact file that caused the crash above:

1. copy the damaged `.pt` back into `files/playbackSession/`
2. `adb shell am force-stop`, clear the log buffers, start the app again

Before, the app died on the startup sync every time. After:

```
E/DbManager: readEntry: Dropping unreadable playbackSession entry <id>
E/DbManager: io.paperdb.PaperDbException: Couldn't read/deserialize file ...
I/AbsLogger: syncLocalSessions: Successfully synced local sessions
I/AbsLogger: mounted: fully initialized
```

Crash buffer empty, the app runs, the damaged entry is gone, and the next start
does not even log it. Normal startup, library browsing, downloads and playback
were exercised afterwards with an undamaged database.

## Screenshots

Not applicable - no frontend changes.
