### PR TITLE
Offer the download again when the local copy is behind the server

### DIFF
--- a/pages/item/_id/index.vue
+++ b/pages/item/_id/index.vue
@@ -60,7 +60,7 @@
               <span v-if="!showPlay" class="px-2 text-base">{{ $strings.ButtonRead }} {{ ebookFormat }}</span>
             </ui-btn>
             <ui-btn v-if="showDownload" :color="downloadItem ? 'warning' : 'primary'" class="flex items-center justify-center mx-1" :padding-x="2" @click="downloadClick">
-              <span class="material-symbols text-2xl" :class="downloadItem || startingDownload ? 'animate-pulse' : ''">{{ downloadItem || startingDownload ? 'downloading' : 'download' }}</span>
+              <span class="material-symbols text-2xl" :class="downloadItem || startingDownload ? 'animate-pulse' : ''">{{ downloadItem || startingDownload ? 'downloading' : localCopyIsOutdated ? 'sync' : 'download' }}</span>
             </ui-btn>
             <ui-btn color="primary" class="flex items-center justify-center mx-1" :padding-x="2" @click="moreButtonPress">
               <span class="material-symbols text-2xl">more_vert</span>
@@ -248,6 +248,22 @@ export default {
     },
     localLibraryItemId() {
       return this.localLibraryItem?.id || null
+    },
+    localCopyIsOutdated() {
+      // Downloaded copy is missing audio tracks the server item has. Happens
+      // when tracks are added to an item after it was downloaded, and when a
+      // download only partly completed: the local copy plays what it has and
+      // offers no way to fetch the rest, while this page lists the server's
+      // tracks - visible and unplayable.
+      if (this.isPodcast || this.isLocal || !this.localLibraryItem) return false
+      return this.localTrackCount > 0 && this.numTracks > this.localTrackCount
+    },
+    localTrackCount() {
+      return this.localLibraryItem?.media?.tracks?.length || 0
+    },
+    missingTrackCount() {
+      if (!this.localCopyIsOutdated) return 0
+      return this.numTracks - this.localTrackCount
     },
     localLibraryItemEpisodes() {
       if (!this.isPodcast || !this.localLibraryItem) return []
@@ -449,7 +465,8 @@ export default {
       return this.ebookFile
     },
     showDownload() {
-      if (this.isPodcast || this.hasLocal) return false
+      if (this.isPodcast) return false
+      if (this.hasLocal && !this.localCopyIsOutdated) return false
       return this.user && this.userCanDownload && (this.showPlay || this.showRead)
     },
     libraryFiles() {
@@ -632,6 +649,12 @@ export default {
     async download(selectedLocalFolder = null) {
       // Get the local folder to download to
       let localFolder = selectedLocalFolder
+      if (!localFolder && this.localCopyIsOutdated) {
+        // Updating a copy that already exists: put it back where it lives,
+        // rather than asking again and risking a second copy elsewhere.
+        const localFolders = (await this.$db.getLocalFolders()) || []
+        localFolder = localFolders.find((lf) => lf.id === this.localLibraryItem.folderId) || null
+      }
       if (!localFolder) {
         const localFolders = (await this.$db.getLocalFolders()) || []
         console.log('Local folders loaded', localFolders.length)
@@ -662,7 +685,9 @@ export default {
 
       console.log('Local folder', JSON.stringify(localFolder))
       let startDownloadMessage = `Start download for "${this.title}" with ${this.numTracks} audio track${this.numTracks == 1 ? '' : 's'} to folder ${localFolder.name}?`
-      if (!this.isIos && this.showRead) {
+      if (this.localCopyIsOutdated) {
+        startDownloadMessage = `"${this.title}" has ${this.missingTrackCount} more audio track${this.missingTrackCount == 1 ? '' : 's'} on the server than the copy in ${localFolder.name}. Update the download?`
+      } else if (!this.isIos && this.showRead) {
         if (this.numTracks > 0) {
           startDownloadMessage = `Start download for "${this.title}" with ${this.numTracks} audio track${this.numTracks == 1 ? '' : 's'} and ebook file to folder ${localFolder.name}?`
         } else {


### PR DESCRIPTION
## Problem

A downloaded book never learns that its server item gained tracks.

`showDownload()` returns `false` whenever `hasLocal` is true, so once a local copy exists the download button is gone and there is no other action that fetches the missing files. Meanwhile the item page keeps listing the **server** item's tracks with a LOCAL badge, and playback prefers the local copy — so the new track is visible in the UI and silently absent from the audio. The only way out is to delete the local copy and download the whole item again, which is not discoverable and re-fetches everything.

Two ways to hit this:

- **Tracks added to an existing item.** Anything appended to a book folder after it was downloaded (a missing part that arrives later, a re-encode split into more files, or — my case — a library item that is written to incrementally).
- **A download that only partly completed.** The local copy holds what it got, plays it, and offers no way to fetch the rest.

Related: #525 is the same shape for chapters (server updates, local copy keeps the old ones), and #1362 asks for the local folder to be reconciled with the server.

## What this PR does

Client-side only, `pages/item/_id/index.vue`, no changes to the downloader or the scanner:

- `localCopyIsOutdated` — true when the local copy has fewer audio tracks than the server item (books only; podcasts already download per episode and are excluded).
- `showDownload()` offers the button again in exactly that case, with a `sync` icon instead of `download` so it does not read as a duplicate download.
- The confirm dialog says what will happen: *"X" has N more audio tracks on the server than the copy in <folder>. Update the download?*
- The update goes back to the folder the existing copy is in (`localLibraryItem.folderId`) rather than prompting again, so it cannot land a second copy in a different folder.

The download path itself is unchanged and already does the right thing: `FolderScanner.scanDownloadItem` looks up `local_<libraryItemId>` and reuses it, so this updates the existing local item rather than creating a duplicate, and `setAudioTracks` renumbers and re-offsets the merged result.

## What it deliberately does not do

It re-downloads every track, not just the missing ones. Skipping files already on disk is exactly what #1898 implements in `DownloadItemManager`, and the two compose: with that PR merged, this button becomes an incremental update for free, since parts already on disk complete immediately and the scan still sees the full set. I kept this one to the UI so the two do not overlap.

## Testing

**Builds clean** — `build-apk.yml` on this branch: `npm ci`, `npm run generate`, `npx cap sync`, `gradlew assembleDebug`, APK uploaded, all green.

**Run on a device** (see the comment below): a two-track item downloaded to Internal App Storage, a third track added on the server, and the `sync` button appeared and completed the update. Done on **v0.13.0-beta**, because a master build cannot download anything at all (#1970) and so never reaches this code.

What I did verify beyond the build:

- The server-side behaviour it responds to, measured against Audiobookshelf 2.35.1: appending a file to a book folder keeps the same item id, appends the track at the right offset, leaves existing files' `ino`, index and mtime untouched, and preserves the listener's position (stored in seconds). So "the local copy is behind" is a real state a server can be in, not a hypothetical.
- The code paths by reading: `showDownload`, `download()`'s folder resolution, `AbsDownloader.downloadLibraryItem` → `startLibraryItemDownload`, and `FolderScanner.scanDownloadItem`/`scanParts`.
- The branch table, by running the four computed properties as plain functions over nine cases: not downloaded, downloaded and current, item grew, partial download, local copy somehow ahead, ebook-only with no tracks, podcast, viewing the local item page, and a user without download permission.

If you would rather this arrived as an issue with the analysis and no patch, say so and I will close it — the finding is worth more than the diff.
