### PR TITLE
Report receiver availability from the framework as well

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/CastManager.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/CastManager.kt
@@ -21,6 +21,31 @@ class CastManager constructor(val mainActivity:Activity) {
 
   private var playerNotificationService:PlayerNotificationService? = null
   private var newConnectionListener: SessionListener? = null
+  private var castStateListener: CastStateListener? = null
+
+  /**
+   * The framework reports NO_DEVICES_AVAILABLE when a session ends, because it stops discovering -
+   * taken at face value that hides the cast button. The media router is the second opinion.
+   */
+  private fun isReceiverAvailable(castState: Int): Boolean {
+    if (castState != CastState.NO_DEVICES_AVAILABLE) return true
+
+    // The framework's own selector, which carries the receiver id this app is configured with -
+    // building one by hand here would ask about a different receiver than the one being cast to
+    val selector = getContext().mergedSelector ?: return false
+
+    return getMediaRouter()?.isRouteAvailable(
+      selector,
+      MediaRouter.AVAILABILITY_FLAG_IGNORE_DEFAULT_ROUTE or
+        MediaRouter.AVAILABILITY_FLAG_REQUIRE_MATCH
+    ) == true
+  }
+
+  /** Drops what this manager registered for the activity, which does not outlive it. */
+  fun detach() {
+    castStateListener?.let { getContext().removeCastStateListener(it) }
+    castStateListener = null
+  }
 
   private fun switchToPlayer(useCastPlayer:Boolean) {
     Handler(Looper.getMainLooper()).post() {
@@ -123,6 +148,13 @@ class CastManager constructor(val mainActivity:Activity) {
   }
 
   fun startRouteScan(connListener:ChromecastListener) {
+    // ChromecastListener has always implemented CastStateListener, but nothing registered it, so
+    // availability hung entirely on the media router callback below - which does not always fire
+    val stateListener = CastStateListener { state -> connListener.onReceiverAvailableUpdate(isReceiverAvailable(state)) }
+    castStateListener = stateListener
+    getContext().addCastStateListener(stateListener)
+    connListener.onReceiverAvailableUpdate(isReceiverAvailable(getContext().castState))
+
     val callback = object : ScanCallback() {
       override fun onRouteUpdate(routes: List<MediaRouter.RouteInfo>?) {
         Log.d(tag, "CAST On ROUTE UPDATED ${routes?.size} | ${getContext().castState}")

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -127,6 +127,11 @@ class AbsAudioPlayer : Plugin() {
     notifyListeners(evtName, ret)
   }
 
+  override fun handleOnDestroy() {
+    castManager?.detach()
+    super.handleOnDestroy()
+  }
+
   override fun handleOnPause() {
     super.handleOnPause()
     isInForeground = false


### PR DESCRIPTION
## Brief summary

The cast button disappears and only comes back after the app is fully restarted.
`ChromecastListener` has always implemented `CastStateListener`, but nothing ever
registered it, so availability hung entirely on media router callbacks - and
those stop arriving once the routes are known.

## Which issue is fixed?

Fixes #1130

## Pull Request Type

Android only, native side. No frontend changes.

## In-depth Description

`startRouteScan` reports a receiver as available from the media router callback,
and stops scanning as soon as it has seen one. The media router only calls back
when routes *change*, so on a later activity creation the fresh callback fires
once against an empty list, reports "no devices", and is never called again -
the routes have long been published and nothing changes after that.

Captured on a device, first launch and a later one in the same session:

```
08:01:52.547  Starting route scan; current cast state=1
08:01:52.547  CAST On ROUTE UPDATED 0 | 1  ->  No cast devices available
08:01:53.230  CAST On ROUTE UPDATED 8 | 2  ->  eight devices
08:01:53.230  stopRouteScan
08:01:53.230  ChromecastListener: CAST Receiver Update Available true

08:03:12.992  Starting route scan; current cast state=1
08:03:12.992  CAST On ROUTE UPDATED 0 | 1  ->  No cast devices available
08:03:13.381  getIsCastAvailable
              ... and nothing after that.
```

`getIsCastAvailable` does not rescue it either: the plugin's `isCastAvailable`
field belongs to the plugin instance, and a new activity means a new instance
that starts out false.

That matches every report in #1130 - "I basically have to force stop the app and
relaunch it", "I then have to reboot in order to cast".

This registers the framework's own `CastStateListener` alongside the existing
callback. It reports cast state changes independently of route changes, so the
button appears when a receiver shows up even though the media router stays quiet.

`NO_DEVICES_AVAILABLE` from the framework is deliberately not taken at face
value: the framework reports it when a session ends, because it stops discovering
at that point, and trusting it would hide the button right after someone stops
casting. The routes the media router knows are used as a second opinion for that
one case.

This also makes #1762 unnecessary, which works around the same symptom by always
showing the button on Android - at the cost of showing it when no receiver is
reachable at all.

## How have you tested this?

On a Pixel 10 Pro XL with several Chromecast groups and speakers:

1. launch the app - cast button appears
2. leave the app and reopen it so the activity is recreated
3. without this change the button stays gone until the app is force stopped;
   with it, it is there

Casting itself, starting and stopping a session, and the button state right after
a session ends were exercised as well - the button stays visible after stopping,
which was the case the second opinion is there for.

## Screenshots

Not applicable - no frontend changes.
