### PR TITLE
Fix iOS crash on launch when expired logs are cleaned

### DIFF
--- a/ios/App/Shared/util/Database.swift
+++ b/ios/App/Shared/util/Database.swift
@@ -314,18 +314,19 @@ class Database {
         let numberOfHoursToKeep = 48
         let keepLogCutoffMs = Int(Date().addingTimeInterval(TimeInterval(-1 * numberOfHoursToKeep * 3600)).timeIntervalSince1970 * 1000)
 
-        let allLogs = getAllLogs()
-        var logsRemoved = 0
-        try? realm.write {
-            allLogs.forEach { log in
-                if log.timestamp < keepLogCutoffMs {
-                    realm.delete(log)
-                    logsRemoved += 1
-                }
-            }
+        // Delete the managed objects of this realm. getAllLogs() returns detached copies and
+        // deleting a detached object throws an RLMException that Swift cannot catch (app abort)
+        let expiredLogs = realm.objects(LogEntry.self).filter("timestamp < %@", keepLogCutoffMs)
+        let logsRemoved = expiredLogs.count
+        guard logsRemoved > 0 else { return }
+
+        try realm.write {
+            realm.delete(expiredLogs)
         }
-        
-        if logsRemoved > 0 {
+
+        // This runs inside the initializer of Database.shared and AbsLogger stores its entry
+        // through Database.shared again, so log once the initializer has finished
+        DispatchQueue.main.async {
             AbsLogger.info(message: "cleanLogs: Removed \(logsRemoved) logs older than \(numberOfHoursToKeep) hours")
         }
     }


### PR DESCRIPTION
## Brief summary

Since 0.14.1 the iOS app aborts at every launch on any device that has a log entry older than 48 hours: black screen, then SIGABRT before the WebView loads. This fixes the log cleanup in `Database.cleanExpiredLogs()` that causes it.

## Which issue is fixed?

Fixes #2015

## Pull Request Type

iOS only, native (Swift) layer. One function in `ios/App/Shared/util/Database.swift`.

## In-depth Description

b706337 ("Fix iOS expired logs never clearing") corrected the cutoff in `cleanExpiredLogs()` from seconds to milliseconds, so the cleanup deletes logs for the first time. That exposed two latent problems in the function, which runs inside the lazy initializer of `Database.shared` (first touched by `AbsLogger.info` in `applicationDidBecomeActive`):

1. The logs came from `getAllLogs()`, which returns detached copies (`Results.toArray()` calls `detached()`). Deleting a detached object throws `RLMException: Can only delete an object from the Realm it belongs to`. Swift's `try?` cannot catch an Objective-C exception, so the app terminates. The failed transaction never commits, the old logs stay and the crash repeats on every launch. Every update from 0.14.0 hits it immediately, a fresh install after about 48 hours.
2. After a successful deletion the function logged through `AbsLogger.info`, which stores the entry via `Database.shared` again. Calling that from inside its own initializer is a recursive `dispatch_once` and would abort as well.

9a2f0c3 ("Add one time wipe of logs for iOS") wipes the accumulated logs once in the schema 21 migration. That removes the trigger for existing installs, but only until the first new log entry is older than 48 hours, about two days after the update: `cleanExpiredLogs()` then deletes a detached copy again and the app crashes at every launch as before. This change fixes the delete itself and is complementary to the wipe; with it the cleanup keeps the logs to 48 hours, so they no longer accumulate either.

The fix selects the expired entries with a Realm query (`timestamp < cutoff`) and deletes them as the managed objects of that realm in a single write. The "removed N logs" entry is still written to the app log, but via `DispatchQueue.main.async`, so it runs after the initializer has finished. The other `realm.delete` call sites in the iOS code delete managed objects, so no other place has the same pattern.

## How have you tested this?

- Reproduced on iPad (iPad8,1), iPadOS 26.6, 0.14.1: crash at every launch. Device crash report: `EXC_CRASH (SIGABRT)`, main thread, last exception backtrace `RLMDeleteObjectFromRealm` <- `Realm.write` <- `_dispatch_once_callout` <- `-[UIApplication _stopDeactivatingForReason:]`.
- With this change installed over the crashing build on the same iPad (existing data kept): the app launches normally and the app log shows "cleanLogs: Removed 1523 logs older than 48 hours".
- 0.14.0 (before b706337) does not crash, because the wrong cutoff never deleted anything.

## Screenshots

Not applicable, no frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
