### PR TITLE
Add weblate translation credit workflow

### DIFF
--- a/.github/workflows/translate-credits.yml
+++ b/.github/workflows/translate-credits.yml
@@ -1,0 +1,25 @@
+name: Prepare translation credits
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  release-notes:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'weblate')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: translator-credits
+        uses: audiobookshelf/get-translator-credits@v1.1.0
+
+      - name: Show translator credits
+        run: |
+          printf '%s\n' "${{ steps.translator-credits.outputs.credits }}"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

If you do not follow this template, the PR may be closed without review.

Please ensure all checks pass.
If you are a new contributor, the workflows will need to be manually approved before they run.
-->

## Brief summary

This PR adds a workflow to make crediting translators easier for the release notes.

## Which issue is fixed?

No issue

## Pull Request Type

Internal workflow

## In-depth Description

See https://github.com/advplyr/audiobookshelf/pull/5558, this is the same workflow file

## How have you tested this?

See https://github.com/advplyr/audiobookshelf/pull/5558, this is the same workflow file

## Screenshots

N/A