### PR TITLE
Fix username whitespace on login

### DIFF
--- a/components/connection/ServerConnectForm.vue
+++ b/components/connection/ServerConnectForm.vue
@@ -639,7 +639,7 @@ export default {
         'x-return-tokens': 'true',
         ...(this.serverConfig.customHeaders || {})
       }
-      return this.postRequest(`${this.serverConfig.address}/login`, { username: this.serverConfig.username, password: this.password || '' }, headers, 20000)
+      return this.postRequest(`${this.serverConfig.address}/login`, { username: this.serverConfig.username.trim(), password: this.password || '' }, headers, 20000)
         .then((data) => {
           if (!data.user) {
             console.error(data.error)


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Trims leading and trailing whitespace from the username before sending the login request. This prevents login failures when a username is entered with accidental spaces.

## Which issue is fixed?

Fixes #1900

## Pull Request
Android frontend bug fix.

## In-depth Description

The login request previously used the username exactly as entered by the user. If the username contained a leading or trailing space, authentication could fail.

This change applies `trim()` to the username before sending the login request. The password is not modified.


## How have you tested this?

Verified that the login request now uses the trimmed username and confirmed that no other files were changed.


## Screenshots

Not applicable. This change does not modify the user interface.
