### PR TITLE
feat(android): continuous playback for downloaded series and collections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Audiobookshelf mobile app built with **NuxtJS 2** (SSR disabled, static target) and **Capacitor 7**, sharing one JS codebase across Android and iOS. Requires a running Audiobookshelf server to connect to.
+
+## Development Commands
+
+```bash
+npm install                  # install dependencies
+npm run generate             # build static web app into dist/
+npx cap sync                 # copy dist/ into android/ios native shells
+npm run sync                 # shortcut: generate + cap sync (use after JS changes)
+npm run dev                  # local web dev server at http://0.0.0.0:1337
+npx cap open android         # open Android Studio
+npx cap open ios             # open Xcode
+npm run devlive              # live reload via ionic cap run on connected device
+```
+
+There are no automated tests in this project.
+
+## Architecture
+
+### Two-layer structure
+
+**JS Layer (NuxtJS)** → compiled to `dist/` → synced into native shells via Capacitor.
+
+**Native Layer (Android/Kotlin)** in `android/app/src/main/java/com/audiobookshelf/app/`.
+
+### Custom Capacitor Plugins
+
+The bridge between JS and native is five custom Capacitor plugins. Each has a JS counterpart in `plugins/capacitor/` and a Kotlin implementation in `android/.../plugins/`:
+
+| Plugin | Purpose |
+|---|---|
+| `AbsAudioPlayer` | Audio playback control, cast, sleep timer |
+| `AbsDatabase` | Local SQLite DB, device data, download progress |
+| `AbsDownloader` | File download management |
+| `AbsFileSystem` | File system access, folder scanning |
+| `AbsLogger` | Native log capture |
+
+**JS → Native**: Call plugin methods directly, e.g. `AbsAudioPlayer.prepareLibraryItem({...})`.
+**Native → JS**: Use Capacitor's `notifyListeners()` on the native side and `addListener()` on the JS side.
+
+### Android Native Key Files
+
+- `MainActivity.kt` — `BridgeActivity` subclass; registers all plugins; binds `PlayerNotificationService` on `onPostCreate` and wires it to `AbsAudioPlayer` via `pluginCallback`.
+- `player/PlayerNotificationService.kt` — `MediaBrowserServiceCompat` foreground service; owns ExoPlayer instance; implements `ClientEventEmitter` interface to push events back to `AbsAudioPlayer.kt`.
+- `player/CastManager.kt` / `CastPlayer.kt` — Google Cast support.
+- `media/MediaManager.kt` — Caches library items, authors, series, collections, and podcast data for Android Auto / media browser.
+- `media/MediaProgressSyncer.kt` — Syncs playback progress with the server.
+- `managers/DbManager.kt` — SQLite wrapper for local library items and progress.
+- `managers/SleepTimerManager.kt` — Sleep timer logic.
+- `server/ApiHandler.kt` — All REST API calls to the ABS server.
+
+### JS Layer Key Files
+
+- `plugins/server.js` — `ServerSocket` class (socket.io); injected as `$socket`; handles authentication and real-time events from server.
+- `plugins/db.js` — `DbService`; thin wrapper around `AbsDatabase`; injected as `$db`; also listens for `onTokenRefresh` / `onTokenRefreshFailure` events.
+- `plugins/localStore.js` — `LocalStorage` class backed by Capacitor `Preferences`; injected as `$localStore`; persists user settings, theme, language, last library.
+- `plugins/init.client.js` — Registers global Vue utilities (`$eventBus`, date/time helpers, `$bytesPretty`, `$elapsedPretty`, etc.); handles back-button behavior for Android and iOS swipe navigation.
+- `plugins/capacitor/AbsAudioPlayer.js` — Web fallback implementation of `AbsAudioPlayer` using the HTML5 `<audio>` element; used during browser-based development.
+
+### Vuex Store
+
+- `store/index.js` — Global state: network status, current playback session, player playing/fullscreen state, cast availability, playlist queue.
+- `store/user.js` — Auth token, server connection config, user object (permissions, media progress, bookmarks), user settings.
+- `store/libraries.js` — Library list, current library ID, filter data.
+- `store/globals.js` — Modal open state and other UI globals.
+
+### Playlist Queue
+
+Podcast playlist playback is coordinated entirely in the JS layer. `store/index.js` holds `playlistQueue: { playlistId, items, currentIndex }`. When an episode ends, `AudioPlayer.vue` receives the `ENDED` `onMetadata` event and emits `playback-ended` on `$eventBus`. `AudioPlayerContainer.vue` handles this by advancing `currentIndex` and emitting `play-item` for the next episode.
+
+**Background playback gotcha**: `AbsAudioPlayer.kt` suppresses `onMetadata` events while the app is backgrounded (`isInForeground == false`) to avoid flooding the WebView. The `ENDED` state is explicitly exempted from this suppression so that playlist advancement works when the screen is off or the app is minimized. Do not remove this exemption.
+
+### Communication Patterns
+
+- **Server REST API**: `$axios` (configured in `plugins/axios.js`); base URL is the connected server address.
+- **Real-time updates**: socket.io via `$socket`; socket must be authenticated with `auth` event after connection.
+- **Playback events**: flow from `PlayerNotificationService` → `AbsAudioPlayer.kt` (via `ClientEventEmitter`) → `notifyListeners()` → JS `addListener()` handlers → Vuex mutations.
+
+### i18n
+
+Translation strings live in `strings/<locale>.json`. Applied via `plugins/i18n.js`. Language preference is persisted with `$localStore.setLanguage()`.
+
+### Styling
+
+Tailwind CSS 3 with PostCSS. Global styles in `assets/app.css` and `assets/tailwind.css`. The `tailwind.config.js` controls customization.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
@@ -145,6 +145,7 @@ class PlayerListener(var playerNotificationService:PlayerNotificationService) : 
         playerNotificationService.sendClientMetadata(PlayerState.ENDED)
 
         playerNotificationService.handlePlaybackEnded()
+        playerNotificationService.advancePlaylistQueue()
       }
       if (playerNotificationService.currentPlayer.playbackState == Player.STATE_IDLE) {
         Log.d(tag, "STATE_IDLE")

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
@@ -141,7 +141,7 @@ class PlayerListener(var playerNotificationService:PlayerNotificationService) : 
         playerNotificationService.sendClientMetadata(PlayerState.BUFFERING)
       }
       if (playerNotificationService.currentPlayer.playbackState == Player.STATE_ENDED) {
-        Log.d(tag, "STATE_ENDED")
+        Log.d(tag, "STATE_ENDED | playlistQueueSize=${playerNotificationService.playlistQueue.size} | playlistQueueIndex=${playerNotificationService.playlistQueueIndex}")
         playerNotificationService.sendClientMetadata(PlayerState.ENDED)
 
         playerNotificationService.handlePlaybackEnded()

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationListener.kt
@@ -18,19 +18,26 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
     notification: Notification,
     onGoing: Boolean) {
 
-    // Keep foreground service alive when a playlist queue is active (e.g. between episodes)
+    // Keep foreground service alive when a playlist queue is active AND the player
+    // intends to continue playing (playWhenReady is true).  When the player is
+    // paused — whether by Bluetooth disconnect (ACTION_AUDIO_BECOMING_NOISY),
+    // user pause, or any other reason — playWhenReady is false and we must NOT
+    // re-assert foreground, because doing so can interfere with the pause on
+    // some devices (Samsung One UI, Android 12+) or prevent the system from
+    // properly demoting the service after an audio-route change.
     val hasPlaylistQueue = playerNotificationService.playlistQueue.isNotEmpty()
-    val effectiveOnGoing = onGoing || hasPlaylistQueue
+    val playerWantsToPlay = playerNotificationService.currentPlayer.playWhenReady
+    val effectiveOnGoing = onGoing || (hasPlaylistQueue && playerWantsToPlay)
 
     if (effectiveOnGoing) {
       if (!isForegroundService) {
         // Start foreground service for the first time
-        Log.d(tag, "Notification Posted $notificationId - Start Foreground | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue")
+        Log.d(tag, "Notification Posted $notificationId - Start Foreground | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue playWhenReady=$playerWantsToPlay")
         PlayerNotificationService.isClosed = false
-      } else if (!onGoing && hasPlaylistQueue) {
-        // Player stopped but playlist queue active: re-assert foreground to prevent system from
-        // downgrading the service (Android 12+ may demote non-ongoing foreground services)
-        Log.d(tag, "Notification Posted $notificationId - Re-assert Foreground for playlist queue | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue")
+      } else if (!onGoing && hasPlaylistQueue && playerWantsToPlay) {
+        // Player not actively playing but intends to continue (e.g. between episodes):
+        // re-assert foreground to prevent system from downgrading the service
+        Log.d(tag, "Notification Posted $notificationId - Re-assert Foreground for playlist queue | onGoing=$onGoing hasPlaylistQueue=$hasPlaylistQueue playWhenReady=$playerWantsToPlay")
       } else {
         // Already in foreground and ongoing - just update the notification
         return
@@ -43,7 +50,7 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
       }
       isForegroundService = true
     } else {
-      Log.d(tag, "Notification posted $notificationId, not starting foreground - onGoing=$onGoing | hasPlaylistQueue=$hasPlaylistQueue | isForegroundService=$isForegroundService")
+      Log.d(tag, "Notification posted $notificationId, not starting foreground - onGoing=$onGoing | hasPlaylistQueue=$hasPlaylistQueue | playWhenReady=$playerWantsToPlay | isForegroundService=$isForegroundService")
     }
   }
 
