### PR TITLE
Update "close issue on release" workflow to use node24

### DIFF
--- a/.github/workflows/close-issues-on-release.yml
+++ b/.github/workflows/close-issues-on-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close issues marked as fixed upon a release.
-        uses: gcampbell-msft/fixed-pending-release@dbc2297e6154e0a671790a8fa6b1f016035c56ab
+        uses: gcampbell-msft/fixed-pending-release@0.1.0
         with:
           label: 'awaiting release'
           removeLabel: true

--- a/.github/workflows/close-issues-on-release.yml
+++ b/.github/workflows/close-issues-on-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close issues marked as fixed upon a release.
-        uses: gcampbell-msft/fixed-pending-release@7fa1b75a0c04bcd4b375110522878e5f6100cff5
+        uses: gcampbell-msft/fixed-pending-release@dbc2297e6154e0a671790a8fa6b1f016035c56ab
         with:
           label: 'awaiting release'
           removeLabel: true


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

Workflow chore, update to node 24

## Which issue is fixed?

No issue

## Pull Request Type

Internal

## In-depth Description

I submitted a PR to the upstream GitHub action to update to node 24 which has been merged in.

The action also has an actual release number now, so using the release instead of the hash. :)

## How have you tested this?

Tested action in my personal repo. Run results: https://github.com/nichwall/issue_testing/actions/runs/34617512861/job/103323006520

## Screenshots

N/A
