### PR TITLE
Let the sleep timer fade out on a cast device too

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/CastPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/CastPlayer.kt
@@ -815,12 +815,21 @@ class CastPlayer(var castContext: CastContext) : BasePlayer() {
    return AudioAttributes.DEFAULT
   }
 
+  /**
+   * The volume of the media stream, which is what the sleep timer fades - not the volume of the
+   * receiver. The device volume stays where the user put it, and on a cast group the balance
+   * between its members is left alone, because the receiver applies this to the group's output.
+   */
   override fun setVolume(audioVolume: Float) {
-
+    try {
+      remoteMediaClient?.setStreamVolume(audioVolume.toDouble().coerceIn(0.0, 1.0))
+    } catch (e: Exception) {
+      Log.e(tag, "Failed to set the cast stream volume", e)
+    }
   }
 
   override fun getVolume(): Float {
-    return 0F
+    return remoteMediaClient?.mediaStatus?.streamVolume?.toFloat() ?: 1F
   }
 
   override fun clearVideoSurface() {


### PR DESCRIPTION
## Brief summary

The sleep timer's fade-out does nothing while casting, because `CastPlayer`
never implemented the volume it is driven by. Both accessors now go through the
Cast SDK's media stream volume.

## Which issue is fixed?

No existing issue found.

## Pull Request Type

Android only, native side. No frontend changes.

## In-depth Description

Over its last minute the sleep timer fades playback down to 10% by setting
`currentPlayer.volume`. In `CastPlayer`, `setVolume` was an empty method and
`getVolume` returned zero, so while casting the fade did nothing at all -
playback simply stopped at full volume.

Both now go through `RemoteMediaClient.setStreamVolume` and
`MediaStatus.getStreamVolume`. Nothing in `SleepTimerManager` changes.

That is deliberately the stream volume and not the receiver's device volume
(`CastSession.setVolume`, which the app already uses for the volume rocker):

- the device volume stays where the user left it, so a fade cannot leave the
  speaker turned down afterwards
- on a cast group the balance between its members is untouched, because the
  receiver applies the stream volume to the group's output. No per-member volume
  has to be read, stored and written back, and an interrupted fade cannot leave
  one speaker quieter than the rest.

Nothing else in the app touches the stream volume, so it is at 1.0 whenever the
timer is not fading, and the existing restore to full volume stays correct.

## How have you tested this?

On Android, casting an audiobook to a Chromecast audio receiver:

1. started casting, set a sleep timer
2. listened through the last minute - the volume ramps down as it does for local
   playback, instead of staying at full level until playback stops
3. pressed pause and then play shortly before the timer ran out - the volume was
   back at its normal level right away

Before this change step 2 and 3 did nothing at all while casting, because
`CastPlayer.setVolume` was empty.

The group case is covered by construction rather than by a test: the stream
volume is applied by the receiver to the group's output, and no member volume is
read or written, so there is nothing that could leave one speaker out of balance.

## Screenshots

Not applicable - no frontend changes.