@@ -54,11 +61,15 @@ class PlayerNotificationListener(var playerNotificationService:PlayerNotificatio
     val hasPlaylistQueue = playerNotificationService.playlistQueue.isNotEmpty()
 
     if (dismissedByUser) {
-      if (hasPlaylistQueue) {
-        Log.d(tag, "onNotificationCancelled dismissed by user but playlist queue active - keeping service alive")
+      // Only keep the service alive if the player actually intends to continue
+      // playing (e.g. between episodes).  If the user paused and then dismissed,
+      // or if Bluetooth disconnected (playWhenReady == false), allow the stop.
+      val playerWantsToPlay = playerNotificationService.currentPlayer.playWhenReady
+      if (hasPlaylistQueue && playerWantsToPlay) {
+        Log.d(tag, "onNotificationCancelled dismissed by user but playlist queue active and playWhenReady - keeping service alive")
         return
       }
-      Log.d(tag, "onNotificationCancelled dismissed by user")
+      Log.d(tag, "onNotificationCancelled dismissed by user | hasPlaylistQueue=$hasPlaylistQueue | playWhenReady=$playerWantsToPlay")
       playerNotificationService.stopSelf()
     } else {
       Log.d(tag, "onNotificationCancelled not dismissed by user | hasPlaylistQueue=$hasPlaylistQueue")

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -126,6 +126,11 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
 
   private var isAndroidAuto = false
 
+  // Playlist queue for native background advancement (bypasses WebView/JS layer)
+  data class PlaylistQueueItem(val libraryItemId: String, val episodeId: String?)
+  var playlistQueue: List<PlaylistQueueItem> = emptyList()
+  var playlistQueueIndex: Int = -1
+
   // The following are used for the shake detection
   private var isShakeSensorRegistered: Boolean = false
   private var mSensorManager: SensorManager? = null
@@ -662,6 +667,53 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                 Handler(Looper.getMainLooper()).post { preparePlayer(it, true, playbackRate) }
               }
             }
+          }
+        }
+      }
+    }
+  }
+
+  fun advancePlaylistQueue() {
+    if (playlistQueue.isEmpty()) return
+    val nextIndex = playlistQueueIndex + 1
+    if (nextIndex >= playlistQueue.size) {
+      Log.d(tag, "advancePlaylistQueue: end of queue")
+      playlistQueue = emptyList()
+      playlistQueueIndex = -1
+      return
+    }
+    playlistQueueIndex = nextIndex
+    val nextItem = playlistQueue[nextIndex]
+    Log.d(tag, "advancePlaylistQueue: advancing to index $nextIndex, libraryItemId=${nextItem.libraryItemId}")
+    val playbackRate = initialPlaybackRate ?: 1f
+
+    if (nextItem.libraryItemId.startsWith("local")) {
+      val localItem = DeviceManager.dbManager.getLocalLibraryItem(nextItem.libraryItemId)
+      if (localItem == null) {
+        Log.e(tag, "advancePlaylistQueue: Local library item not found ${nextItem.libraryItemId}")
+        return
+      }
+      var episode: PodcastEpisode? = null
+      if (!nextItem.episodeId.isNullOrEmpty()) {
+        val podcastMedia = localItem.media as? Podcast
+        episode = podcastMedia?.episodes?.find { ep -> ep.id == nextItem.episodeId }
+        if (episode == null) {
+          Log.e(tag, "advancePlaylistQueue: Local podcast episode not found ${nextItem.episodeId}")
+          return
+        }
+      }
+      val playbackSession = localItem.getPlaybackSession(episode, getDeviceInfo())
+      PlayerListener.lazyIsPlaying = false
+      preparePlayer(playbackSession, true, playbackRate)
+    } else {
+      val playItemRequestPayload = getPlayItemRequestPayload(false)
+      mediaProgressSyncer.stop {
+        apiHandler.playLibraryItem(nextItem.libraryItemId, nextItem.episodeId ?: "", playItemRequestPayload) { session ->
+          if (session == null) {
+            Log.e(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId}")
+          } else {
+            PlayerListener.lazyIsPlaying = false
+            Handler(Looper.getMainLooper()).post { preparePlayer(session, true, playbackRate) }
           }
         }
       }

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -10,6 +10,7 @@ import android.graphics.ImageDecoder
 import android.hardware.Sensor
 import android.hardware.SensorManager
 import android.net.*
+import android.net.wifi.WifiManager
 import android.os.*
 import android.os.PowerManager
 import android.provider.MediaStore
@@ -220,8 +221,14 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   // removing service when user swipe out our app
   override fun onTaskRemoved(rootIntent: Intent?) {
     super.onTaskRemoved(rootIntent)
-    Log.d(tag, "onTaskRemoved")
 
+    val isPlaying = try { currentPlayer.isPlaying } catch (e: Exception) { false }
+    if (playlistQueue.isNotEmpty() || isPlaying) {
+      Log.d(tag, "onTaskRemoved: keeping service alive (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying)")
+      return
+    }
+
+    Log.d(tag, "onTaskRemoved: stopping service")
     stopSelf()
   }
 
@@ -676,25 +683,30 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   }
 
   fun advancePlaylistQueue() {
-    if (playlistQueue.isEmpty()) return
+    Log.d(tag, "advancePlaylistQueue: called with queueSize=${playlistQueue.size}, currentIndex=$playlistQueueIndex")
+    if (playlistQueue.isEmpty()) {
+      Log.d(tag, "advancePlaylistQueue: queue is empty, nothing to do")
+      return
+    }
     val nextIndex = playlistQueueIndex + 1
     if (nextIndex >= playlistQueue.size) {
-      Log.d(tag, "advancePlaylistQueue: end of queue")
+      Log.d(tag, "advancePlaylistQueue: end of queue (nextIndex=$nextIndex >= size=${playlistQueue.size})")
       playlistQueue = emptyList()
       playlistQueueIndex = -1
       return
     }
     playlistQueueIndex = nextIndex
     val nextItem = playlistQueue[nextIndex]
-    Log.d(tag, "advancePlaylistQueue: advancing to index $nextIndex, libraryItemId=${nextItem.libraryItemId}")
+    Log.d(tag, "advancePlaylistQueue: advancing to index $nextIndex, libraryItemId=${nextItem.libraryItemId}, episodeId=${nextItem.episodeId}")
     val playbackRate = initialPlaybackRate ?: 1f
 
     // Acquire a temporary WakeLock to keep the CPU alive during playlist advancement
     val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
     val wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "audiobookshelf:playlistAdvance")
-    wakeLock.acquire(30_000L) // 30 second timeout
+    wakeLock.acquire(60_000L) // 60 second timeout
 
     if (nextItem.libraryItemId.startsWith("local")) {
+      Log.d(tag, "advancePlaylistQueue: loading local item ${nextItem.libraryItemId}")
       val localItem = DeviceManager.dbManager.getLocalLibraryItem(nextItem.libraryItemId)
       if (localItem == null) {
         Log.e(tag, "advancePlaylistQueue: Local library item not found ${nextItem.libraryItemId}")
@@ -712,32 +724,51 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         }
       }
       val playbackSession = localItem.getPlaybackSession(episode, getDeviceInfo())
+      Log.d(tag, "advancePlaylistQueue: local session ready, calling preparePlayer")
       PlayerListener.lazyIsPlaying = false
       preparePlayer(playbackSession, true, playbackRate)
       if (wakeLock.isHeld) wakeLock.release()
     } else {
-      advancePlaylistQueueServerItem(nextItem, playbackRate, wakeLock, 0)
+      Log.d(tag, "advancePlaylistQueue: requesting server item ${nextItem.libraryItemId}")
+      // Acquire WiFi lock for server items to keep network alive during API call
+      val wifiManager = applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+      @Suppress("DEPRECATION")
+      val wifiLock = wifiManager.createWifiLock(WifiManager.WIFI_MODE_FULL_HIGH_PERF, "audiobookshelf:playlistAdvance")
+      wifiLock.acquire()
+
+      // Stop progress syncer fire-and-forget (don't block on callback)
+      mediaProgressSyncer.stop {
+        Log.d(tag, "advancePlaylistQueue: mediaProgressSyncer stopped (fire-and-forget)")
+      }
+
+      // Immediately request next item from server without waiting for sync to complete
+      advancePlaylistQueueServerItem(nextItem, playbackRate, wakeLock, wifiLock, 0)
     }
   }
 
-  private fun advancePlaylistQueueServerItem(nextItem: PlaylistQueueItem, playbackRate: Float, wakeLock: PowerManager.WakeLock, retryCount: Int) {
+  private fun advancePlaylistQueueServerItem(nextItem: PlaylistQueueItem, playbackRate: Float, wakeLock: PowerManager.WakeLock, wifiLock: WifiManager.WifiLock, retryCount: Int) {
+    Log.d(tag, "advancePlaylistQueueServerItem: libraryItemId=${nextItem.libraryItemId}, episodeId=${nextItem.episodeId}, retry=$retryCount")
     val playItemRequestPayload = getPlayItemRequestPayload(false)
-    mediaProgressSyncer.stop {
-      apiHandler.playLibraryItem(nextItem.libraryItemId, nextItem.episodeId ?: "", playItemRequestPayload) { session ->
-        if (session == null && retryCount < 2) {
-          val delay = (retryCount + 1) * 2000L
-          Log.w(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId}, retrying in ${delay}ms (attempt ${retryCount + 1}/2)")
-          Handler(Looper.getMainLooper()).postDelayed({
-            advancePlaylistQueueServerItem(nextItem, playbackRate, wakeLock, retryCount + 1)
-          }, delay)
-        } else if (session != null) {
-          PlayerListener.lazyIsPlaying = false
-          Handler(Looper.getMainLooper()).post { preparePlayer(session, true, playbackRate) }
-          if (wakeLock.isHeld) wakeLock.release()
-        } else {
-          Log.e(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId} after ${retryCount + 1} attempts")
-          if (wakeLock.isHeld) wakeLock.release()
+    apiHandler.playLibraryItem(nextItem.libraryItemId, nextItem.episodeId ?: "", playItemRequestPayload) { session ->
+      if (session == null && retryCount < 3) {
+        val delay = (retryCount + 1) * 2000L
+        Log.w(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId}, retrying in ${delay}ms (attempt ${retryCount + 1}/3)")
+        Handler(Looper.getMainLooper()).postDelayed({
+          advancePlaylistQueueServerItem(nextItem, playbackRate, wakeLock, wifiLock, retryCount + 1)
+        }, delay)
+      } else if (session != null) {
+        Log.d(tag, "advancePlaylistQueue: Got server session, calling preparePlayer for ${nextItem.libraryItemId}")
+        PlayerListener.lazyIsPlaying = false
+        Handler(Looper.getMainLooper()).post {
+          preparePlayer(session, true, playbackRate)
+          Log.d(tag, "advancePlaylistQueue: preparePlayer called successfully")
         }
+        if (wifiLock.isHeld) wifiLock.release()
+        if (wakeLock.isHeld) wakeLock.release()
+      } else {
+        Log.e(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId} after ${retryCount + 1} attempts, giving up")
+        if (wifiLock.isHeld) wifiLock.release()
+        if (wakeLock.isHeld) wakeLock.release()
       }
     }
   }

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -11,6 +11,7 @@ import android.hardware.Sensor
 import android.hardware.SensorManager
 import android.net.*
 import android.os.*
+import android.os.PowerManager
 import android.provider.MediaStore
 import android.provider.Settings
 import android.support.v4.media.MediaBrowserCompat
@@ -407,6 +408,7 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                     .setSeekBackIncrementMs(deviceSettings.jumpBackwardsTimeMs)
                     .setSeekForwardIncrementMs(deviceSettings.jumpForwardTimeMs)
                     .build()
+    mPlayer.setWakeMode(C.WAKE_MODE_NETWORK)
     mPlayer.setHandleAudioBecomingNoisy(true)
     mPlayer.addListener(PlayerListener(this))
     val audioAttributes: AudioAttributes =
@@ -687,10 +689,16 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     Log.d(tag, "advancePlaylistQueue: advancing to index $nextIndex, libraryItemId=${nextItem.libraryItemId}")
     val playbackRate = initialPlaybackRate ?: 1f
 
+    // Acquire a temporary WakeLock to keep the CPU alive during playlist advancement
+    val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+    val wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "audiobookshelf:playlistAdvance")
+    wakeLock.acquire(30_000L) // 30 second timeout
+
     if (nextItem.libraryItemId.startsWith("local")) {
       val localItem = DeviceManager.dbManager.getLocalLibraryItem(nextItem.libraryItemId)
       if (localItem == null) {
         Log.e(tag, "advancePlaylistQueue: Local library item not found ${nextItem.libraryItemId}")
+        if (wakeLock.isHeld) wakeLock.release()
         return
       }
       var episode: PodcastEpisode? = null
@@ -699,22 +707,36 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         episode = podcastMedia?.episodes?.find { ep -> ep.id == nextItem.episodeId }
         if (episode == null) {
           Log.e(tag, "advancePlaylistQueue: Local podcast episode not found ${nextItem.episodeId}")
+          if (wakeLock.isHeld) wakeLock.release()
           return
         }
       }
       val playbackSession = localItem.getPlaybackSession(episode, getDeviceInfo())
       PlayerListener.lazyIsPlaying = false
       preparePlayer(playbackSession, true, playbackRate)
+      if (wakeLock.isHeld) wakeLock.release()
     } else {
-      val playItemRequestPayload = getPlayItemRequestPayload(false)
-      mediaProgressSyncer.stop {
-        apiHandler.playLibraryItem(nextItem.libraryItemId, nextItem.episodeId ?: "", playItemRequestPayload) { session ->
-          if (session == null) {
-            Log.e(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId}")
-          } else {
-            PlayerListener.lazyIsPlaying = false
-            Handler(Looper.getMainLooper()).post { preparePlayer(session, true, playbackRate) }
-          }
+      advancePlaylistQueueServerItem(nextItem, playbackRate, wakeLock, 0)
+    }
+  }
+
+  private fun advancePlaylistQueueServerItem(nextItem: PlaylistQueueItem, playbackRate: Float, wakeLock: PowerManager.WakeLock, retryCount: Int) {
+    val playItemRequestPayload = getPlayItemRequestPayload(false)
+    mediaProgressSyncer.stop {
+      apiHandler.playLibraryItem(nextItem.libraryItemId, nextItem.episodeId ?: "", playItemRequestPayload) { session ->
+        if (session == null && retryCount < 2) {
+          val delay = (retryCount + 1) * 2000L
+          Log.w(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId}, retrying in ${delay}ms (attempt ${retryCount + 1}/2)")
+          Handler(Looper.getMainLooper()).postDelayed({
+            advancePlaylistQueueServerItem(nextItem, playbackRate, wakeLock, retryCount + 1)
+          }, delay)
+        } else if (session != null) {
+          PlayerListener.lazyIsPlaying = false
+          Handler(Looper.getMainLooper()).post { preparePlayer(session, true, playbackRate) }
+          if (wakeLock.isHeld) wakeLock.release()
+        } else {
+          Log.e(tag, "advancePlaylistQueue: Server play request failed for ${nextItem.libraryItemId} after ${retryCount + 1} attempts")
+          if (wakeLock.isHeld) wakeLock.release()
         }
       }
     }

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -483,6 +483,14 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
           playWhenReady: Boolean,
           playbackRate: Float?
   ) {
+    // Native playback entry points (for example Android Auto) can bypass the JS queue setup.
+    val queuedItem = playlistQueue.getOrNull(playlistQueueIndex)
+    val sessionItemId = playbackSession.localLibraryItem?.id ?: playbackSession.libraryItemId
+    val sessionEpisodeId = if (playbackSession.isLocal) playbackSession.localEpisodeId else playbackSession.episodeId
+    if (queuedItem != null && (queuedItem.libraryItemId != sessionItemId || queuedItem.episodeId != sessionEpisodeId)) {
+      playlistQueue = emptyList()
+      playlistQueueIndex = -1
+    }
     if (!isStarted) {
       Log.i(tag, "preparePlayer: foreground service not started - Starting service --")
       Intent(ctx, PlayerNotificationService::class.java).also { intent ->
@@ -754,6 +762,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
       val localItem = DeviceManager.dbManager.getLocalLibraryItem(nextItem.libraryItemId)
       if (localItem == null) {
         Log.e(tag, "advancePlaylistQueue: Local library item not found ${nextItem.libraryItemId}")
+        playlistQueue = emptyList()
+        playlistQueueIndex = -1
         if (wakeLock.isHeld) wakeLock.release()
         return
       }
@@ -766,6 +776,14 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
           if (wakeLock.isHeld) wakeLock.release()
           return
         }
+      }
+      // Downloads can be removed after queue setup. Never fall back to streaming.
+      if (localItem.mediaType == "book" && (localItem.isInvalid || !localItem.hasTracks(null))) {
+        Log.e(tag, "advancePlaylistQueue: Downloaded audiobook has no playable files")
+        playlistQueue = emptyList()
+        playlistQueueIndex = -1
+        if (wakeLock.isHeld) wakeLock.release()
+        return
       }
       val playbackSession = localItem.getPlaybackSession(episode, getDeviceInfo())
       Log.d(tag, "advancePlaylistQueue: local session ready, calling preparePlayer")
@@ -791,6 +809,11 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   }
 
   private fun advancePlaylistQueueServerItem(nextItem: PlaylistQueueItem, playbackRate: Float, wakeLock: PowerManager.WakeLock, wifiLock: WifiManager.WifiLock, retryCount: Int) {
+    if (playlistQueue.getOrNull(playlistQueueIndex) !== nextItem) {
+      if (wifiLock.isHeld) wifiLock.release()
+      if (wakeLock.isHeld) wakeLock.release()
+      return
+    }
     Log.d(tag, "advancePlaylistQueueServerItem: libraryItemId=${nextItem.libraryItemId}, episodeId=${nextItem.episodeId}, retry=$retryCount")
     val playItemRequestPayload = getPlayItemRequestPayload(false)
     apiHandler.playLibraryItem(nextItem.libraryItemId, nextItem.episodeId ?: "", playItemRequestPayload) { session ->
@@ -804,7 +827,7 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         Log.d(tag, "advancePlaylistQueue: Got server session, calling preparePlayer for ${nextItem.libraryItemId}")
         PlayerListener.lazyIsPlaying = false
         Handler(Looper.getMainLooper()).post {
-          preparePlayer(session, true, playbackRate)
+          if (playlistQueue.getOrNull(playlistQueueIndex) === nextItem) preparePlayer(session, true, playbackRate)
           Log.d(tag, "advancePlaylistQueue: preparePlayer called successfully")
         }
         if (wifiLock.isHeld) wifiLock.release()
@@ -1174,6 +1197,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   }
 
   fun closePlayback(calledOnError: Boolean? = false) {
+    playlistQueue = emptyList()
+    playlistQueueIndex = -1
     Log.d(tag, "closePlayback")
     val config = DeviceManager.serverConnectionConfig
 

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -2,8 +2,10 @@ package com.audiobookshelf.app.player
 
 import android.annotation.SuppressLint
 import android.app.*
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.ImageDecoder
@@ -113,6 +115,12 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   lateinit var currentPlayer: Player
   var castPlayer: CastPlayer? = null
 
+  // Defense-in-depth receiver for Bluetooth disconnect / headphone unplug.
+  // ExoPlayer's setHandleAudioBecomingNoisy(true) registers its own receiver,
+  // but on some devices (Samsung One UI, Android 12+) the foreground service
+  // re-assertion can interfere.  This explicit receiver ensures pause sticks.
+  private var audioNoisyReceiver: BroadcastReceiver? = null
+
   lateinit var sleepTimerManager: SleepTimerManager
   lateinit var mediaProgressSyncer: MediaProgressSyncer
 
@@ -203,6 +211,12 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
       Log.e(tag, "Error unregistering network listening callback $error")
     }
 
+    // Unregister the defense-in-depth AUDIO_BECOMING_NOISY receiver
+    audioNoisyReceiver?.let {
+      try { unregisterReceiver(it) } catch (_: Exception) {}
+      audioNoisyReceiver = null
+    }
+
     Log.d(tag, "onDestroy")
     isStarted = false
     isClosed = true
@@ -223,12 +237,17 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     super.onTaskRemoved(rootIntent)
 
     val isPlaying = try { currentPlayer.isPlaying } catch (e: Exception) { false }
-    if (playlistQueue.isNotEmpty() || isPlaying) {
-      Log.d(tag, "onTaskRemoved: keeping service alive (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying)")
+    val playerWantsToPlay = try { currentPlayer.playWhenReady } catch (e: Exception) { false }
+    // Only keep the service alive if the player is actively playing or if it
+    // intends to continue (playWhenReady == true with a playlist queue, i.e.
+    // between episodes).  When paused by Bluetooth disconnect or user action,
+    // playWhenReady is false and the service should be allowed to stop.
+    if (isPlaying || (playlistQueue.isNotEmpty() && playerWantsToPlay)) {
+      Log.d(tag, "onTaskRemoved: keeping service alive (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying, playWhenReady=$playerWantsToPlay)")
       return
     }
 
-    Log.d(tag, "onTaskRemoved: stopping service")
+    Log.d(tag, "onTaskRemoved: stopping service (playlistQueue=${playlistQueue.size}, isPlaying=$isPlaying, playWhenReady=$playerWantsToPlay)")
     stopSelf()
   }
 
@@ -424,6 +443,31 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                     .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
                     .build()
     mPlayer.setAudioAttributes(audioAttributes, true)
+
+    // Defense-in-depth: register an explicit receiver for audio route changes
+    // (Bluetooth disconnect, headphone unplug).  ExoPlayer's built-in handler
+    // should pause the player, but on some devices the foreground service
+    // lifecycle can interfere.  This receiver ensures the pause is authoritative.
+    audioNoisyReceiver?.let {
+      try { unregisterReceiver(it) } catch (_: Exception) {}
+    }
+    audioNoisyReceiver = object : BroadcastReceiver() {
+      override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent?.action == AudioManager.ACTION_AUDIO_BECOMING_NOISY) {
+          Log.d(tag, "ACTION_AUDIO_BECOMING_NOISY received — ensuring player is paused")
+          try {
+            if (mPlayer.playWhenReady) {
+              mPlayer.playWhenReady = false
+              Log.d(tag, "Forced playWhenReady=false on AUDIO_BECOMING_NOISY")
+            }
+          } catch (e: Exception) {
+            Log.e(tag, "Error handling AUDIO_BECOMING_NOISY: $e")
+          }
+        }
+      }
+    }
+    val noisyFilter = IntentFilter(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+    registerReceiver(audioNoisyReceiver, noisyFilter)
 
     // attach player to playerNotificationManager
     playerNotificationManager.setPlayer(mPlayer)

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -778,7 +778,7 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         }
       }
       // Downloads can be removed after queue setup. Never fall back to streaming.
-      if (localItem.mediaType == "book" && (localItem.isInvalid || !localItem.hasTracks(null))) {
+      if (localItem.mediaType == "book" && (localItem.isInvalid || !localItem.hasTracks(this, episode))) {
         Log.e(tag, "advancePlaylistQueue: Downloaded audiobook has no playable files")
         playlistQueue = emptyList()
         playlistQueueIndex = -1

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -63,8 +63,9 @@ class AbsAudioPlayer : Plugin() {
         }
 
         override fun onMetadata(metadata: PlaybackMetadata) {
-          // Skip frequent metadata updates when app is backgrounded to prevent event queue buildup
-          if (!isInForeground) return
+          // Skip frequent metadata updates when app is backgrounded to prevent event queue buildup,
+          // but always forward ENDED state so playlist queue advancement works in background
+          if (!isInForeground && metadata.playerState != PlayerState.ENDED) return
           notifyListeners("onMetadata", JSObject(jacksonMapper.writeValueAsString(metadata)))
         }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -454,6 +454,36 @@ class AbsAudioPlayer : Plugin() {
   }
 
   @PluginMethod
+  fun setPlaylistQueue(call: PluginCall) {
+    val items = call.getArray("items") ?: run { call.resolve(); return }
+    val currentIndex = call.getInt("currentIndex", 0) ?: 0
+    val queue = mutableListOf<PlayerNotificationService.PlaylistQueueItem>()
+    for (i in 0 until items.length()) {
+      val item = items.getJSONObject(i)
+      queue.add(PlayerNotificationService.PlaylistQueueItem(
+        libraryItemId = item.getString("libraryItemId"),
+        episodeId = if (item.has("episodeId") && !item.isNull("episodeId")) item.getString("episodeId") else null
+      ))
+    }
+    Handler(Looper.getMainLooper()).post {
+      playerNotificationService.playlistQueue = queue
+      playerNotificationService.playlistQueueIndex = currentIndex
+      Log.d(tag, "setPlaylistQueue: ${queue.size} items, currentIndex=$currentIndex")
+    }
+    call.resolve()
+  }
+
+  @PluginMethod
+  fun clearPlaylistQueue(call: PluginCall) {
+    Handler(Looper.getMainLooper()).post {
+      playerNotificationService.playlistQueue = emptyList()
+      playerNotificationService.playlistQueueIndex = -1
+      Log.d(tag, "clearPlaylistQueue: cleared")
+    }
+    call.resolve()
+  }
+
+  @PluginMethod
   fun getIsCastAvailable(call: PluginCall) {
     val jsobj = JSObject()
     jsobj.put("value", isCastAvailable)

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -469,8 +469,18 @@ class AbsAudioPlayer : Plugin() {
       playerNotificationService.playlistQueue = queue
       playerNotificationService.playlistQueueIndex = currentIndex
       Log.d(tag, "setPlaylistQueue: ${queue.size} items, currentIndex=$currentIndex")
+      call.resolve()
     }
-    call.resolve()
+  }
+
+  @PluginMethod
+  fun getPlaylistQueue(call: PluginCall) {
+    Handler(Looper.getMainLooper()).post {
+      val result = JSObject()
+      result.put("items", JSArray(jacksonMapper.writeValueAsString(playerNotificationService.playlistQueue)))
+      result.put("currentIndex", playerNotificationService.playlistQueueIndex)
+      call.resolve(result)
+    }
   }
 
   @PluginMethod
@@ -479,8 +489,8 @@ class AbsAudioPlayer : Plugin() {
       playerNotificationService.playlistQueue = emptyList()
       playerNotificationService.playlistQueueIndex = -1
       Log.d(tag, "clearPlaylistQueue: cleared")
+      call.resolve()
     }
-    call.resolve()
   }
 
   @PluginMethod

--- a/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/server/ApiHandler.kt
@@ -44,7 +44,11 @@ class ApiHandler(var ctx:Context) {
     }
   }
 
-  private var defaultClient = OkHttpClient()
+  private var defaultClient = OkHttpClient.Builder()
+    .connectTimeout(15, TimeUnit.SECONDS)
+    .readTimeout(15, TimeUnit.SECONDS)
+    .writeTimeout(15, TimeUnit.SECONDS)
+    .build()
   private var pingClient = OkHttpClient.Builder().callTimeout(3, TimeUnit.SECONDS).build()
   private var jacksonMapper = jacksonObjectMapper().enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
   private var secureStorage = SecureStorage(ctx)

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -870,6 +870,7 @@ export default {
 
       if (data.playerState === 'ENDED') {
         console.log('[AudioPlayer] Playback ended')
+        this.$eventBus.$emit('playback-ended')
       }
       this.isEnded = data.playerState === 'ENDED'
 

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -192,12 +192,56 @@ export default {
           this.$toast.error('Failed to play')
         })
     },
+    onPlaybackEnded() {
+      const playlistQueue = this.$store.state.playlistQueue
+      if (!playlistQueue) return
+
+      const { items, currentIndex } = playlistQueue
+      const nextIndex = currentIndex + 1
+      if (nextIndex >= items.length) {
+        this.$store.commit('clearPlaylistQueue')
+        return
+      }
+
+      const nextItem = items[nextIndex]
+      this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: nextIndex })
+      this.$store.commit('setPlayerIsStartingPlayback', nextItem.episodeId || nextItem.libraryItemId)
+      if (nextItem.localLibraryItem) {
+        this.$eventBus.$emit('play-item', {
+          libraryItemId: nextItem.localLibraryItem.id,
+          episodeId: nextItem.localEpisode?.id,
+          serverLibraryItemId: nextItem.libraryItemId,
+          serverEpisodeId: nextItem.episodeId,
+          fromPlaylistQueue: true
+        })
+      } else {
+        this.$eventBus.$emit('play-item', {
+          libraryItemId: nextItem.libraryItemId,
+          episodeId: nextItem.episodeId,
+          fromPlaylistQueue: true
+        })
+      }
+    },
     async playLibraryItem(payload) {
       await AbsLogger.info({ tag: 'AudioPlayerContainer', message: `playLibraryItem: Received play request for library item ${payload.libraryItemId} ${payload.episodeId ? `episode ${payload.episodeId}` : ''}` })
       const libraryItemId = payload.libraryItemId
       const episodeId = payload.episodeId
       const startTime = payload.startTime
       const startWhenReady = !payload.paused
+
+      if (!payload.fromPlaylistQueue) {
+        const playlistQueue = this.$store.state.playlistQueue
+        if (playlistQueue) {
+          const serverLibraryItemId = payload.serverLibraryItemId || (!libraryItemId?.startsWith('local') ? libraryItemId : null)
+          const serverEpisodeId = payload.serverEpisodeId || (!episodeId?.startsWith('local') ? episodeId : null)
+          const matchIndex = playlistQueue.items.findIndex((i) => i.libraryItemId === serverLibraryItemId && i.episodeId === serverEpisodeId)
+          if (matchIndex >= 0) {
+            this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: matchIndex })
+          } else {
+            this.$store.commit('clearPlaylistQueue')
+          }
+        }
+      }
 
       const isLocal = libraryItemId.startsWith('local')
       if (!isLocal) {
@@ -453,6 +497,7 @@ export default {
     this.$eventBus.$on('playback-time-update', this.playbackTimeUpdate)
     this.$eventBus.$on('device-focus-update', this.deviceFocused)
     this.$eventBus.$on('socket-reconnected', this.socketReconnected)
+    this.$eventBus.$on('playback-ended', this.onPlaybackEnded)
   },
   beforeDestroy() {
     this.onLocalMediaProgressUpdateListener?.remove()
@@ -469,6 +514,7 @@ export default {
     this.$eventBus.$off('playback-time-update', this.playbackTimeUpdate)
     this.$eventBus.$off('device-focus-update', this.deviceFocused)
     this.$eventBus.$off('socket-reconnected', this.socketReconnected)
+    this.$eventBus.$off('playback-ended', this.onPlaybackEnded)
   }
 }
 </script>

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -193,6 +193,9 @@ export default {
         })
     },
     onPlaybackEnded() {
+      // Native layer (PlayerNotificationService.advancePlaylistQueue) handles the actual
+      // playback advancement even when the screen is off or the app is backgrounded.
+      // This handler only keeps the Vuex state in sync for UI purposes.
       const playlistQueue = this.$store.state.playlistQueue
       if (!playlistQueue) return
 
@@ -200,27 +203,12 @@ export default {
       const nextIndex = currentIndex + 1
       if (nextIndex >= items.length) {
         this.$store.commit('clearPlaylistQueue')
+        AbsAudioPlayer.clearPlaylistQueue()
         return
       }
 
-      const nextItem = items[nextIndex]
+      // Advance Vuex index so the UI reflects the currently playing episode
       this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: nextIndex })
-      this.$store.commit('setPlayerIsStartingPlayback', nextItem.episodeId || nextItem.libraryItemId)
-      if (nextItem.localLibraryItem) {
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: nextItem.localLibraryItem.id,
-          episodeId: nextItem.localEpisode?.id,
-          serverLibraryItemId: nextItem.libraryItemId,
-          serverEpisodeId: nextItem.episodeId,
-          fromPlaylistQueue: true
-        })
-      } else {
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: nextItem.libraryItemId,
-          episodeId: nextItem.episodeId,
-          fromPlaylistQueue: true
-        })
-      }
     },
     async playLibraryItem(payload) {
       await AbsLogger.info({ tag: 'AudioPlayerContainer', message: `playLibraryItem: Received play request for library item ${payload.libraryItemId} ${payload.episodeId ? `episode ${payload.episodeId}` : ''}` })
@@ -239,6 +227,7 @@ export default {
             this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: matchIndex })
           } else {
             this.$store.commit('clearPlaylistQueue')
+            AbsAudioPlayer.clearPlaylistQueue()
           }
         }
       }

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -12,6 +12,7 @@
 import { AbsAudioPlayer, AbsLogger } from '@/plugins/capacitor'
 import { Dialog } from '@capacitor/dialog'
 import CellularPermissionHelpers from '@/mixins/cellularPermissionHelpers'
+import { nativeQueueItems, resolvePlaybackQueue } from '@/utils/playbackQueue'
 
 export default {
   data() {
@@ -19,6 +20,7 @@ export default {
       isReady: false,
       settingsLoaded: false,
       audioPlayerReady: false,
+      preparingPlayback: false,
       stream: null,
       download: null,
       showPlaybackSpeedModal: false,
@@ -51,6 +53,14 @@ export default {
     },
     currentPlaybackSession() {
       return this.$store.state.currentPlaybackSession
+    }
+  },
+  watch: {
+    currentPlaybackSession() {
+      // Sessions arrive on native advancement, including after background playback.
+      this.onPlaybackEnded()
+      this.serverLibraryItemId = this.currentPlaybackSession?.libraryItemId || null
+      this.serverEpisodeId = this.currentPlaybackSession?.episodeId || null
     }
   },
   methods: {
@@ -172,7 +182,9 @@ export default {
         this.playServerLibraryItemAndCast(this.serverLibraryItemId, this.serverEpisodeId)
       }
     },
-    playServerLibraryItemAndCast(libraryItemId, episodeId) {
+    async playServerLibraryItemAndCast(libraryItemId, episodeId) {
+      this.$store.commit('clearPlaybackQueue')
+      if (this.$platform === 'android') await AbsAudioPlayer.clearPlaylistQueue()
       var playbackRate = 1
       if (this.$refs.audioPlayer) {
         playbackRate = this.$refs.audioPlayer.currentPlaybackRate || 1
@@ -192,45 +204,45 @@ export default {
           this.$toast.error('Failed to play')
         })
     },
-    onPlaybackEnded() {
-      // Native layer (PlayerNotificationService.advancePlaylistQueue) handles the actual
-      // playback advancement even when the screen is off or the app is backgrounded.
-      // This handler only keeps the Vuex state in sync for UI purposes.
-      const playlistQueue = this.$store.state.playlistQueue
-      if (!playlistQueue) return
-
-      const { items, currentIndex } = playlistQueue
-      const nextIndex = currentIndex + 1
-      if (nextIndex >= items.length) {
-        this.$store.commit('clearPlaylistQueue')
-        AbsAudioPlayer.clearPlaylistQueue()
-        return
+    async onPlaybackEnded() {
+      const queue = this.$store.state.playbackQueue
+      if (!queue || this.$platform !== 'android') return
+      try {
+        const native = await AbsAudioPlayer.getPlaylistQueue()
+        // A newer play request must not be overwritten by an old bridge response.
+        if (this.$store.state.playbackQueue !== queue) return
+        if (!native.items.length) this.$store.commit('clearPlaybackQueue')
+        else if (native.items.length === queue.items.length && nativeQueueItems(queue.items).every((item, index) => item.libraryItemId === native.items[index].libraryItemId && item.episodeId === (native.items[index].episodeId || null))) {
+          this.$store.commit('setPlaybackQueue', { ...queue, currentIndex: native.currentIndex })
+        }
+      } catch (error) {
+        console.error('Failed to read playback queue', error)
       }
-
-      // Advance Vuex index so the UI reflects the currently playing episode
-      this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: nextIndex })
     },
     async playLibraryItem(payload) {
+      if (this.preparingPlayback) return
+      this.preparingPlayback = true
+      try {
+        // Explicit source context is required, even if the item also occurs in an old queue.
+        this.$store.commit('clearPlaybackQueue')
+        if (this.$platform === 'android') await AbsAudioPlayer.clearPlaylistQueue()
+        const resolved = await resolvePlaybackQueue(this, payload)
+        await this.startLibraryItem(resolved.payload, resolved.queue)
+      } catch (error) {
+        this.$store.commit('clearPlaybackQueue')
+        if (this.$platform === 'android') await AbsAudioPlayer.clearPlaylistQueue().catch((clearError) => console.error('Failed to clear playback queue', clearError))
+        this.$store.commit('setPlayerDoneStartingPlayback')
+        this.$toast.error(error.message || 'Failed to prepare playback queue')
+      } finally {
+        this.preparingPlayback = false
+      }
+    },
+    async startLibraryItem(payload, queue) {
       await AbsLogger.info({ tag: 'AudioPlayerContainer', message: `playLibraryItem: Received play request for library item ${payload.libraryItemId} ${payload.episodeId ? `episode ${payload.episodeId}` : ''}` })
       const libraryItemId = payload.libraryItemId
       const episodeId = payload.episodeId
       const startTime = payload.startTime
       const startWhenReady = !payload.paused
-
-      if (!payload.fromPlaylistQueue) {
-        const playlistQueue = this.$store.state.playlistQueue
-        if (playlistQueue) {
-          const serverLibraryItemId = payload.serverLibraryItemId || (!libraryItemId?.startsWith('local') ? libraryItemId : null)
-          const serverEpisodeId = payload.serverEpisodeId || (!episodeId?.startsWith('local') ? episodeId : null)
-          const matchIndex = playlistQueue.items.findIndex((i) => i.libraryItemId === serverLibraryItemId && i.episodeId === serverEpisodeId)
-          if (matchIndex >= 0) {
-            this.$store.commit('setPlaylistQueue', { ...playlistQueue, currentIndex: matchIndex })
-          } else {
-            this.$store.commit('clearPlaylistQueue')
-            AbsAudioPlayer.clearPlaylistQueue()
-          }
-        }
-      }
 
       const isLocal = libraryItemId.startsWith('local')
       if (!isLocal) {
@@ -257,6 +269,11 @@ export default {
         }
       }
 
+      if (queue) {
+        await AbsAudioPlayer.setPlaylistQueue({ items: nativeQueueItems(queue.items), currentIndex: queue.currentIndex })
+        this.$store.commit('setPlaybackQueue', queue)
+      }
+
       // if already playing this item then jump to start time
       if (this.$store.getters['getIsMediaStreaming'](libraryItemId, episodeId)) {
         console.log('Already streaming item', startTime)
@@ -281,9 +298,11 @@ export default {
       console.log('Called playLibraryItem', libraryItemId)
       const preparePayload = { libraryItemId, episodeId, playWhenReady: startWhenReady, playbackRate }
       if (startTime !== undefined && startTime !== null) preparePayload.startTime = startTime
-      AbsAudioPlayer.prepareLibraryItem(preparePayload)
+      return AbsAudioPlayer.prepareLibraryItem(preparePayload)
         .then((data) => {
           if (data.error) {
+            this.$store.commit('clearPlaybackQueue')
+            if (this.$platform === 'android') AbsAudioPlayer.clearPlaylistQueue()
             const errorMsg = data.error || 'Failed to play'
             this.$toast.error(errorMsg)
           } else {
@@ -301,6 +320,8 @@ export default {
           }
         })
         .catch((error) => {
+          this.$store.commit('clearPlaybackQueue')
+          if (this.$platform === 'android') AbsAudioPlayer.clearPlaylistQueue()
           console.error('Failed', error)
           this.$toast.error('Failed to play')
         })
@@ -436,6 +457,7 @@ export default {
      * if local item is open then fetch the server media progress and update if more recent
      */
     async deviceFocused(hasFocus) {
+      if (hasFocus) await this.onPlaybackEnded()
       if (!this.currentPlaybackSession || !hasFocus) return
       // dont update timestamps if player is playing
       if (this.$refs.audioPlayer?.isPlaying) return

--- a/components/cards/LazyBookCard.vue
+++ b/components/cards/LazyBookCard.vue
@@ -106,6 +106,7 @@ import { Capacitor } from '@capacitor/core'
 export default {
   props: {
     index: Number,
+    queueSource: Object,
     width: {
       type: Number,
       default: 120
@@ -410,8 +411,7 @@ export default {
       return this._libraryItem.rssFeed || null
     },
     showPlayButton() {
-      return false
-      // return !this.isMissing && !this.isInvalid && !this.isStreaming && (this.numTracks || this.recentEpisode)
+      return !!this.queueSource && !this.collapsedSeries && !this.isPodcast && !this.isMissing && !this.isInvalid && !!this.numTracks
     }
   },
   methods: {
@@ -453,7 +453,16 @@ export default {
       // Server books may have a local library item
       this.localLibraryItem = localLibraryItem
     },
-    async play() {},
+    async play() {
+      if (this.playerIsStartingPlayback || !this.queueSource) return
+      const eventBus = this.$eventBus || this.$nuxt.$eventBus
+      if (this.streamIsPlaying) {
+        eventBus.$emit('pause-item')
+        return
+      }
+      this.store.commit('setPlayerIsStartingPlayback', this.libraryItemId)
+      eventBus.$emit('play-item', { libraryItemId: this.libraryItemId, queueSource: this.queueSource })
+    },
     async playEpisode() {
       if (this.playerIsStartingPlayback) return
 

--- a/components/cards/LazyListBookCard.vue
+++ b/components/cards/LazyListBookCard.vue
@@ -53,6 +53,7 @@ import { Capacitor } from '@capacitor/core'
 export default {
   props: {
     index: Number,
+    queueSource: Object,
     width: {
       type: Number,
       default: 120
@@ -348,7 +349,7 @@ export default {
         }
 
         this.store.commit('setPlayerIsStartingPlayback', this.libraryItemId)
-        eventBus.$emit('play-item', { libraryItemId, serverLibraryItemId: this.libraryItemId })
+        eventBus.$emit('play-item', { libraryItemId, serverLibraryItemId: this.libraryItemId, queueSource: this.queueSource })
       }
     },
     destroy() {

--- a/components/home/BookshelfToolbar.vue
+++ b/components/home/BookshelfToolbar.vue
@@ -13,6 +13,7 @@
           </div>
           <span class="material-symbols text-2xl px-2" @click="showSortModal = true">sort</span>
         </template>
+        <button v-if="seriesBookPage && $platform === 'android'" type="button" class="flex items-center px-2 text-success" :disabled="$store.state.playerIsStartingPlayback" @click="$eventBus.$emit('play-series-click')"><span class="material-symbols text-2xl">play_arrow</span>{{ $strings.ButtonPlay }}</button>
         <span v-if="seriesBookPage" class="material-symbols text-2xl px-2" @click="downloadSeries">download</span>
         <span v-if="(page == 'library' && isBookLibrary) || seriesBookPage" class="material-symbols text-2xl px-2" @click="showMoreMenuDialog = true">more_vert</span>
       </div>

--- a/components/tables/collection/BookTableRow.vue
+++ b/components/tables/collection/BookTableRow.vue
@@ -24,6 +24,7 @@
 export default {
   props: {
     collectionId: String,
+    queueBooks: Array,
     book: {
       type: Object,
       default: () => {}
@@ -98,14 +99,17 @@ export default {
         return
       }
 
+      const queueSource = { sourceType: 'collection', sourceId: this.collectionId, books: this.queueBooks }
       this.$store.commit('setPlayerIsStartingPlayback', this.libraryItemId)
       if (this.localLibraryItem) {
         this.$eventBus.$emit('play-item', {
+          queueSource,
           libraryItemId: this.localLibraryItem.id,
           serverLibraryItemId: this.libraryItemId
         })
       } else {
         this.$eventBus.$emit('play-item', {
+          queueSource,
           libraryItemId: this.libraryItemId
         })
       }

--- a/components/tables/collection/CollectionBooksTable.vue
+++ b/components/tables/collection/CollectionBooksTable.vue
@@ -11,7 +11,7 @@
       <p v-if="totalDuration" class="text-sm text-fg">{{ totalDurationPretty }}</p>
     </div>
     <template v-for="book in booksCopy">
-      <tables-collection-book-table-row :key="book.id" :book="book" :collection-id="collectionId" class="item collection-book-item" @edit="editBook" />
+      <tables-collection-book-table-row :key="book.id" :book="book" :queue-books="books" :collection-id="collectionId" class="item collection-book-item" @edit="editBook" />
     </template>
   </div>
 </template>

--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -38,6 +38,10 @@ export default {
     item: {
       type: Object,
       default: () => {}
+    },
+    playlistPlayableItems: {
+      type: Array,
+      default: () => []
     }
   },
   data() {
@@ -162,20 +166,32 @@ export default {
       let mediaId = this.episodeId || this.libraryItem.id
       if (this.streamIsPlaying) {
         this.$eventBus.$emit('pause-item')
-      } else if (this.localLibraryItem) {
-        this.$store.commit('setPlayerIsStartingPlayback', mediaId)
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: this.localLibraryItem.id,
-          episodeId: this.localEpisode?.id,
-          serverLibraryItemId: this.libraryItem.id,
-          serverEpisodeId: this.episodeId
-        })
       } else {
-        this.$store.commit('setPlayerIsStartingPlayback', mediaId)
-        this.$eventBus.$emit('play-item', {
-          libraryItemId: this.libraryItem.id,
-          episodeId: this.episodeId
-        })
+        if (this.playlistPlayableItems.length) {
+          const currentIndex = this.playlistPlayableItems.findIndex((i) => i.libraryItemId === this.libraryItem.id && i.episodeId === this.episodeId)
+          if (currentIndex >= 0) {
+            this.$store.commit('setPlaylistQueue', {
+              playlistId: this.playlistId,
+              items: this.playlistPlayableItems,
+              currentIndex
+            })
+          }
+        }
+        if (this.localLibraryItem) {
+          this.$store.commit('setPlayerIsStartingPlayback', mediaId)
+          this.$eventBus.$emit('play-item', {
+            libraryItemId: this.localLibraryItem.id,
+            episodeId: this.localEpisode?.id,
+            serverLibraryItemId: this.libraryItem.id,
+            serverEpisodeId: this.episodeId
+          })
+        } else {
+          this.$store.commit('setPlayerIsStartingPlayback', mediaId)
+          this.$eventBus.$emit('play-item', {
+            libraryItemId: this.libraryItem.id,
+            episodeId: this.episodeId
+          })
+        }
       }
     }
   },

--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+import { AbsAudioPlayer } from '@/plugins/capacitor'
+
 export default {
   props: {
     playlistId: String,
@@ -173,6 +175,14 @@ export default {
             this.$store.commit('setPlaylistQueue', {
               playlistId: this.playlistId,
               items: this.playlistPlayableItems,
+              currentIndex
+            })
+            // Sync queue to native layer so it can advance independently of the WebView
+            AbsAudioPlayer.setPlaylistQueue({
+              items: this.playlistPlayableItems.map((item) => ({
+                libraryItemId: item.localLibraryItem ? item.localLibraryItem.id : item.libraryItemId,
+                episodeId: item.localLibraryItem ? (item.localEpisode?.id || null) : (item.episodeId || null)
+              })),
               currentIndex
             })
           }

--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -32,8 +32,6 @@
 </template>
 
 <script>
-import { AbsAudioPlayer } from '@/plugins/capacitor'
-
 export default {
   props: {
     playlistId: String,
@@ -169,27 +167,11 @@ export default {
       if (this.streamIsPlaying) {
         this.$eventBus.$emit('pause-item')
       } else {
-        if (this.playlistPlayableItems.length) {
-          const currentIndex = this.playlistPlayableItems.findIndex((i) => i.libraryItemId === this.libraryItem.id && i.episodeId === this.episodeId)
-          if (currentIndex >= 0) {
-            this.$store.commit('setPlaylistQueue', {
-              playlistId: this.playlistId,
-              items: this.playlistPlayableItems,
-              currentIndex
-            })
-            // Sync queue to native layer so it can advance independently of the WebView
-            AbsAudioPlayer.setPlaylistQueue({
-              items: this.playlistPlayableItems.map((item) => ({
-                libraryItemId: item.localLibraryItem ? item.localLibraryItem.id : item.libraryItemId,
-                episodeId: item.localLibraryItem ? (item.localEpisode?.id || null) : (item.episodeId || null)
-              })),
-              currentIndex
-            })
-          }
-        }
+        const queueSource = { sourceType: 'playlist', sourceId: this.playlistId, items: this.playlistPlayableItems }
         if (this.localLibraryItem) {
           this.$store.commit('setPlayerIsStartingPlayback', mediaId)
           this.$eventBus.$emit('play-item', {
+            queueSource,
             libraryItemId: this.localLibraryItem.id,
             episodeId: this.localEpisode?.id,
             serverLibraryItemId: this.libraryItem.id,
@@ -198,6 +180,7 @@ export default {
         } else {
           this.$store.commit('setPlayerIsStartingPlayback', mediaId)
           this.$eventBus.$emit('play-item', {
+            queueSource,
             libraryItemId: this.libraryItem.id,
             episodeId: this.episodeId
           })

--- a/components/tables/playlist/PlaylistItemsTable.vue
+++ b/components/tables/playlist/PlaylistItemsTable.vue
@@ -11,7 +11,7 @@
       <p v-if="totalDuration" class="text-sm text-fg">{{ totalDurationPretty }}</p>
     </div>
     <template v-for="item in items">
-      <tables-playlist-item-table-row :key="item.id" :item="item" :playlist-id="playlistId" @showMore="showMore" />
+      <tables-playlist-item-table-row :key="item.id" :item="item" :playlist-id="playlistId" :playlist-playable-items="playableItems" @showMore="showMore" />
     </template>
   </div>
 </template>
@@ -29,6 +29,14 @@ export default {
     return {}
   },
   computed: {
+    playableItems() {
+      return this.items.filter((item) => {
+        const libraryItem = item.libraryItem
+        if (!libraryItem || libraryItem.isMissing || libraryItem.isInvalid) return false
+        if (item.episode) return !!item.episode.audioFile
+        return libraryItem.media?.tracks?.length > 0
+      })
+    },
     totalDuration() {
       var _total = 0
       this.items.forEach((item) => {

--- a/docs/continuous-playback.md
+++ b/docs/continuous-playback.md
@@ -1,0 +1,126 @@
+# Downloaded audiobook continuous playback
+
+## Inspection before implementation
+
+Base: PR #1923, `bb5f30c706d3ca76d35ceaa5cb619bd1eab6f29b`. The separately fetched `reference/pr-1810-rebased` lacks the PR's Bluetooth fix and includes debug icon changes. No draft patch was supplied or applied.
+
+- `store/index.js` holds nullable `playlistQueue` with playlistId, items and currentIndex. The playlist page and `tables/playlist/ItemTableRow.vue` duplicate queue mapping and native bridge calls.
+- `AudioPlayerContainer.vue` increments the JS index on ENDED, independent of whether native advancement succeeds. Manual playback matches server IDs, updates only the JS index, and can retain an old queue when the same item is played outside its source.
+- `AbsAudioPlayer.kt.setPlaylistQueue` accepts only items and currentIndex. Each native `PlaylistQueueItem` is a libraryItemId and nullable episodeId. Neither playlist ID nor media type is required.
+- `PlayerListener` handles ExoPlayer STATE_ENDED and calls service advancement without the WebView. `PlayerNotificationService.advancePlaylistQueue` retains the PR's wake/network locks and server retry handling.
+- Local IDs beginning with `local` use `DbManager.getLocalLibraryItem`: a Paper `localLibraryItems` book keyed by actual local item ID, not SQLite. Server IDs take a separate streaming branch. Do not manufacture a local ID from a server ID.
+- With a null episode ID, advancement skips podcast lookup and calls `LocalLibraryItem.getPlaybackSession(null, deviceInfo)`. For books this supplies book chapters, all local audio tracks, local progress and PLAYMETHOD_LOCAL. This is the same session factory as manual audiobook playback. The proposed local-book assumption was supported by source inspection and subsequently by the user-reported device tests below.
+- Manual local preparation checks `hasTracks`, including file existence. The PR's auto-advance path does not check it.
+- Collections already have a Play button and an ordered `collection.books` response. `CollectionBooksTable` copies that order into `BookTableRow`; rows currently play independently.
+- The series page delegates to `LazyBookshelf`. The shelf fetches pages of 20 and can collapse subseries. `bookshelfCardsHelpers` creates cards with `new ComponentClass`, without a parent; source context must be passed explicitly in props.
+- `LazyListBookCard.play` starts audiobooks. `LazyBookCard.play` is empty and its audiobook Play button is disabled; podcast episode playback is separate. Item detail and other playback emitters have no source context and should clear a queue.
+- Complete series retrieval uses the existing `/api/libraries/:id/items` endpoint, `filter=series.<encoded ID>`, `sort=sequence`, `desc=0`, without collapse. Fetch every page, independent of shelf state. The server supports sequence sorting and places absent sequences last; no client numeric sort is needed.
+
+Server source inspected: [LibraryController](https://github.com/advplyr/audiobookshelf/blob/master/server/controllers/LibraryController.js), [libraryItemsBookFilters](https://github.com/advplyr/audiobookshelf/blob/master/server/utils/queries/libraryItemsBookFilters.js).
+
+## Design
+
+Nullable Vuex `playbackQueue`: `{ sourceType, sourceId, items, currentIndex }`. Queue items preserve server identity and optional local identity; one helper maps them to the existing native format. Source-aware `play-item` requests establish the queue centrally before preparation. Requests without a source clear it. Series/collection construction is Android-only and filters current local database records for playable downloaded books belonging to the current server connection. Playlist streaming behavior remains supported.
+
+Native names and advancement remain unchanged. A queue-state read supports authoritative JS index synchronization, and local audiobook advancement gains the existing manual file validation. Resolve queue mutations on the main thread before starting playback.
+
+## Implemented behavior
+
+- The series toolbar has an Android Play entry point. Both list and grid book-card Play controls pass the series source explicitly. Queue retrieval requests every page of server sequence order with no collapsed series. The visible shelf's pagination does not limit playback.
+- Collection Play and its book rows pass the same full collection order. Play All selects the first unfinished downloaded book, preferring local progress over server progress. If none remain, it reports that fact; an individual finished book can still be selected.
+- `utils/playbackQueue.js` builds source-independent queues, filters downloaded books against the active server connection, and translates actual local item/episode IDs for the bridge. Missing, invalid, ebook-only and detectably partial downloads are excluded. No series/collection queue contains server playback IDs.
+- A manually selected undownloaded book retains the existing single-item behavior, including the normal streaming permission check, and has no queue. Automatic advancement never selects it.
+- The central player clears prior Vue/native queues for each explicit play request, resolves the source, waits for permission/cast decisions, installs the native queue, then prepares playback. An item launched without source context clears the old queue even if it also appears in that queue.
+- Vue reads the native queue on ENDED, new sessions and foreground return. It does not increment its own index or initiate auto-advance. A late read cannot replace a newer Vue queue.
+- Native names, local session factory, wake locks, network locks and the Doze advancement path are retained. New checks stop on deleted/missing audiobook files, clear queues on player close or unrelated native preparation, and ignore old podcast retry results after queue replacement. These checks prevent queue leakage without moving advancement into JavaScript.
+
+## Changed files
+
+| File                                                                                   | Purpose                                                                             |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `utils/playbackQueue.js`                                                               | Source resolution, complete series fetch, downloaded-book filter and bridge mapping |
+| `store/index.js`                                                                       | Generic nullable queue state and mutations                                          |
+| `components/app/AudioPlayerContainer.vue`                                              | Queue setup/clearing, native synchronization and playback ordering                  |
+| `pages/playlist/_id.vue`                                                               | Existing playlist Play uses shared source abstraction                               |
+| `components/tables/playlist/ItemTableRow.vue`                                          | Playlist row source context                                                         |
+| `pages/bookshelf/series/_id.vue`                                                       | Handles series Play                                                                 |
+| `components/home/BookshelfToolbar.vue`                                                 | Android series Play entry point                                                     |
+| `mixins/bookshelfCardsHelpers.js`                                                      | Explicit source props for dynamically instantiated cards                            |
+| `components/cards/LazyListBookCard.vue`                                                | Series source on list-card playback                                                 |
+| `components/cards/LazyBookCard.vue`                                                    | Enables series grid-card playback                                                   |
+| `pages/collection/_id.vue`                                                             | Existing Collection Play builds downloaded queue                                    |
+| `components/tables/collection/CollectionBooksTable.vue`                                | Passes full collection order to rows                                                |
+| `components/tables/collection/BookTableRow.vue`                                        | Individual collection book source context                                           |
+| `android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt`           | Main-thread queue mutation completion and queue-state read                          |
+| `android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt` | File checks and queue cancellation guards                                           |
+| `tests/playbackQueue.test.mjs`                                                         | Automated queue and component-boundary regressions                                  |
+| `docs/continuous-playback.md`                                                          | Inspection, design and validation report                                            |
+
+## Device acceptance results
+
+Updated September 9, 2026 from the user's reports after installing the debug APK. These are user-performed tests, not tests observed through ADB by the agent. Device model, Android version, logs and exact idle duration were not supplied. The user confirmed expected behavior after each walkthrough.
+
+| Scenario                 | Device result         | Evidence and scope                                                                                                                                                                                              |
+| ------------------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A. Podcast playlist      | Not tested            | User has no podcasts. Automated local/server episode mapping and queue-boundary tests passed; actual podcast playback and Bluetooth-disconnect regression remain unverified.                                    |
+| B. Downloaded series     | Passed, user-reported | User reported the APK works as intended, including playback with screen on/off and player foreground/background.                                                                                                |
+| C. Start in middle       | Passed, user-reported | User explicitly confirmed that starting book 3 continues to book 4. Separate coverage of both list and grid views was not recorded.                                                                             |
+| D. Collection            | Passed, user-reported | User confirmed the collection Play and middle-book walkthrough: advancement follows displayed collection order.                                                                                                 |
+| E. Clear queue           | Passed, user-reported | User confirmed the walkthrough for starting a series/collection, playing an unrelated audiobook, and stopping at its completion without resuming the old queue.                                                 |
+| F. Download protection   | Passed, user-reported | User confirmed the walkthrough with books 1 and 3 downloaded, book 2 absent, and airplane mode enabled after starting: advancement skips the absent book. Deleting a download after queue setup was not tested. |
+| G. Background/screen off | Passed, user-reported | User tested screen on/off and foreground/background, then confirmed the extended locked-screen, unplugged, stationary-device walkthrough. Android's actual Doze state was not measured.                         |
+
+Remaining optional device checks: explicitly confirm Doze state with ADB/logcat, remove a downloaded file after queue setup, and exercise both series card layouts separately. Podcast playlist playback and Bluetooth pause remain untested because no podcast fixtures are available. The earlier build-host ADB check found no connected device; subsequent user testing took place independently.
+
+## Remaining limitations
+
+- Android only. No iOS continuous playback was added.
+- Series setup still needs server connectivity for canonical full membership/order, as do the existing source pages. Once installed, the local queue advances without JS or server playback requests. No offline source catalog or queue persistence across process death was added.
+- Undownloaded entries are omitted, so the next downloaded entry may skip a gap in the series/collection.
+- If a queued download disappears after setup, playback stops rather than streaming or trying another item.
+- Source edits during playback do not rebuild the queue. A new source Play request refreshes it. Interrupted/duplicate pagination fails instead of starting an incomplete queue.
+- Item-detail playback has no source context and clears the queue; use the series/collection Play controls to start continuous playback.
+- Audiobook device acceptance checks passed as reported above. Podcast regression, explicit Doze-state confirmation and behavior across other devices/OEMs remain unverified.
+
+## Build and automated validation
+
+Tools were installed under ignored `.cache/` because the host initially lacked npm, Java and the Android SDK. No dependency manifests or lockfiles were changed. Commands below abbreviate the workspace-local npm executable as `npm` and the Capacitor executable as `cap`.
+
+| Command | Result |
+| --- | --- |
+| `npm ci --cache .cache/npm --no-audit --no-fund` | Passed: 1,502 packages. Initial sandbox attempt failed with registry EACCES; retry with network permission passed. |
+| `node --test tests/playbackQueue.test.mjs` | Passed: 14 tests, including mocked container behavior and HTTP/DB/bridge boundaries. |
+| `node node_modules/prettier/bin-prettier.js --check <changed Vue/JS files> utils/playbackQueue.js tests/playbackQueue.test.mjs docs/continuous-playback.md` | Passed. No project ESLint/ktlint command is configured. |
+| `npm run generate` | Passed, repeated after final JS changes. Existing bundle-size and stale Browserslist warnings remain. |
+| `cap sync android` | Passed. Existing warning: screen-orientation Cordova plugin declares missing es6-promise-plugin. |
+| `gradlew.bat --gradle-user-home ../.cache/gradle --no-daemon -Dorg.gradle.java.installations.paths=<JDK17> assembleDebug` | Passed: BUILD SUCCESSFUL, 402 tasks, Kotlin compilation and APK packaging. |
+| `gradlew.bat --gradle-user-home ../.cache/gradle --no-daemon -Porg.gradle.java.installations.paths=<JDK17> :app:assembleDebug :app:testDebugUnitTest :app:lintDebug` | Final APK packaging passed. Task chain then failed at the unchanged example unit test: `package org.junit does not exist`. The base app build.gradle has no testImplementation dependency for its example test. This was not caused by queue changes; lint was rerun separately. |
+| `adb devices -l` | No devices/emulators attached to the build host. Subsequent user-performed device results are recorded above. |
+| `gradlew.bat --gradle-user-home ../.cache/gradle --no-daemon -Porg.gradle.java.installations.paths=<JDK17> :app:lintDebug` | Passed separately: BUILD SUCCESSFUL, 499 tasks. |
+| `git diff --check` | Passed. |
+
+Java 21 ran Gradle; the project's declared Java 17 toolchain was provided separately. Android SDK platform/build-tools 35 and Gradle 8.11.1 were used. Build output is `android/app/build/outputs/apk/debug/app-debug.apk`.
+
+The implementation was initially delivered as an uncommitted review patch; the user subsequently authorized committing, pushing to their fork and opening a draft pull request. The review patch includes the new helper, tests and this report in addition to tracked edits.
+
+## git diff --stat
+
+Tracked-file diff (new files are listed above and included in the exported patch):
+
+```text
+ .../app/player/PlayerNotificationService.kt        | 27 ++++++-
+ .../audiobookshelf/app/plugins/AbsAudioPlayer.kt   | 14 +++-
+ components/app/AudioPlayerContainer.vue            | 88 ++++++++++++++--------
+ components/cards/LazyBookCard.vue                  | 15 +++-
+ components/cards/LazyListBookCard.vue              |  3 +-
+ components/home/BookshelfToolbar.vue               |  1 +
+ components/tables/collection/BookTableRow.vue      |  4 +
+ .../tables/collection/CollectionBooksTable.vue     |  4 +-
+ components/tables/playlist/ItemTableRow.vue        | 23 +-----
+ mixins/bookshelfCardsHelpers.js                    | 11 ++-
+ pages/bookshelf/series/_id.vue                     |  7 ++
+ pages/collection/_id.vue                           |  6 ++
+ pages/playlist/_id.vue                             | 24 ++----
+ store/index.js                                     | 10 +--
+ 14 files changed, 147 insertions(+), 90 deletions(-)
+```

--- a/mixins/bookshelfCardsHelpers.js
+++ b/mixins/bookshelfCardsHelpers.js
@@ -50,7 +50,10 @@ export default {
         bookCoverAspectRatio: this.bookCoverAspectRatio,
         isAltViewEnabled: this.altViewEnabled
       }
-      if (this.entityName === 'series-books') props.showSequence = true
+      if (this.entityName === 'series-books') {
+        props.showSequence = true
+        if (this.$platform === 'android') props.queueSource = { sourceType: 'series', sourceId: this.seriesId, libraryId: this.$store.state.globals.series.libraryId }
+      }
       if (this.entityName === 'books') {
         props.filterBy = this.filterBy
         props.orderBy = this.orderBy
@@ -81,12 +84,12 @@ export default {
         instance.setEntity(entity)
 
         if (this.isBookEntity && !entity.isLocal) {
-          var localLibraryItem = this.localLibraryItems.find(lli => lli.libraryItemId == entity.id)
+          var localLibraryItem = this.localLibraryItems.find((lli) => lli.libraryItemId == entity.id)
           if (localLibraryItem) {
             instance.setLocalLibraryItem(localLibraryItem)
           }
         }
       }
-    },
+    }
   }
 }

--- a/pages/bookshelf/series/_id.vue
+++ b/pages/bookshelf/series/_id.vue
@@ -40,6 +40,11 @@ export default {
     }
   },
   methods: {
+    playSeries() {
+      if (this.$platform !== 'android' || this.$store.state.playerIsStartingPlayback) return
+      this.$store.commit('setPlayerIsStartingPlayback', this.seriesId)
+      this.$eventBus.$emit('play-item', { queueSource: { sourceType: 'series', sourceId: this.seriesId, libraryId: this.series.libraryId } })
+    },
     async downloadSeriesClick() {
       console.log('Download Series clicked')
       if (this.startingDownload) return
@@ -175,9 +180,11 @@ export default {
     }
   },
   mounted() {
+    this.$eventBus.$on('play-series-click', this.playSeries)
     this.$eventBus.$on('download-series-click', this.downloadSeriesClick)
   },
   beforeDestroy() {
+    this.$eventBus.$off('play-series-click', this.playSeries)
     this.$eventBus.$off('download-series-click', this.downloadSeriesClick)
   }
 }

--- a/pages/collection/_id.vue
+++ b/pages/collection/_id.vue
@@ -121,6 +121,12 @@ export default {
       }
     },
     playNextItem() {
+      if (this.$platform === 'android') {
+        this.$store.commit('setPlayerIsStartingPlayback', this.collection.id)
+        this.mediaIdStartingPlayback = this.collection.id
+        this.$eventBus.$emit('play-item', { queueSource: { sourceType: 'collection', sourceId: this.collection.id, books: this.bookItems } })
+        return
+      }
       const nextBookNotRead = this.playableItems.find((pb) => {
         const prog = this.$store.getters['user/getUserMediaProgress'](pb.id)
         return !prog?.isFinished

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -140,11 +140,17 @@ export default {
       }
     },
     playNextItem() {
-      const nextItem = this.playableItems.find((i) => {
+      const nextIndex = this.playableItems.findIndex((i) => {
         const prog = this.$store.getters['user/getUserMediaProgress'](i.libraryItemId, i.episodeId)
         return !prog?.isFinished
       })
-      if (nextItem) {
+      if (nextIndex >= 0) {
+        const nextItem = this.playableItems[nextIndex]
+        this.$store.commit('setPlaylistQueue', {
+          playlistId: this.playlist.id,
+          items: this.playableItems,
+          currentIndex: nextIndex
+        })
         this.mediaIdStartingPlayback = nextItem.episodeId || nextItem.libraryItemId
         this.$store.commit('setPlayerIsStartingPlayback', this.mediaIdStartingPlayback)
         if (nextItem.localLibraryItem) {

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -32,6 +32,8 @@
 </template>
 
 <script>
+import { AbsAudioPlayer } from '@/plugins/capacitor'
+
 export default {
   async asyncData({ store, params, app, redirect, route }) {
     if (!store.state.user.user) {
@@ -149,6 +151,14 @@ export default {
         this.$store.commit('setPlaylistQueue', {
           playlistId: this.playlist.id,
           items: this.playableItems,
+          currentIndex: nextIndex
+        })
+        // Pass queue to native layer so it can advance independently of the WebView
+        AbsAudioPlayer.setPlaylistQueue({
+          items: this.playableItems.map((item) => ({
+            libraryItemId: item.localLibraryItem ? item.localLibraryItem.id : item.libraryItemId,
+            episodeId: item.localLibraryItem ? (item.localEpisode?.id || null) : (item.episodeId || null)
+          })),
           currentIndex: nextIndex
         })
         this.mediaIdStartingPlayback = nextItem.episodeId || nextItem.libraryItemId

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script>
-import { AbsAudioPlayer } from '@/plugins/capacitor'
+import { queueItemPayload } from '@/utils/playbackQueue'
 
 export default {
   async asyncData({ store, params, app, redirect, route }) {
@@ -148,26 +148,12 @@ export default {
       })
       if (nextIndex >= 0) {
         const nextItem = this.playableItems[nextIndex]
-        this.$store.commit('setPlaylistQueue', {
-          playlistId: this.playlist.id,
-          items: this.playableItems,
-          currentIndex: nextIndex
-        })
-        // Pass queue to native layer so it can advance independently of the WebView
-        AbsAudioPlayer.setPlaylistQueue({
-          items: this.playableItems.map((item) => ({
-            libraryItemId: item.localLibraryItem ? item.localLibraryItem.id : item.libraryItemId,
-            episodeId: item.localLibraryItem ? (item.localEpisode?.id || null) : (item.episodeId || null)
-          })),
-          currentIndex: nextIndex
-        })
         this.mediaIdStartingPlayback = nextItem.episodeId || nextItem.libraryItemId
         this.$store.commit('setPlayerIsStartingPlayback', this.mediaIdStartingPlayback)
-        if (nextItem.localLibraryItem) {
-          this.$eventBus.$emit('play-item', { libraryItemId: nextItem.localLibraryItem.id, episodeId: nextItem.localEpisode?.id, serverLibraryItemId: nextItem.libraryItemId, serverEpisodeId: nextItem.episodeId })
-        } else {
-          this.$eventBus.$emit('play-item', { libraryItemId: nextItem.libraryItemId, episodeId: nextItem.episodeId })
-        }
+        this.$eventBus.$emit('play-item', {
+          ...queueItemPayload(nextItem),
+          queueSource: { sourceType: 'playlist', sourceId: this.playlist.id, items: this.playableItems }
+        })
       }
     },
     playlistUpdated(playlist) {

--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -171,6 +171,16 @@ class AbsAudioPlayerWeb extends WebPlugin {
     return false
   }
 
+  // PluginMethod
+  setPlaylistQueue() {
+    // Web: queue advancement handled in JS layer
+  }
+
+  // PluginMethod
+  clearPlaylistQueue() {
+    // Web: queue advancement handled in JS layer
+  }
+
   initializePlayer() {
     if (document.getElementById('audio-player')) {
       document.getElementById('audio-player').remove()

--- a/store/index.js
+++ b/store/index.js
@@ -9,6 +9,7 @@ export const state = () => ({
   playerIsFullscreen: false,
   playerIsStartingPlayback: false, // When pressing play before native play response
   playerStartingPlaybackMediaId: null,
+  playlistQueue: null, // { playlistId: String, items: Array, currentIndex: Number }
   isCasting: false,
   isCastAvailable: false,
   attemptingConnection: false,
@@ -210,5 +211,11 @@ export const mutations = {
   setServerSettings(state, val) {
     state.serverSettings = val
     this.$localStore.setServerSettings(state.serverSettings)
+  },
+  setPlaylistQueue(state, queue) {
+    state.playlistQueue = queue
+  },
+  clearPlaylistQueue(state) {
+    state.playlistQueue = null
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -9,7 +9,7 @@ export const state = () => ({
   playerIsFullscreen: false,
   playerIsStartingPlayback: false, // When pressing play before native play response
   playerStartingPlaybackMediaId: null,
-  playlistQueue: null, // { playlistId: String, items: Array, currentIndex: Number }
+  playbackQueue: null, // { sourceType: String, sourceId: String, items: Array, currentIndex: Number }
   isCasting: false,
   isCastAvailable: false,
   attemptingConnection: false,
@@ -212,10 +212,10 @@ export const mutations = {
     state.serverSettings = val
     this.$localStore.setServerSettings(state.serverSettings)
   },
-  setPlaylistQueue(state, queue) {
-    state.playlistQueue = queue
+  setPlaybackQueue(state, queue) {
+    state.playbackQueue = queue
   },
-  clearPlaylistQueue(state) {
-    state.playlistQueue = null
+  clearPlaybackQueue(state) {
+    state.playbackQueue = null
   }
 }

--- a/tests/playbackQueue.test.mjs
+++ b/tests/playbackQueue.test.mjs
@@ -1,0 +1,236 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import vm from 'node:vm'
+// Load the Nuxt ES module without changing this project's CommonJS package type.
+const helperSource = await readFile(new URL('../utils/playbackQueue.js', import.meta.url), 'utf8')
+const { downloadedBookItems, fetchSeriesBooks, nativeQueueItems, resolvePlaybackQueue } = await import(`data:text/javascript;base64,${Buffer.from(helperSource).toString('base64')}`)
+
+const book = (id) => ({ id, mediaType: 'book', media: { numTracks: 1 } })
+const local = (id, overrides = {}) => ({ id: `local_device_${id}`, libraryItemId: id, serverConnectionConfigId: 'server', mediaType: 'book', media: { tracks: [{}] }, ...overrides })
+function context(localItems = []) {
+  return {
+    $platform: 'android',
+    $encode: (value) => Buffer.from(value).toString('base64'),
+    $db: { getLocalLibraryItems: async () => localItems },
+    $store: { getters: { 'user/getServerConnectionConfigId': 'server', 'globals/getLocalMediaProgressById': () => null, 'user/getUserMediaProgress': () => null } }
+  }
+}
+
+test('download filtering preserves source order and uses real local IDs, excluding invalid/foreign/non-audio items', () => {
+  const books = ['c', 'b', 'a', 'missing', 'invalid', 'ebook', 'foreign'].map(book)
+  books[4].isInvalid = true
+  const items = downloadedBookItems(books, [local('a'), local('c'), local('invalid'), local('ebook', { media: { tracks: [] } }), local('foreign', { serverConnectionConfigId: 'other' })], 'server')
+  assert.deepEqual(nativeQueueItems(items), [
+    { libraryItemId: 'local_device_c', episodeId: null },
+    { libraryItemId: 'local_device_a', episodeId: null }
+  ])
+})
+
+test('partial downloads are not eligible for auto-advance', () => {
+  assert.deepEqual(downloadedBookItems([{ ...book('a'), media: { numTracks: 3 } }], [local('a')], 'server'), [])
+})
+
+test('complete series uses server sequence order, all pages, and never shelf collapse', async () => {
+  const calls = []
+  const books = Array.from({ length: 205 }, (_, i) => book(String(205 - i)))
+  const http = {
+    get: async (url) => {
+      calls.push(url)
+      const query = new URL(url, 'http://test').searchParams
+      assert.equal(query.get('sort'), 'sequence')
+      assert.equal(query.get('desc'), '0')
+      assert.equal(query.get('collapseseries'), null)
+      assert.equal(query.get('filter'), 'series.encoded')
+      const page = Number(query.get('page'))
+      return { results: books.slice(page * 100, page * 100 + 100), total: 205 }
+    }
+  }
+  assert.deepEqual(await fetchSeriesBooks(http, 'library', 'series', () => 'encoded'), books)
+  assert.equal(calls.length, 3)
+})
+
+test('incomplete, failed or repeated series pages fail instead of playing a partial queue', async () => {
+  await assert.rejects(fetchSeriesBooks({ get: async () => ({ results: [], total: 5 }) }, 'l', 's', String))
+  await assert.rejects(
+    fetchSeriesBooks(
+      {
+        get: async () => {
+          throw new Error('offline')
+        }
+      },
+      'l',
+      's',
+      String
+    ),
+    /offline/
+  )
+  await assert.rejects(fetchSeriesBooks({ get: async () => ({ results: [book('a')], total: 5 }) }, 'l', 's', String), /changed/)
+})
+
+test('Play All starts at first unfinished downloaded book using local progress', async () => {
+  const ctx = context([local('a'), local('c'), local('d')])
+  ctx.$store.getters['globals/getLocalMediaProgressById'] = (id) => ({ isFinished: id === 'local_device_a' })
+  const result = await resolvePlaybackQueue(ctx, { queueSource: { sourceType: 'collection', sourceId: 'c', books: ['a', 'b', 'c', 'd'].map(book) } })
+  assert.equal(result.queue.currentIndex, 1)
+  assert.equal(result.payload.libraryItemId, 'local_device_c')
+  assert.equal(result.payload.episodeId, null)
+  assert.deepEqual(
+    result.queue.items.map((item) => item.libraryItemId),
+    ['a', 'c', 'd']
+  )
+})
+
+test('starting a middle series book constructs the full queue and points at that book', async () => {
+  const ctx = context(['1', '2', '3', '4'].map((id) => local(id)))
+  ctx.$nativeHttp = { get: async () => ({ results: ['1', '2', '3', '4'].map(book), total: 4 }) }
+  const result = await resolvePlaybackQueue(ctx, { libraryItemId: '3', queueSource: { sourceType: 'series', sourceId: 's', libraryId: 'l' } })
+  assert.equal(result.queue.currentIndex, 2)
+  assert.equal(nativeQueueItems(result.queue.items)[result.queue.currentIndex + 1].libraryItemId, 'local_device_4')
+})
+
+test('collection middle start follows collection order; missing download is never queued', async () => {
+  const result = await resolvePlaybackQueue(context([local('1'), local('3'), local('4')]), { libraryItemId: 'local_device_3', queueSource: { sourceType: 'collection', sourceId: 'c', books: ['4', '3', '2', '1'].map(book) } })
+  assert.equal(result.queue.currentIndex, 1)
+  assert.equal(nativeQueueItems(result.queue.items)[2].libraryItemId, 'local_device_1')
+})
+
+test('manual non-downloaded selection has no queue; no source never acquires a queue', async () => {
+  const payload = { libraryItemId: '2', queueSource: { sourceType: 'collection', sourceId: 'c', books: ['1', '2'].map(book) } }
+  assert.equal((await resolvePlaybackQueue(context([local('1')]), payload)).queue, null)
+  assert.equal((await resolvePlaybackQueue(context([local('1')]), { libraryItemId: '1' })).queue, null)
+})
+
+test('iOS and web do not build Android queues or call the database', async () => {
+  for (const platform of ['ios', 'web']) {
+    const result = await resolvePlaybackQueue({ $platform: platform }, { libraryItemId: '1', queueSource: { sourceType: 'series' } })
+    assert.equal(result.queue, null)
+  }
+})
+
+test('podcast playlist preserves local episode identity and streaming entries', async () => {
+  const items = [
+    { libraryItemId: 'p', episodeId: 'e1', localLibraryItem: { id: 'local_p' }, localEpisode: { id: 'local_e1' } },
+    { libraryItemId: 'p', episodeId: 'e2' }
+  ]
+  const result = await resolvePlaybackQueue(context(), { libraryItemId: 'local_p', episodeId: 'local_e1', queueSource: { sourceType: 'playlist', sourceId: 'p1', items } })
+  assert.equal(result.queue.currentIndex, 0)
+  assert.deepEqual(nativeQueueItems(result.queue.items), [
+    { libraryItemId: 'local_p', episodeId: 'local_e1' },
+    { libraryItemId: 'p', episodeId: 'e2' }
+  ])
+  assert.equal(result.payload.serverEpisodeId, 'e1')
+})
+
+// Exercise the real container methods with a mocked Capacitor boundary.
+async function container(native) {
+  const source = await readFile(new URL('../components/app/AudioPlayerContainer.vue', import.meta.url), 'utf8')
+  const script = source
+    .match(/<script>([\s\S]*?)<\/script>/)[1]
+    .replace(/^import .*$/gm, '')
+    .replace('export default', 'globalThis.component =')
+  const sandbox = { AbsAudioPlayer: native, AbsLogger: { info: async () => {} }, CellularPermissionHelpers: {}, nativeQueueItems, resolvePlaybackQueue, console }
+  vm.runInNewContext(script, sandbox)
+  const ctx = context([local('1'), local('2')])
+  ctx.$store.state = { playbackQueue: null }
+  ctx.$store.commit = (name, payload) => {
+    if (name === 'setPlaybackQueue') ctx.$store.state.playbackQueue = payload
+    if (name === 'clearPlaybackQueue') ctx.$store.state.playbackQueue = null
+  }
+  ctx.$toast = {
+    error: (message) => {
+      ctx.error = message
+    }
+  }
+  ctx.$refs = {}
+  ctx.$store.getters.getIsMediaStreaming = () => false
+  Object.assign(ctx, sandbox.component.data())
+  for (const [name, fn] of Object.entries(sandbox.component.methods)) ctx[name] = fn.bind(ctx)
+  return ctx
+}
+
+test('unrelated playback clears both queues before starting; failed queue fetch does not play', async () => {
+  const calls = []
+  const ctx = await container({ clearPlaylistQueue: async () => calls.push('clear') })
+  ctx.$store.state.playbackQueue = { sourceType: 'series' }
+  ctx.startLibraryItem = async (_, queue) => {
+    assert.equal(queue, null)
+    calls.push('play')
+  }
+  await ctx.playLibraryItem({ libraryItemId: 'unrelated' })
+  assert.deepEqual(calls, ['clear', 'play'])
+  assert.equal(ctx.$store.state.playbackQueue, null)
+  ctx.$nativeHttp = {
+    get: async () => {
+      throw new Error('offline')
+    }
+  }
+  await ctx.playLibraryItem({ queueSource: { sourceType: 'series', sourceId: 's' } })
+  assert.equal(ctx.error, 'offline')
+  assert.equal(calls.filter((call) => call === 'play').length, 1)
+})
+
+test('native queue installation completes before local book preparation', async () => {
+  const calls = []
+  const ctx = await container({
+    clearPlaylistQueue: async () => calls.push('clear'),
+    setPlaylistQueue: async (queue) => {
+      await Promise.resolve()
+      assert.equal(queue.items[1].libraryItemId, 'local_device_2')
+      assert.equal(queue.items[1].episodeId, null)
+      calls.push('queue')
+    },
+    prepareLibraryItem: async (payload) => {
+      calls.push('play')
+      assert.equal(payload.libraryItemId, 'local_device_1')
+      assert.equal(payload.episodeId, null)
+      return {}
+    }
+  })
+  await ctx.playLibraryItem({ queueSource: { sourceType: 'collection', sourceId: 'c', books: [book('1'), book('2')] } })
+  assert.deepEqual(calls, ['clear', 'queue', 'play'])
+  assert.equal(ctx.$store.state.playbackQueue.sourceType, 'collection')
+})
+
+test('failed native queue installation prevents playback', async () => {
+  let played = false
+  const ctx = await container({
+    clearPlaylistQueue: async () => {},
+    setPlaylistQueue: async () => {
+      throw new Error('bridge failure')
+    },
+    prepareLibraryItem: async () => {
+      played = true
+    }
+  })
+  await ctx.playLibraryItem({ queueSource: { sourceType: 'collection', sourceId: 'c', books: [book('1')] } })
+  assert.equal(played, false)
+  assert.equal(ctx.$store.state.playbackQueue, null)
+  assert.equal(ctx.error, 'bridge failure')
+})
+
+test('delayed ENDED reads authoritative native index; stale responses cannot replace a new queue', async () => {
+  let resolve
+  const ctx = await container({
+    getPlaylistQueue: () =>
+      new Promise((done) => {
+        resolve = done
+      })
+  })
+  const queue = { sourceType: 'collection', sourceId: 'c', items: [{ libraryItemId: 'a' }, { libraryItemId: 'b' }, { libraryItemId: 'c' }], currentIndex: 0 }
+  ctx.$store.state.playbackQueue = queue
+  const sync = ctx.onPlaybackEnded()
+  resolve({ items: nativeQueueItems(queue.items), currentIndex: 2 })
+  await sync
+  assert.equal(ctx.$store.state.playbackQueue.currentIndex, 2)
+  const stale = ctx.onPlaybackEnded()
+  const replacement = { ...queue, sourceId: 'new' }
+  ctx.$store.state.playbackQueue = replacement
+  resolve({ items: [], currentIndex: -1 })
+  await stale
+  assert.equal(ctx.$store.state.playbackQueue, replacement)
+  const ended = ctx.onPlaybackEnded()
+  resolve({ items: [], currentIndex: -1 })
+  await ended
+  assert.equal(ctx.$store.state.playbackQueue, null)
+})

--- a/utils/playbackQueue.js
+++ b/utils/playbackQueue.js
@@ -1,0 +1,80 @@
+// Keep server identity for UI/progress, and translate to device identity only at the bridge.
+export function nativeQueueItems(items) {
+  return items.map((item) => ({
+    libraryItemId: item.localLibraryItem?.id || item.libraryItemId,
+    episodeId: item.localLibraryItem ? item.localEpisode?.id || null : item.episodeId || null
+  }))
+}
+
+export function queueItemPayload(item) {
+  const nativeItem = nativeQueueItems([item])[0]
+  return {
+    ...nativeItem,
+    serverLibraryItemId: item.libraryItemId,
+    serverEpisodeId: item.episodeId || null
+  }
+}
+
+export function downloadedBookItems(books, localItems, serverConnectionConfigId) {
+  return books.flatMap((book) => {
+    const localLibraryItem = localItems.find((local) => local.libraryItemId === book.id && local.serverConnectionConfigId === serverConnectionConfigId && local.id?.startsWith('local') && local.mediaType === 'book' && !local.isInvalid && local.media?.tracks?.length)
+    const expectedTracks = book.media?.numTracks || book.media?.tracks?.length || 0
+    if (!localLibraryItem || book.isMissing || book.isInvalid || localLibraryItem.media.tracks.length < expectedTracks) return []
+    return [{ libraryItemId: book.id, episodeId: null, localLibraryItem }]
+  })
+}
+
+export async function fetchSeriesBooks(http, libraryId, seriesId, encode) {
+  const books = []
+  const ids = new Set()
+  const limit = 100
+  for (let page = 0; ; page++) {
+    const query = new URLSearchParams({ filter: `series.${encode(seriesId)}`, sort: 'sequence', desc: '0', limit: String(limit), page: String(page), minified: '1' })
+    const payload = await http.get(`/api/libraries/${libraryId}/items?${query}`)
+    if (!Array.isArray(payload?.results) || !Number.isFinite(payload.total)) throw new Error('Failed to load the complete series')
+    for (const book of payload.results) {
+      if (ids.has(book.id)) throw new Error('Series changed while loading. Please try again.')
+      ids.add(book.id)
+      books.push(book)
+    }
+    if (books.length >= payload.total) return books
+    if (!payload.results.length) throw new Error('Failed to load the complete series')
+  }
+}
+
+export async function resolvePlaybackQueue(context, payload) {
+  const source = payload.queueSource
+  if (!source || context.$platform !== 'android') return { payload, queue: null }
+  let items
+  if (source.sourceType === 'playlist') {
+    items = source.items
+  } else if (source.sourceType === 'series' || source.sourceType === 'collection') {
+    const books = source.sourceType === 'series' ? await fetchSeriesBooks(context.$nativeHttp, source.libraryId, source.sourceId, context.$encode) : source.books
+    const localItems = (await context.$db.getLocalLibraryItems('book')) || []
+    items = downloadedBookItems(books, localItems, context.$store.getters['user/getServerConnectionConfigId'])
+  } else {
+    throw new Error('Unknown playback queue source')
+  }
+  let currentIndex
+  if (payload.libraryItemId) {
+    currentIndex = items.findIndex((item) => {
+      const nativeItem = nativeQueueItems([item])[0]
+      const serverMatch = item.libraryItemId === (payload.serverLibraryItemId || payload.libraryItemId) && (item.episodeId || null) === (payload.serverEpisodeId || payload.episodeId || null)
+      const localMatch = nativeItem.libraryItemId === payload.libraryItemId && nativeItem.episodeId === (payload.episodeId || null)
+      return serverMatch || localMatch
+    })
+    // A manually selected undownloaded book may play normally, but never retains a queue.
+    if (currentIndex < 0) return { payload, queue: null }
+  } else {
+    currentIndex = items.findIndex((item) => {
+      const localProgress = item.localLibraryItem && context.$store.getters['globals/getLocalMediaProgressById'](item.localLibraryItem.id, item.localEpisode?.id)
+      const progress = localProgress || context.$store.getters['user/getUserMediaProgress'](item.libraryItemId, item.episodeId)
+      return !progress?.isFinished
+    })
+    if (currentIndex < 0) throw new Error(items.length ? 'All downloaded books are finished' : 'No downloaded audiobooks available')
+  }
+  return {
+    payload: { ...payload, ...queueItemPayload(items[currentIndex]) },
+    queue: { sourceType: source.sourceType, sourceId: source.sourceId, items, currentIndex }
+  }
+}


### PR DESCRIPTION
## Brief summary

Add Android continuous playback for downloaded audiobooks in series and collections. Starting a middle book continues with the next downloaded book in source order; playing an unrelated item clears the queue.

This builds on PR #1923 at bb5f30c7 and includes that PR's podcast playlist commits. Review this as dependent on #1923; the audiobook-specific change is the final commit on this branch.

## Which issue is fixed?

Extends the queue mechanism from #1923 (rebased #1810). No additional issue is claimed as fixed.

## Pull Request Type

Android feature, with shared Vue/JavaScript queue setup and small Kotlin bridge/service changes. No iOS continuous-playback support is added.

## In-depth Description

- Generalize Vuex state to a nullable playbackQueue with sourceType, sourceId, items and currentIndex, while retaining the native playlist queue representation.
- Add series Play and pass source context through dynamically instantiated list/grid cards. Fetch the complete series using server sequence sorting, independently of shelf pagination.
- Extend existing Collection Play and individual collection rows, preserving collection order.
- Queue only playable local audiobook records for the active server connection. Exclude absent, invalid and detectably partial downloads. Play All starts at the first unfinished downloaded book.
- Install the native queue before playback; read native state to synchronize the UI after background advancement. Unrelated playback clears the queue, even when the selected item also belongs to it.
- Retain native background/Doze advancement. Check audiobook files at advancement time, clear the queue on close/unrelated native playback, and prevent stale podcast retry results from replacing newer playback.

Automatic audiobook advancement does not stream undownloaded titles. Explicitly selecting an undownloaded title retains existing single-item playback behavior without a queue. Series setup still needs server connectivity; queue persistence across process death is out of scope.

See docs/continuous-playback.md for source inspection, changed files, validation and limitations.

## How have you tested this?

- Passed: 14 Node regression tests covering complete pagination, middle starts, source order, download filtering, podcast ID mapping, queue installation/clearing and stale native responses.
- Passed: Nuxt production generation, Android debug APK build (including Kotlin compilation), Android lint, Prettier and git diff --check.
- User-reported device tests passed: downloaded-series playback, book 3 advancing to book 4, collection order/middle starts, omission of undownloaded books in airplane mode, clearing the queue when switching to an unrelated audiobook, screen on/off, foreground/background and extended locked-screen playback.
- Not tested on device: podcast playlists/Bluetooth-disconnect regression (tester has no podcasts), explicit Android Doze-state confirmation, and deleting a download after queue setup. Device model/OS and logs were not supplied.
- Existing Android ExampleUnitTest could not compile because the base app build.gradle lacks its JUnit test dependency. The unchanged example is not a playback test; APK build and separately run lint passed.

## Screenshots

No before/after screenshots were captured. UI changes are a series toolbar Play control and enabling the series grid-card Play control. This PR remains a draft for review and remaining device coverage.
